### PR TITLE
regs: Fix clock division configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+- SW Clock division configuration
+
 ## 1.0.1 - 2023-03-13
 
 ### Changed

--- a/src/regs/serial_link.hjson
+++ b/src/regs/serial_link.hjson
@@ -103,10 +103,10 @@
     },
     { multireg:
       {
-        name: "TX_PHY_CTRL1",
+        name: "TX_PHY_CLK_DIV",
         desc: "Holds clock divider factor for forwarded clock of the TX Phys",
         count: "NumChannels",
-        cname: "TX_PHY_CTRL1",
+        cname: "TX_PHY_CLK_DIV",
         swaccess: "rw",
         hwaccess: "hro",
         compact: false,
@@ -121,10 +121,10 @@
     },
     { multireg:
       {
-        name: "TX_PHY_CTRL2",
+        name: "TX_PHY_CLK_START",
         desc: "Controls duty cycle and phase of rising edge in TX Phys",
         count: "NumChannels",
-        cname: "TX_PHY_CTRL2",
+        cname: "TX_PHY_CLK_START",
         compact: false,
         swaccess: "rw",
         hwaccess: "hro",
@@ -139,10 +139,10 @@
     },
     { multireg:
       {
-        name: "TX_PHY_CTRL3",
+        name: "TX_PHY_CLK_END",
         desc: "Controls duty cycle and phase of falling edge in TX Phys",
         count: "NumChannels",
-        cname: "TX_PHY_CTRL3",
+        cname: "TX_PHY_CLK_END",
         compact: false,
         swaccess: "rw",
         hwaccess: "hro",

--- a/src/regs/serial_link.hjson
+++ b/src/regs/serial_link.hjson
@@ -122,7 +122,7 @@
     { multireg:
       {
         name: "TX_PHY_CTRL2",
-        desc: "Controls duty cycle and phase of rising and falling edge in TX Phys",
+        desc: "Controls duty cycle and phase of rising edge in TX Phys",
         count: "NumChannels",
         cname: "TX_PHY_CTRL2",
         compact: false,
@@ -133,7 +133,20 @@
             name: "clk_shift_start",
             desc: "Positive Edge of divided, shifted clock",
             resval: 2
-          },
+          }
+        ]
+      }
+    },
+    { multireg:
+      {
+        name: "TX_PHY_CTRL3",
+        desc: "Controls duty cycle and phase of falling edge in TX Phys",
+        count: "NumChannels",
+        cname: "TX_PHY_CTRL3",
+        compact: false,
+        swaccess: "rw",
+        hwaccess: "hro",
+        fields: [
           { bits: "Log2MaxClkDiv:0",
             name: "clk_shift_end",
             desc: "Negative Edge of divided, shifted clock",

--- a/src/regs/serial_link_reg_pkg.sv
+++ b/src/regs/serial_link_reg_pkg.sv
@@ -38,15 +38,15 @@ package serial_link_reg_pkg;
 
   typedef struct packed {
     logic [10:0] q;
-  } serial_link_reg2hw_tx_phy_ctrl1_mreg_t;
+  } serial_link_reg2hw_tx_phy_clk_div_mreg_t;
 
   typedef struct packed {
     logic [10:0] q;
-  } serial_link_reg2hw_tx_phy_ctrl2_mreg_t;
+  } serial_link_reg2hw_tx_phy_clk_start_mreg_t;
 
   typedef struct packed {
     logic [10:0] q;
-  } serial_link_reg2hw_tx_phy_ctrl3_mreg_t;
+  } serial_link_reg2hw_tx_phy_clk_end_mreg_t;
 
   typedef struct packed {
     logic        q;
@@ -166,9 +166,9 @@ package serial_link_reg_pkg;
   // Register -> HW type
   typedef struct packed {
     serial_link_reg2hw_ctrl_reg_t ctrl; // [1444:1441]
-    serial_link_reg2hw_tx_phy_ctrl1_mreg_t [37:0] tx_phy_ctrl1; // [1440:1023]
-    serial_link_reg2hw_tx_phy_ctrl2_mreg_t [37:0] tx_phy_ctrl2; // [1022:605]
-    serial_link_reg2hw_tx_phy_ctrl3_mreg_t [37:0] tx_phy_ctrl3; // [604:187]
+    serial_link_reg2hw_tx_phy_clk_div_mreg_t [37:0] tx_phy_clk_div; // [1440:1023]
+    serial_link_reg2hw_tx_phy_clk_start_mreg_t [37:0] tx_phy_clk_start; // [1022:605]
+    serial_link_reg2hw_tx_phy_clk_end_mreg_t [37:0] tx_phy_clk_end; // [604:187]
     serial_link_reg2hw_raw_mode_en_reg_t raw_mode_en; // [186:186]
     serial_link_reg2hw_raw_mode_in_ch_sel_reg_t raw_mode_in_ch_sel; // [185:180]
     serial_link_reg2hw_raw_mode_in_data_reg_t raw_mode_in_data; // [179:163]
@@ -196,120 +196,120 @@ package serial_link_reg_pkg;
   // Register offsets
   parameter logic [BlockAw-1:0] SERIAL_LINK_CTRL_OFFSET = 10'h 0;
   parameter logic [BlockAw-1:0] SERIAL_LINK_ISOLATED_OFFSET = 10'h 4;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_0_OFFSET = 10'h 8;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_1_OFFSET = 10'h c;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_2_OFFSET = 10'h 10;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_3_OFFSET = 10'h 14;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_4_OFFSET = 10'h 18;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_5_OFFSET = 10'h 1c;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_6_OFFSET = 10'h 20;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_7_OFFSET = 10'h 24;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_8_OFFSET = 10'h 28;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_9_OFFSET = 10'h 2c;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_10_OFFSET = 10'h 30;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_11_OFFSET = 10'h 34;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_12_OFFSET = 10'h 38;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_13_OFFSET = 10'h 3c;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_14_OFFSET = 10'h 40;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_15_OFFSET = 10'h 44;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_16_OFFSET = 10'h 48;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_17_OFFSET = 10'h 4c;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_18_OFFSET = 10'h 50;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_19_OFFSET = 10'h 54;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_20_OFFSET = 10'h 58;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_21_OFFSET = 10'h 5c;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_22_OFFSET = 10'h 60;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_23_OFFSET = 10'h 64;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_24_OFFSET = 10'h 68;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_25_OFFSET = 10'h 6c;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_26_OFFSET = 10'h 70;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_27_OFFSET = 10'h 74;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_28_OFFSET = 10'h 78;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_29_OFFSET = 10'h 7c;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_30_OFFSET = 10'h 80;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_31_OFFSET = 10'h 84;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_32_OFFSET = 10'h 88;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_33_OFFSET = 10'h 8c;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_34_OFFSET = 10'h 90;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_35_OFFSET = 10'h 94;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_36_OFFSET = 10'h 98;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_37_OFFSET = 10'h 9c;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_0_OFFSET = 10'h a0;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_1_OFFSET = 10'h a4;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_2_OFFSET = 10'h a8;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_3_OFFSET = 10'h ac;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_4_OFFSET = 10'h b0;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_5_OFFSET = 10'h b4;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_6_OFFSET = 10'h b8;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_7_OFFSET = 10'h bc;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_8_OFFSET = 10'h c0;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_9_OFFSET = 10'h c4;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_10_OFFSET = 10'h c8;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_11_OFFSET = 10'h cc;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_12_OFFSET = 10'h d0;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_13_OFFSET = 10'h d4;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_14_OFFSET = 10'h d8;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_15_OFFSET = 10'h dc;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_16_OFFSET = 10'h e0;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_17_OFFSET = 10'h e4;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_18_OFFSET = 10'h e8;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_19_OFFSET = 10'h ec;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_20_OFFSET = 10'h f0;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_21_OFFSET = 10'h f4;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_22_OFFSET = 10'h f8;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_23_OFFSET = 10'h fc;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_24_OFFSET = 10'h 100;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_25_OFFSET = 10'h 104;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_26_OFFSET = 10'h 108;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_27_OFFSET = 10'h 10c;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_28_OFFSET = 10'h 110;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_29_OFFSET = 10'h 114;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_30_OFFSET = 10'h 118;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_31_OFFSET = 10'h 11c;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_32_OFFSET = 10'h 120;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_33_OFFSET = 10'h 124;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_34_OFFSET = 10'h 128;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_35_OFFSET = 10'h 12c;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_36_OFFSET = 10'h 130;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_37_OFFSET = 10'h 134;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_0_OFFSET = 10'h 138;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_1_OFFSET = 10'h 13c;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_2_OFFSET = 10'h 140;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_3_OFFSET = 10'h 144;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_4_OFFSET = 10'h 148;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_5_OFFSET = 10'h 14c;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_6_OFFSET = 10'h 150;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_7_OFFSET = 10'h 154;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_8_OFFSET = 10'h 158;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_9_OFFSET = 10'h 15c;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_10_OFFSET = 10'h 160;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_11_OFFSET = 10'h 164;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_12_OFFSET = 10'h 168;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_13_OFFSET = 10'h 16c;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_14_OFFSET = 10'h 170;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_15_OFFSET = 10'h 174;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_16_OFFSET = 10'h 178;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_17_OFFSET = 10'h 17c;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_18_OFFSET = 10'h 180;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_19_OFFSET = 10'h 184;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_20_OFFSET = 10'h 188;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_21_OFFSET = 10'h 18c;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_22_OFFSET = 10'h 190;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_23_OFFSET = 10'h 194;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_24_OFFSET = 10'h 198;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_25_OFFSET = 10'h 19c;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_26_OFFSET = 10'h 1a0;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_27_OFFSET = 10'h 1a4;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_28_OFFSET = 10'h 1a8;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_29_OFFSET = 10'h 1ac;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_30_OFFSET = 10'h 1b0;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_31_OFFSET = 10'h 1b4;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_32_OFFSET = 10'h 1b8;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_33_OFFSET = 10'h 1bc;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_34_OFFSET = 10'h 1c0;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_35_OFFSET = 10'h 1c4;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_36_OFFSET = 10'h 1c8;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_37_OFFSET = 10'h 1cc;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_DIV_0_OFFSET = 10'h 8;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_DIV_1_OFFSET = 10'h c;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_DIV_2_OFFSET = 10'h 10;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_DIV_3_OFFSET = 10'h 14;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_DIV_4_OFFSET = 10'h 18;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_DIV_5_OFFSET = 10'h 1c;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_DIV_6_OFFSET = 10'h 20;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_DIV_7_OFFSET = 10'h 24;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_DIV_8_OFFSET = 10'h 28;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_DIV_9_OFFSET = 10'h 2c;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_DIV_10_OFFSET = 10'h 30;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_DIV_11_OFFSET = 10'h 34;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_DIV_12_OFFSET = 10'h 38;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_DIV_13_OFFSET = 10'h 3c;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_DIV_14_OFFSET = 10'h 40;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_DIV_15_OFFSET = 10'h 44;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_DIV_16_OFFSET = 10'h 48;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_DIV_17_OFFSET = 10'h 4c;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_DIV_18_OFFSET = 10'h 50;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_DIV_19_OFFSET = 10'h 54;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_DIV_20_OFFSET = 10'h 58;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_DIV_21_OFFSET = 10'h 5c;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_DIV_22_OFFSET = 10'h 60;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_DIV_23_OFFSET = 10'h 64;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_DIV_24_OFFSET = 10'h 68;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_DIV_25_OFFSET = 10'h 6c;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_DIV_26_OFFSET = 10'h 70;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_DIV_27_OFFSET = 10'h 74;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_DIV_28_OFFSET = 10'h 78;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_DIV_29_OFFSET = 10'h 7c;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_DIV_30_OFFSET = 10'h 80;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_DIV_31_OFFSET = 10'h 84;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_DIV_32_OFFSET = 10'h 88;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_DIV_33_OFFSET = 10'h 8c;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_DIV_34_OFFSET = 10'h 90;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_DIV_35_OFFSET = 10'h 94;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_DIV_36_OFFSET = 10'h 98;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_DIV_37_OFFSET = 10'h 9c;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_START_0_OFFSET = 10'h a0;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_START_1_OFFSET = 10'h a4;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_START_2_OFFSET = 10'h a8;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_START_3_OFFSET = 10'h ac;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_START_4_OFFSET = 10'h b0;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_START_5_OFFSET = 10'h b4;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_START_6_OFFSET = 10'h b8;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_START_7_OFFSET = 10'h bc;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_START_8_OFFSET = 10'h c0;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_START_9_OFFSET = 10'h c4;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_START_10_OFFSET = 10'h c8;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_START_11_OFFSET = 10'h cc;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_START_12_OFFSET = 10'h d0;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_START_13_OFFSET = 10'h d4;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_START_14_OFFSET = 10'h d8;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_START_15_OFFSET = 10'h dc;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_START_16_OFFSET = 10'h e0;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_START_17_OFFSET = 10'h e4;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_START_18_OFFSET = 10'h e8;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_START_19_OFFSET = 10'h ec;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_START_20_OFFSET = 10'h f0;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_START_21_OFFSET = 10'h f4;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_START_22_OFFSET = 10'h f8;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_START_23_OFFSET = 10'h fc;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_START_24_OFFSET = 10'h 100;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_START_25_OFFSET = 10'h 104;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_START_26_OFFSET = 10'h 108;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_START_27_OFFSET = 10'h 10c;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_START_28_OFFSET = 10'h 110;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_START_29_OFFSET = 10'h 114;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_START_30_OFFSET = 10'h 118;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_START_31_OFFSET = 10'h 11c;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_START_32_OFFSET = 10'h 120;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_START_33_OFFSET = 10'h 124;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_START_34_OFFSET = 10'h 128;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_START_35_OFFSET = 10'h 12c;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_START_36_OFFSET = 10'h 130;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_START_37_OFFSET = 10'h 134;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_END_0_OFFSET = 10'h 138;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_END_1_OFFSET = 10'h 13c;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_END_2_OFFSET = 10'h 140;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_END_3_OFFSET = 10'h 144;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_END_4_OFFSET = 10'h 148;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_END_5_OFFSET = 10'h 14c;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_END_6_OFFSET = 10'h 150;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_END_7_OFFSET = 10'h 154;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_END_8_OFFSET = 10'h 158;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_END_9_OFFSET = 10'h 15c;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_END_10_OFFSET = 10'h 160;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_END_11_OFFSET = 10'h 164;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_END_12_OFFSET = 10'h 168;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_END_13_OFFSET = 10'h 16c;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_END_14_OFFSET = 10'h 170;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_END_15_OFFSET = 10'h 174;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_END_16_OFFSET = 10'h 178;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_END_17_OFFSET = 10'h 17c;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_END_18_OFFSET = 10'h 180;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_END_19_OFFSET = 10'h 184;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_END_20_OFFSET = 10'h 188;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_END_21_OFFSET = 10'h 18c;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_END_22_OFFSET = 10'h 190;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_END_23_OFFSET = 10'h 194;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_END_24_OFFSET = 10'h 198;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_END_25_OFFSET = 10'h 19c;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_END_26_OFFSET = 10'h 1a0;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_END_27_OFFSET = 10'h 1a4;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_END_28_OFFSET = 10'h 1a8;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_END_29_OFFSET = 10'h 1ac;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_END_30_OFFSET = 10'h 1b0;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_END_31_OFFSET = 10'h 1b4;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_END_32_OFFSET = 10'h 1b8;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_END_33_OFFSET = 10'h 1bc;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_END_34_OFFSET = 10'h 1c0;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_END_35_OFFSET = 10'h 1c4;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_END_36_OFFSET = 10'h 1c8;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CLK_END_37_OFFSET = 10'h 1cc;
   parameter logic [BlockAw-1:0] SERIAL_LINK_RAW_MODE_EN_OFFSET = 10'h 1d0;
   parameter logic [BlockAw-1:0] SERIAL_LINK_RAW_MODE_IN_CH_SEL_OFFSET = 10'h 1d4;
   parameter logic [BlockAw-1:0] SERIAL_LINK_RAW_MODE_IN_DATA_VALID_0_OFFSET = 10'h 1d8;
@@ -349,120 +349,120 @@ package serial_link_reg_pkg;
   typedef enum int {
     SERIAL_LINK_CTRL,
     SERIAL_LINK_ISOLATED,
-    SERIAL_LINK_TX_PHY_CTRL1_0,
-    SERIAL_LINK_TX_PHY_CTRL1_1,
-    SERIAL_LINK_TX_PHY_CTRL1_2,
-    SERIAL_LINK_TX_PHY_CTRL1_3,
-    SERIAL_LINK_TX_PHY_CTRL1_4,
-    SERIAL_LINK_TX_PHY_CTRL1_5,
-    SERIAL_LINK_TX_PHY_CTRL1_6,
-    SERIAL_LINK_TX_PHY_CTRL1_7,
-    SERIAL_LINK_TX_PHY_CTRL1_8,
-    SERIAL_LINK_TX_PHY_CTRL1_9,
-    SERIAL_LINK_TX_PHY_CTRL1_10,
-    SERIAL_LINK_TX_PHY_CTRL1_11,
-    SERIAL_LINK_TX_PHY_CTRL1_12,
-    SERIAL_LINK_TX_PHY_CTRL1_13,
-    SERIAL_LINK_TX_PHY_CTRL1_14,
-    SERIAL_LINK_TX_PHY_CTRL1_15,
-    SERIAL_LINK_TX_PHY_CTRL1_16,
-    SERIAL_LINK_TX_PHY_CTRL1_17,
-    SERIAL_LINK_TX_PHY_CTRL1_18,
-    SERIAL_LINK_TX_PHY_CTRL1_19,
-    SERIAL_LINK_TX_PHY_CTRL1_20,
-    SERIAL_LINK_TX_PHY_CTRL1_21,
-    SERIAL_LINK_TX_PHY_CTRL1_22,
-    SERIAL_LINK_TX_PHY_CTRL1_23,
-    SERIAL_LINK_TX_PHY_CTRL1_24,
-    SERIAL_LINK_TX_PHY_CTRL1_25,
-    SERIAL_LINK_TX_PHY_CTRL1_26,
-    SERIAL_LINK_TX_PHY_CTRL1_27,
-    SERIAL_LINK_TX_PHY_CTRL1_28,
-    SERIAL_LINK_TX_PHY_CTRL1_29,
-    SERIAL_LINK_TX_PHY_CTRL1_30,
-    SERIAL_LINK_TX_PHY_CTRL1_31,
-    SERIAL_LINK_TX_PHY_CTRL1_32,
-    SERIAL_LINK_TX_PHY_CTRL1_33,
-    SERIAL_LINK_TX_PHY_CTRL1_34,
-    SERIAL_LINK_TX_PHY_CTRL1_35,
-    SERIAL_LINK_TX_PHY_CTRL1_36,
-    SERIAL_LINK_TX_PHY_CTRL1_37,
-    SERIAL_LINK_TX_PHY_CTRL2_0,
-    SERIAL_LINK_TX_PHY_CTRL2_1,
-    SERIAL_LINK_TX_PHY_CTRL2_2,
-    SERIAL_LINK_TX_PHY_CTRL2_3,
-    SERIAL_LINK_TX_PHY_CTRL2_4,
-    SERIAL_LINK_TX_PHY_CTRL2_5,
-    SERIAL_LINK_TX_PHY_CTRL2_6,
-    SERIAL_LINK_TX_PHY_CTRL2_7,
-    SERIAL_LINK_TX_PHY_CTRL2_8,
-    SERIAL_LINK_TX_PHY_CTRL2_9,
-    SERIAL_LINK_TX_PHY_CTRL2_10,
-    SERIAL_LINK_TX_PHY_CTRL2_11,
-    SERIAL_LINK_TX_PHY_CTRL2_12,
-    SERIAL_LINK_TX_PHY_CTRL2_13,
-    SERIAL_LINK_TX_PHY_CTRL2_14,
-    SERIAL_LINK_TX_PHY_CTRL2_15,
-    SERIAL_LINK_TX_PHY_CTRL2_16,
-    SERIAL_LINK_TX_PHY_CTRL2_17,
-    SERIAL_LINK_TX_PHY_CTRL2_18,
-    SERIAL_LINK_TX_PHY_CTRL2_19,
-    SERIAL_LINK_TX_PHY_CTRL2_20,
-    SERIAL_LINK_TX_PHY_CTRL2_21,
-    SERIAL_LINK_TX_PHY_CTRL2_22,
-    SERIAL_LINK_TX_PHY_CTRL2_23,
-    SERIAL_LINK_TX_PHY_CTRL2_24,
-    SERIAL_LINK_TX_PHY_CTRL2_25,
-    SERIAL_LINK_TX_PHY_CTRL2_26,
-    SERIAL_LINK_TX_PHY_CTRL2_27,
-    SERIAL_LINK_TX_PHY_CTRL2_28,
-    SERIAL_LINK_TX_PHY_CTRL2_29,
-    SERIAL_LINK_TX_PHY_CTRL2_30,
-    SERIAL_LINK_TX_PHY_CTRL2_31,
-    SERIAL_LINK_TX_PHY_CTRL2_32,
-    SERIAL_LINK_TX_PHY_CTRL2_33,
-    SERIAL_LINK_TX_PHY_CTRL2_34,
-    SERIAL_LINK_TX_PHY_CTRL2_35,
-    SERIAL_LINK_TX_PHY_CTRL2_36,
-    SERIAL_LINK_TX_PHY_CTRL2_37,
-    SERIAL_LINK_TX_PHY_CTRL3_0,
-    SERIAL_LINK_TX_PHY_CTRL3_1,
-    SERIAL_LINK_TX_PHY_CTRL3_2,
-    SERIAL_LINK_TX_PHY_CTRL3_3,
-    SERIAL_LINK_TX_PHY_CTRL3_4,
-    SERIAL_LINK_TX_PHY_CTRL3_5,
-    SERIAL_LINK_TX_PHY_CTRL3_6,
-    SERIAL_LINK_TX_PHY_CTRL3_7,
-    SERIAL_LINK_TX_PHY_CTRL3_8,
-    SERIAL_LINK_TX_PHY_CTRL3_9,
-    SERIAL_LINK_TX_PHY_CTRL3_10,
-    SERIAL_LINK_TX_PHY_CTRL3_11,
-    SERIAL_LINK_TX_PHY_CTRL3_12,
-    SERIAL_LINK_TX_PHY_CTRL3_13,
-    SERIAL_LINK_TX_PHY_CTRL3_14,
-    SERIAL_LINK_TX_PHY_CTRL3_15,
-    SERIAL_LINK_TX_PHY_CTRL3_16,
-    SERIAL_LINK_TX_PHY_CTRL3_17,
-    SERIAL_LINK_TX_PHY_CTRL3_18,
-    SERIAL_LINK_TX_PHY_CTRL3_19,
-    SERIAL_LINK_TX_PHY_CTRL3_20,
-    SERIAL_LINK_TX_PHY_CTRL3_21,
-    SERIAL_LINK_TX_PHY_CTRL3_22,
-    SERIAL_LINK_TX_PHY_CTRL3_23,
-    SERIAL_LINK_TX_PHY_CTRL3_24,
-    SERIAL_LINK_TX_PHY_CTRL3_25,
-    SERIAL_LINK_TX_PHY_CTRL3_26,
-    SERIAL_LINK_TX_PHY_CTRL3_27,
-    SERIAL_LINK_TX_PHY_CTRL3_28,
-    SERIAL_LINK_TX_PHY_CTRL3_29,
-    SERIAL_LINK_TX_PHY_CTRL3_30,
-    SERIAL_LINK_TX_PHY_CTRL3_31,
-    SERIAL_LINK_TX_PHY_CTRL3_32,
-    SERIAL_LINK_TX_PHY_CTRL3_33,
-    SERIAL_LINK_TX_PHY_CTRL3_34,
-    SERIAL_LINK_TX_PHY_CTRL3_35,
-    SERIAL_LINK_TX_PHY_CTRL3_36,
-    SERIAL_LINK_TX_PHY_CTRL3_37,
+    SERIAL_LINK_TX_PHY_CLK_DIV_0,
+    SERIAL_LINK_TX_PHY_CLK_DIV_1,
+    SERIAL_LINK_TX_PHY_CLK_DIV_2,
+    SERIAL_LINK_TX_PHY_CLK_DIV_3,
+    SERIAL_LINK_TX_PHY_CLK_DIV_4,
+    SERIAL_LINK_TX_PHY_CLK_DIV_5,
+    SERIAL_LINK_TX_PHY_CLK_DIV_6,
+    SERIAL_LINK_TX_PHY_CLK_DIV_7,
+    SERIAL_LINK_TX_PHY_CLK_DIV_8,
+    SERIAL_LINK_TX_PHY_CLK_DIV_9,
+    SERIAL_LINK_TX_PHY_CLK_DIV_10,
+    SERIAL_LINK_TX_PHY_CLK_DIV_11,
+    SERIAL_LINK_TX_PHY_CLK_DIV_12,
+    SERIAL_LINK_TX_PHY_CLK_DIV_13,
+    SERIAL_LINK_TX_PHY_CLK_DIV_14,
+    SERIAL_LINK_TX_PHY_CLK_DIV_15,
+    SERIAL_LINK_TX_PHY_CLK_DIV_16,
+    SERIAL_LINK_TX_PHY_CLK_DIV_17,
+    SERIAL_LINK_TX_PHY_CLK_DIV_18,
+    SERIAL_LINK_TX_PHY_CLK_DIV_19,
+    SERIAL_LINK_TX_PHY_CLK_DIV_20,
+    SERIAL_LINK_TX_PHY_CLK_DIV_21,
+    SERIAL_LINK_TX_PHY_CLK_DIV_22,
+    SERIAL_LINK_TX_PHY_CLK_DIV_23,
+    SERIAL_LINK_TX_PHY_CLK_DIV_24,
+    SERIAL_LINK_TX_PHY_CLK_DIV_25,
+    SERIAL_LINK_TX_PHY_CLK_DIV_26,
+    SERIAL_LINK_TX_PHY_CLK_DIV_27,
+    SERIAL_LINK_TX_PHY_CLK_DIV_28,
+    SERIAL_LINK_TX_PHY_CLK_DIV_29,
+    SERIAL_LINK_TX_PHY_CLK_DIV_30,
+    SERIAL_LINK_TX_PHY_CLK_DIV_31,
+    SERIAL_LINK_TX_PHY_CLK_DIV_32,
+    SERIAL_LINK_TX_PHY_CLK_DIV_33,
+    SERIAL_LINK_TX_PHY_CLK_DIV_34,
+    SERIAL_LINK_TX_PHY_CLK_DIV_35,
+    SERIAL_LINK_TX_PHY_CLK_DIV_36,
+    SERIAL_LINK_TX_PHY_CLK_DIV_37,
+    SERIAL_LINK_TX_PHY_CLK_START_0,
+    SERIAL_LINK_TX_PHY_CLK_START_1,
+    SERIAL_LINK_TX_PHY_CLK_START_2,
+    SERIAL_LINK_TX_PHY_CLK_START_3,
+    SERIAL_LINK_TX_PHY_CLK_START_4,
+    SERIAL_LINK_TX_PHY_CLK_START_5,
+    SERIAL_LINK_TX_PHY_CLK_START_6,
+    SERIAL_LINK_TX_PHY_CLK_START_7,
+    SERIAL_LINK_TX_PHY_CLK_START_8,
+    SERIAL_LINK_TX_PHY_CLK_START_9,
+    SERIAL_LINK_TX_PHY_CLK_START_10,
+    SERIAL_LINK_TX_PHY_CLK_START_11,
+    SERIAL_LINK_TX_PHY_CLK_START_12,
+    SERIAL_LINK_TX_PHY_CLK_START_13,
+    SERIAL_LINK_TX_PHY_CLK_START_14,
+    SERIAL_LINK_TX_PHY_CLK_START_15,
+    SERIAL_LINK_TX_PHY_CLK_START_16,
+    SERIAL_LINK_TX_PHY_CLK_START_17,
+    SERIAL_LINK_TX_PHY_CLK_START_18,
+    SERIAL_LINK_TX_PHY_CLK_START_19,
+    SERIAL_LINK_TX_PHY_CLK_START_20,
+    SERIAL_LINK_TX_PHY_CLK_START_21,
+    SERIAL_LINK_TX_PHY_CLK_START_22,
+    SERIAL_LINK_TX_PHY_CLK_START_23,
+    SERIAL_LINK_TX_PHY_CLK_START_24,
+    SERIAL_LINK_TX_PHY_CLK_START_25,
+    SERIAL_LINK_TX_PHY_CLK_START_26,
+    SERIAL_LINK_TX_PHY_CLK_START_27,
+    SERIAL_LINK_TX_PHY_CLK_START_28,
+    SERIAL_LINK_TX_PHY_CLK_START_29,
+    SERIAL_LINK_TX_PHY_CLK_START_30,
+    SERIAL_LINK_TX_PHY_CLK_START_31,
+    SERIAL_LINK_TX_PHY_CLK_START_32,
+    SERIAL_LINK_TX_PHY_CLK_START_33,
+    SERIAL_LINK_TX_PHY_CLK_START_34,
+    SERIAL_LINK_TX_PHY_CLK_START_35,
+    SERIAL_LINK_TX_PHY_CLK_START_36,
+    SERIAL_LINK_TX_PHY_CLK_START_37,
+    SERIAL_LINK_TX_PHY_CLK_END_0,
+    SERIAL_LINK_TX_PHY_CLK_END_1,
+    SERIAL_LINK_TX_PHY_CLK_END_2,
+    SERIAL_LINK_TX_PHY_CLK_END_3,
+    SERIAL_LINK_TX_PHY_CLK_END_4,
+    SERIAL_LINK_TX_PHY_CLK_END_5,
+    SERIAL_LINK_TX_PHY_CLK_END_6,
+    SERIAL_LINK_TX_PHY_CLK_END_7,
+    SERIAL_LINK_TX_PHY_CLK_END_8,
+    SERIAL_LINK_TX_PHY_CLK_END_9,
+    SERIAL_LINK_TX_PHY_CLK_END_10,
+    SERIAL_LINK_TX_PHY_CLK_END_11,
+    SERIAL_LINK_TX_PHY_CLK_END_12,
+    SERIAL_LINK_TX_PHY_CLK_END_13,
+    SERIAL_LINK_TX_PHY_CLK_END_14,
+    SERIAL_LINK_TX_PHY_CLK_END_15,
+    SERIAL_LINK_TX_PHY_CLK_END_16,
+    SERIAL_LINK_TX_PHY_CLK_END_17,
+    SERIAL_LINK_TX_PHY_CLK_END_18,
+    SERIAL_LINK_TX_PHY_CLK_END_19,
+    SERIAL_LINK_TX_PHY_CLK_END_20,
+    SERIAL_LINK_TX_PHY_CLK_END_21,
+    SERIAL_LINK_TX_PHY_CLK_END_22,
+    SERIAL_LINK_TX_PHY_CLK_END_23,
+    SERIAL_LINK_TX_PHY_CLK_END_24,
+    SERIAL_LINK_TX_PHY_CLK_END_25,
+    SERIAL_LINK_TX_PHY_CLK_END_26,
+    SERIAL_LINK_TX_PHY_CLK_END_27,
+    SERIAL_LINK_TX_PHY_CLK_END_28,
+    SERIAL_LINK_TX_PHY_CLK_END_29,
+    SERIAL_LINK_TX_PHY_CLK_END_30,
+    SERIAL_LINK_TX_PHY_CLK_END_31,
+    SERIAL_LINK_TX_PHY_CLK_END_32,
+    SERIAL_LINK_TX_PHY_CLK_END_33,
+    SERIAL_LINK_TX_PHY_CLK_END_34,
+    SERIAL_LINK_TX_PHY_CLK_END_35,
+    SERIAL_LINK_TX_PHY_CLK_END_36,
+    SERIAL_LINK_TX_PHY_CLK_END_37,
     SERIAL_LINK_RAW_MODE_EN,
     SERIAL_LINK_RAW_MODE_IN_CH_SEL,
     SERIAL_LINK_RAW_MODE_IN_DATA_VALID_0,
@@ -488,120 +488,120 @@ package serial_link_reg_pkg;
   parameter logic [3:0] SERIAL_LINK_PERMIT [135] = '{
     4'b 0011, // index[  0] SERIAL_LINK_CTRL
     4'b 0001, // index[  1] SERIAL_LINK_ISOLATED
-    4'b 0011, // index[  2] SERIAL_LINK_TX_PHY_CTRL1_0
-    4'b 0011, // index[  3] SERIAL_LINK_TX_PHY_CTRL1_1
-    4'b 0011, // index[  4] SERIAL_LINK_TX_PHY_CTRL1_2
-    4'b 0011, // index[  5] SERIAL_LINK_TX_PHY_CTRL1_3
-    4'b 0011, // index[  6] SERIAL_LINK_TX_PHY_CTRL1_4
-    4'b 0011, // index[  7] SERIAL_LINK_TX_PHY_CTRL1_5
-    4'b 0011, // index[  8] SERIAL_LINK_TX_PHY_CTRL1_6
-    4'b 0011, // index[  9] SERIAL_LINK_TX_PHY_CTRL1_7
-    4'b 0011, // index[ 10] SERIAL_LINK_TX_PHY_CTRL1_8
-    4'b 0011, // index[ 11] SERIAL_LINK_TX_PHY_CTRL1_9
-    4'b 0011, // index[ 12] SERIAL_LINK_TX_PHY_CTRL1_10
-    4'b 0011, // index[ 13] SERIAL_LINK_TX_PHY_CTRL1_11
-    4'b 0011, // index[ 14] SERIAL_LINK_TX_PHY_CTRL1_12
-    4'b 0011, // index[ 15] SERIAL_LINK_TX_PHY_CTRL1_13
-    4'b 0011, // index[ 16] SERIAL_LINK_TX_PHY_CTRL1_14
-    4'b 0011, // index[ 17] SERIAL_LINK_TX_PHY_CTRL1_15
-    4'b 0011, // index[ 18] SERIAL_LINK_TX_PHY_CTRL1_16
-    4'b 0011, // index[ 19] SERIAL_LINK_TX_PHY_CTRL1_17
-    4'b 0011, // index[ 20] SERIAL_LINK_TX_PHY_CTRL1_18
-    4'b 0011, // index[ 21] SERIAL_LINK_TX_PHY_CTRL1_19
-    4'b 0011, // index[ 22] SERIAL_LINK_TX_PHY_CTRL1_20
-    4'b 0011, // index[ 23] SERIAL_LINK_TX_PHY_CTRL1_21
-    4'b 0011, // index[ 24] SERIAL_LINK_TX_PHY_CTRL1_22
-    4'b 0011, // index[ 25] SERIAL_LINK_TX_PHY_CTRL1_23
-    4'b 0011, // index[ 26] SERIAL_LINK_TX_PHY_CTRL1_24
-    4'b 0011, // index[ 27] SERIAL_LINK_TX_PHY_CTRL1_25
-    4'b 0011, // index[ 28] SERIAL_LINK_TX_PHY_CTRL1_26
-    4'b 0011, // index[ 29] SERIAL_LINK_TX_PHY_CTRL1_27
-    4'b 0011, // index[ 30] SERIAL_LINK_TX_PHY_CTRL1_28
-    4'b 0011, // index[ 31] SERIAL_LINK_TX_PHY_CTRL1_29
-    4'b 0011, // index[ 32] SERIAL_LINK_TX_PHY_CTRL1_30
-    4'b 0011, // index[ 33] SERIAL_LINK_TX_PHY_CTRL1_31
-    4'b 0011, // index[ 34] SERIAL_LINK_TX_PHY_CTRL1_32
-    4'b 0011, // index[ 35] SERIAL_LINK_TX_PHY_CTRL1_33
-    4'b 0011, // index[ 36] SERIAL_LINK_TX_PHY_CTRL1_34
-    4'b 0011, // index[ 37] SERIAL_LINK_TX_PHY_CTRL1_35
-    4'b 0011, // index[ 38] SERIAL_LINK_TX_PHY_CTRL1_36
-    4'b 0011, // index[ 39] SERIAL_LINK_TX_PHY_CTRL1_37
-    4'b 0011, // index[ 40] SERIAL_LINK_TX_PHY_CTRL2_0
-    4'b 0011, // index[ 41] SERIAL_LINK_TX_PHY_CTRL2_1
-    4'b 0011, // index[ 42] SERIAL_LINK_TX_PHY_CTRL2_2
-    4'b 0011, // index[ 43] SERIAL_LINK_TX_PHY_CTRL2_3
-    4'b 0011, // index[ 44] SERIAL_LINK_TX_PHY_CTRL2_4
-    4'b 0011, // index[ 45] SERIAL_LINK_TX_PHY_CTRL2_5
-    4'b 0011, // index[ 46] SERIAL_LINK_TX_PHY_CTRL2_6
-    4'b 0011, // index[ 47] SERIAL_LINK_TX_PHY_CTRL2_7
-    4'b 0011, // index[ 48] SERIAL_LINK_TX_PHY_CTRL2_8
-    4'b 0011, // index[ 49] SERIAL_LINK_TX_PHY_CTRL2_9
-    4'b 0011, // index[ 50] SERIAL_LINK_TX_PHY_CTRL2_10
-    4'b 0011, // index[ 51] SERIAL_LINK_TX_PHY_CTRL2_11
-    4'b 0011, // index[ 52] SERIAL_LINK_TX_PHY_CTRL2_12
-    4'b 0011, // index[ 53] SERIAL_LINK_TX_PHY_CTRL2_13
-    4'b 0011, // index[ 54] SERIAL_LINK_TX_PHY_CTRL2_14
-    4'b 0011, // index[ 55] SERIAL_LINK_TX_PHY_CTRL2_15
-    4'b 0011, // index[ 56] SERIAL_LINK_TX_PHY_CTRL2_16
-    4'b 0011, // index[ 57] SERIAL_LINK_TX_PHY_CTRL2_17
-    4'b 0011, // index[ 58] SERIAL_LINK_TX_PHY_CTRL2_18
-    4'b 0011, // index[ 59] SERIAL_LINK_TX_PHY_CTRL2_19
-    4'b 0011, // index[ 60] SERIAL_LINK_TX_PHY_CTRL2_20
-    4'b 0011, // index[ 61] SERIAL_LINK_TX_PHY_CTRL2_21
-    4'b 0011, // index[ 62] SERIAL_LINK_TX_PHY_CTRL2_22
-    4'b 0011, // index[ 63] SERIAL_LINK_TX_PHY_CTRL2_23
-    4'b 0011, // index[ 64] SERIAL_LINK_TX_PHY_CTRL2_24
-    4'b 0011, // index[ 65] SERIAL_LINK_TX_PHY_CTRL2_25
-    4'b 0011, // index[ 66] SERIAL_LINK_TX_PHY_CTRL2_26
-    4'b 0011, // index[ 67] SERIAL_LINK_TX_PHY_CTRL2_27
-    4'b 0011, // index[ 68] SERIAL_LINK_TX_PHY_CTRL2_28
-    4'b 0011, // index[ 69] SERIAL_LINK_TX_PHY_CTRL2_29
-    4'b 0011, // index[ 70] SERIAL_LINK_TX_PHY_CTRL2_30
-    4'b 0011, // index[ 71] SERIAL_LINK_TX_PHY_CTRL2_31
-    4'b 0011, // index[ 72] SERIAL_LINK_TX_PHY_CTRL2_32
-    4'b 0011, // index[ 73] SERIAL_LINK_TX_PHY_CTRL2_33
-    4'b 0011, // index[ 74] SERIAL_LINK_TX_PHY_CTRL2_34
-    4'b 0011, // index[ 75] SERIAL_LINK_TX_PHY_CTRL2_35
-    4'b 0011, // index[ 76] SERIAL_LINK_TX_PHY_CTRL2_36
-    4'b 0011, // index[ 77] SERIAL_LINK_TX_PHY_CTRL2_37
-    4'b 0011, // index[ 78] SERIAL_LINK_TX_PHY_CTRL3_0
-    4'b 0011, // index[ 79] SERIAL_LINK_TX_PHY_CTRL3_1
-    4'b 0011, // index[ 80] SERIAL_LINK_TX_PHY_CTRL3_2
-    4'b 0011, // index[ 81] SERIAL_LINK_TX_PHY_CTRL3_3
-    4'b 0011, // index[ 82] SERIAL_LINK_TX_PHY_CTRL3_4
-    4'b 0011, // index[ 83] SERIAL_LINK_TX_PHY_CTRL3_5
-    4'b 0011, // index[ 84] SERIAL_LINK_TX_PHY_CTRL3_6
-    4'b 0011, // index[ 85] SERIAL_LINK_TX_PHY_CTRL3_7
-    4'b 0011, // index[ 86] SERIAL_LINK_TX_PHY_CTRL3_8
-    4'b 0011, // index[ 87] SERIAL_LINK_TX_PHY_CTRL3_9
-    4'b 0011, // index[ 88] SERIAL_LINK_TX_PHY_CTRL3_10
-    4'b 0011, // index[ 89] SERIAL_LINK_TX_PHY_CTRL3_11
-    4'b 0011, // index[ 90] SERIAL_LINK_TX_PHY_CTRL3_12
-    4'b 0011, // index[ 91] SERIAL_LINK_TX_PHY_CTRL3_13
-    4'b 0011, // index[ 92] SERIAL_LINK_TX_PHY_CTRL3_14
-    4'b 0011, // index[ 93] SERIAL_LINK_TX_PHY_CTRL3_15
-    4'b 0011, // index[ 94] SERIAL_LINK_TX_PHY_CTRL3_16
-    4'b 0011, // index[ 95] SERIAL_LINK_TX_PHY_CTRL3_17
-    4'b 0011, // index[ 96] SERIAL_LINK_TX_PHY_CTRL3_18
-    4'b 0011, // index[ 97] SERIAL_LINK_TX_PHY_CTRL3_19
-    4'b 0011, // index[ 98] SERIAL_LINK_TX_PHY_CTRL3_20
-    4'b 0011, // index[ 99] SERIAL_LINK_TX_PHY_CTRL3_21
-    4'b 0011, // index[100] SERIAL_LINK_TX_PHY_CTRL3_22
-    4'b 0011, // index[101] SERIAL_LINK_TX_PHY_CTRL3_23
-    4'b 0011, // index[102] SERIAL_LINK_TX_PHY_CTRL3_24
-    4'b 0011, // index[103] SERIAL_LINK_TX_PHY_CTRL3_25
-    4'b 0011, // index[104] SERIAL_LINK_TX_PHY_CTRL3_26
-    4'b 0011, // index[105] SERIAL_LINK_TX_PHY_CTRL3_27
-    4'b 0011, // index[106] SERIAL_LINK_TX_PHY_CTRL3_28
-    4'b 0011, // index[107] SERIAL_LINK_TX_PHY_CTRL3_29
-    4'b 0011, // index[108] SERIAL_LINK_TX_PHY_CTRL3_30
-    4'b 0011, // index[109] SERIAL_LINK_TX_PHY_CTRL3_31
-    4'b 0011, // index[110] SERIAL_LINK_TX_PHY_CTRL3_32
-    4'b 0011, // index[111] SERIAL_LINK_TX_PHY_CTRL3_33
-    4'b 0011, // index[112] SERIAL_LINK_TX_PHY_CTRL3_34
-    4'b 0011, // index[113] SERIAL_LINK_TX_PHY_CTRL3_35
-    4'b 0011, // index[114] SERIAL_LINK_TX_PHY_CTRL3_36
-    4'b 0011, // index[115] SERIAL_LINK_TX_PHY_CTRL3_37
+    4'b 0011, // index[  2] SERIAL_LINK_TX_PHY_CLK_DIV_0
+    4'b 0011, // index[  3] SERIAL_LINK_TX_PHY_CLK_DIV_1
+    4'b 0011, // index[  4] SERIAL_LINK_TX_PHY_CLK_DIV_2
+    4'b 0011, // index[  5] SERIAL_LINK_TX_PHY_CLK_DIV_3
+    4'b 0011, // index[  6] SERIAL_LINK_TX_PHY_CLK_DIV_4
+    4'b 0011, // index[  7] SERIAL_LINK_TX_PHY_CLK_DIV_5
+    4'b 0011, // index[  8] SERIAL_LINK_TX_PHY_CLK_DIV_6
+    4'b 0011, // index[  9] SERIAL_LINK_TX_PHY_CLK_DIV_7
+    4'b 0011, // index[ 10] SERIAL_LINK_TX_PHY_CLK_DIV_8
+    4'b 0011, // index[ 11] SERIAL_LINK_TX_PHY_CLK_DIV_9
+    4'b 0011, // index[ 12] SERIAL_LINK_TX_PHY_CLK_DIV_10
+    4'b 0011, // index[ 13] SERIAL_LINK_TX_PHY_CLK_DIV_11
+    4'b 0011, // index[ 14] SERIAL_LINK_TX_PHY_CLK_DIV_12
+    4'b 0011, // index[ 15] SERIAL_LINK_TX_PHY_CLK_DIV_13
+    4'b 0011, // index[ 16] SERIAL_LINK_TX_PHY_CLK_DIV_14
+    4'b 0011, // index[ 17] SERIAL_LINK_TX_PHY_CLK_DIV_15
+    4'b 0011, // index[ 18] SERIAL_LINK_TX_PHY_CLK_DIV_16
+    4'b 0011, // index[ 19] SERIAL_LINK_TX_PHY_CLK_DIV_17
+    4'b 0011, // index[ 20] SERIAL_LINK_TX_PHY_CLK_DIV_18
+    4'b 0011, // index[ 21] SERIAL_LINK_TX_PHY_CLK_DIV_19
+    4'b 0011, // index[ 22] SERIAL_LINK_TX_PHY_CLK_DIV_20
+    4'b 0011, // index[ 23] SERIAL_LINK_TX_PHY_CLK_DIV_21
+    4'b 0011, // index[ 24] SERIAL_LINK_TX_PHY_CLK_DIV_22
+    4'b 0011, // index[ 25] SERIAL_LINK_TX_PHY_CLK_DIV_23
+    4'b 0011, // index[ 26] SERIAL_LINK_TX_PHY_CLK_DIV_24
+    4'b 0011, // index[ 27] SERIAL_LINK_TX_PHY_CLK_DIV_25
+    4'b 0011, // index[ 28] SERIAL_LINK_TX_PHY_CLK_DIV_26
+    4'b 0011, // index[ 29] SERIAL_LINK_TX_PHY_CLK_DIV_27
+    4'b 0011, // index[ 30] SERIAL_LINK_TX_PHY_CLK_DIV_28
+    4'b 0011, // index[ 31] SERIAL_LINK_TX_PHY_CLK_DIV_29
+    4'b 0011, // index[ 32] SERIAL_LINK_TX_PHY_CLK_DIV_30
+    4'b 0011, // index[ 33] SERIAL_LINK_TX_PHY_CLK_DIV_31
+    4'b 0011, // index[ 34] SERIAL_LINK_TX_PHY_CLK_DIV_32
+    4'b 0011, // index[ 35] SERIAL_LINK_TX_PHY_CLK_DIV_33
+    4'b 0011, // index[ 36] SERIAL_LINK_TX_PHY_CLK_DIV_34
+    4'b 0011, // index[ 37] SERIAL_LINK_TX_PHY_CLK_DIV_35
+    4'b 0011, // index[ 38] SERIAL_LINK_TX_PHY_CLK_DIV_36
+    4'b 0011, // index[ 39] SERIAL_LINK_TX_PHY_CLK_DIV_37
+    4'b 0011, // index[ 40] SERIAL_LINK_TX_PHY_CLK_START_0
+    4'b 0011, // index[ 41] SERIAL_LINK_TX_PHY_CLK_START_1
+    4'b 0011, // index[ 42] SERIAL_LINK_TX_PHY_CLK_START_2
+    4'b 0011, // index[ 43] SERIAL_LINK_TX_PHY_CLK_START_3
+    4'b 0011, // index[ 44] SERIAL_LINK_TX_PHY_CLK_START_4
+    4'b 0011, // index[ 45] SERIAL_LINK_TX_PHY_CLK_START_5
+    4'b 0011, // index[ 46] SERIAL_LINK_TX_PHY_CLK_START_6
+    4'b 0011, // index[ 47] SERIAL_LINK_TX_PHY_CLK_START_7
+    4'b 0011, // index[ 48] SERIAL_LINK_TX_PHY_CLK_START_8
+    4'b 0011, // index[ 49] SERIAL_LINK_TX_PHY_CLK_START_9
+    4'b 0011, // index[ 50] SERIAL_LINK_TX_PHY_CLK_START_10
+    4'b 0011, // index[ 51] SERIAL_LINK_TX_PHY_CLK_START_11
+    4'b 0011, // index[ 52] SERIAL_LINK_TX_PHY_CLK_START_12
+    4'b 0011, // index[ 53] SERIAL_LINK_TX_PHY_CLK_START_13
+    4'b 0011, // index[ 54] SERIAL_LINK_TX_PHY_CLK_START_14
+    4'b 0011, // index[ 55] SERIAL_LINK_TX_PHY_CLK_START_15
+    4'b 0011, // index[ 56] SERIAL_LINK_TX_PHY_CLK_START_16
+    4'b 0011, // index[ 57] SERIAL_LINK_TX_PHY_CLK_START_17
+    4'b 0011, // index[ 58] SERIAL_LINK_TX_PHY_CLK_START_18
+    4'b 0011, // index[ 59] SERIAL_LINK_TX_PHY_CLK_START_19
+    4'b 0011, // index[ 60] SERIAL_LINK_TX_PHY_CLK_START_20
+    4'b 0011, // index[ 61] SERIAL_LINK_TX_PHY_CLK_START_21
+    4'b 0011, // index[ 62] SERIAL_LINK_TX_PHY_CLK_START_22
+    4'b 0011, // index[ 63] SERIAL_LINK_TX_PHY_CLK_START_23
+    4'b 0011, // index[ 64] SERIAL_LINK_TX_PHY_CLK_START_24
+    4'b 0011, // index[ 65] SERIAL_LINK_TX_PHY_CLK_START_25
+    4'b 0011, // index[ 66] SERIAL_LINK_TX_PHY_CLK_START_26
+    4'b 0011, // index[ 67] SERIAL_LINK_TX_PHY_CLK_START_27
+    4'b 0011, // index[ 68] SERIAL_LINK_TX_PHY_CLK_START_28
+    4'b 0011, // index[ 69] SERIAL_LINK_TX_PHY_CLK_START_29
+    4'b 0011, // index[ 70] SERIAL_LINK_TX_PHY_CLK_START_30
+    4'b 0011, // index[ 71] SERIAL_LINK_TX_PHY_CLK_START_31
+    4'b 0011, // index[ 72] SERIAL_LINK_TX_PHY_CLK_START_32
+    4'b 0011, // index[ 73] SERIAL_LINK_TX_PHY_CLK_START_33
+    4'b 0011, // index[ 74] SERIAL_LINK_TX_PHY_CLK_START_34
+    4'b 0011, // index[ 75] SERIAL_LINK_TX_PHY_CLK_START_35
+    4'b 0011, // index[ 76] SERIAL_LINK_TX_PHY_CLK_START_36
+    4'b 0011, // index[ 77] SERIAL_LINK_TX_PHY_CLK_START_37
+    4'b 0011, // index[ 78] SERIAL_LINK_TX_PHY_CLK_END_0
+    4'b 0011, // index[ 79] SERIAL_LINK_TX_PHY_CLK_END_1
+    4'b 0011, // index[ 80] SERIAL_LINK_TX_PHY_CLK_END_2
+    4'b 0011, // index[ 81] SERIAL_LINK_TX_PHY_CLK_END_3
+    4'b 0011, // index[ 82] SERIAL_LINK_TX_PHY_CLK_END_4
+    4'b 0011, // index[ 83] SERIAL_LINK_TX_PHY_CLK_END_5
+    4'b 0011, // index[ 84] SERIAL_LINK_TX_PHY_CLK_END_6
+    4'b 0011, // index[ 85] SERIAL_LINK_TX_PHY_CLK_END_7
+    4'b 0011, // index[ 86] SERIAL_LINK_TX_PHY_CLK_END_8
+    4'b 0011, // index[ 87] SERIAL_LINK_TX_PHY_CLK_END_9
+    4'b 0011, // index[ 88] SERIAL_LINK_TX_PHY_CLK_END_10
+    4'b 0011, // index[ 89] SERIAL_LINK_TX_PHY_CLK_END_11
+    4'b 0011, // index[ 90] SERIAL_LINK_TX_PHY_CLK_END_12
+    4'b 0011, // index[ 91] SERIAL_LINK_TX_PHY_CLK_END_13
+    4'b 0011, // index[ 92] SERIAL_LINK_TX_PHY_CLK_END_14
+    4'b 0011, // index[ 93] SERIAL_LINK_TX_PHY_CLK_END_15
+    4'b 0011, // index[ 94] SERIAL_LINK_TX_PHY_CLK_END_16
+    4'b 0011, // index[ 95] SERIAL_LINK_TX_PHY_CLK_END_17
+    4'b 0011, // index[ 96] SERIAL_LINK_TX_PHY_CLK_END_18
+    4'b 0011, // index[ 97] SERIAL_LINK_TX_PHY_CLK_END_19
+    4'b 0011, // index[ 98] SERIAL_LINK_TX_PHY_CLK_END_20
+    4'b 0011, // index[ 99] SERIAL_LINK_TX_PHY_CLK_END_21
+    4'b 0011, // index[100] SERIAL_LINK_TX_PHY_CLK_END_22
+    4'b 0011, // index[101] SERIAL_LINK_TX_PHY_CLK_END_23
+    4'b 0011, // index[102] SERIAL_LINK_TX_PHY_CLK_END_24
+    4'b 0011, // index[103] SERIAL_LINK_TX_PHY_CLK_END_25
+    4'b 0011, // index[104] SERIAL_LINK_TX_PHY_CLK_END_26
+    4'b 0011, // index[105] SERIAL_LINK_TX_PHY_CLK_END_27
+    4'b 0011, // index[106] SERIAL_LINK_TX_PHY_CLK_END_28
+    4'b 0011, // index[107] SERIAL_LINK_TX_PHY_CLK_END_29
+    4'b 0011, // index[108] SERIAL_LINK_TX_PHY_CLK_END_30
+    4'b 0011, // index[109] SERIAL_LINK_TX_PHY_CLK_END_31
+    4'b 0011, // index[110] SERIAL_LINK_TX_PHY_CLK_END_32
+    4'b 0011, // index[111] SERIAL_LINK_TX_PHY_CLK_END_33
+    4'b 0011, // index[112] SERIAL_LINK_TX_PHY_CLK_END_34
+    4'b 0011, // index[113] SERIAL_LINK_TX_PHY_CLK_END_35
+    4'b 0011, // index[114] SERIAL_LINK_TX_PHY_CLK_END_36
+    4'b 0011, // index[115] SERIAL_LINK_TX_PHY_CLK_END_37
     4'b 0001, // index[116] SERIAL_LINK_RAW_MODE_EN
     4'b 0001, // index[117] SERIAL_LINK_RAW_MODE_IN_CH_SEL
     4'b 1111, // index[118] SERIAL_LINK_RAW_MODE_IN_DATA_VALID_0

--- a/src/regs/serial_link_reg_pkg.sv
+++ b/src/regs/serial_link_reg_pkg.sv
@@ -15,7 +15,7 @@ package serial_link_reg_pkg;
   parameter int Log2RawModeTXFifoDepth = 3;
 
   // Address widths within the block
-  parameter int BlockAw = 9;
+  parameter int BlockAw = 10;
 
   ////////////////////////////
   // Typedefs for registers //
@@ -41,13 +41,12 @@ package serial_link_reg_pkg;
   } serial_link_reg2hw_tx_phy_ctrl1_mreg_t;
 
   typedef struct packed {
-    struct packed {
-      logic [10:0] q;
-    } clk_shift_start;
-    struct packed {
-      logic [10:0] q;
-    } clk_shift_end;
+    logic [10:0] q;
   } serial_link_reg2hw_tx_phy_ctrl2_mreg_t;
+
+  typedef struct packed {
+    logic [10:0] q;
+  } serial_link_reg2hw_tx_phy_ctrl3_mreg_t;
 
   typedef struct packed {
     logic        q;
@@ -168,7 +167,8 @@ package serial_link_reg_pkg;
   typedef struct packed {
     serial_link_reg2hw_ctrl_reg_t ctrl; // [1444:1441]
     serial_link_reg2hw_tx_phy_ctrl1_mreg_t [37:0] tx_phy_ctrl1; // [1440:1023]
-    serial_link_reg2hw_tx_phy_ctrl2_mreg_t [37:0] tx_phy_ctrl2; // [1022:187]
+    serial_link_reg2hw_tx_phy_ctrl2_mreg_t [37:0] tx_phy_ctrl2; // [1022:605]
+    serial_link_reg2hw_tx_phy_ctrl3_mreg_t [37:0] tx_phy_ctrl3; // [604:187]
     serial_link_reg2hw_raw_mode_en_reg_t raw_mode_en; // [186:186]
     serial_link_reg2hw_raw_mode_in_ch_sel_reg_t raw_mode_in_ch_sel; // [185:180]
     serial_link_reg2hw_raw_mode_in_data_reg_t raw_mode_in_data; // [179:163]
@@ -194,103 +194,141 @@ package serial_link_reg_pkg;
   } serial_link_hw2reg_t;
 
   // Register offsets
-  parameter logic [BlockAw-1:0] SERIAL_LINK_CTRL_OFFSET = 9'h 0;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_ISOLATED_OFFSET = 9'h 4;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_0_OFFSET = 9'h 8;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_1_OFFSET = 9'h c;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_2_OFFSET = 9'h 10;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_3_OFFSET = 9'h 14;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_4_OFFSET = 9'h 18;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_5_OFFSET = 9'h 1c;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_6_OFFSET = 9'h 20;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_7_OFFSET = 9'h 24;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_8_OFFSET = 9'h 28;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_9_OFFSET = 9'h 2c;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_10_OFFSET = 9'h 30;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_11_OFFSET = 9'h 34;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_12_OFFSET = 9'h 38;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_13_OFFSET = 9'h 3c;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_14_OFFSET = 9'h 40;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_15_OFFSET = 9'h 44;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_16_OFFSET = 9'h 48;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_17_OFFSET = 9'h 4c;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_18_OFFSET = 9'h 50;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_19_OFFSET = 9'h 54;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_20_OFFSET = 9'h 58;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_21_OFFSET = 9'h 5c;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_22_OFFSET = 9'h 60;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_23_OFFSET = 9'h 64;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_24_OFFSET = 9'h 68;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_25_OFFSET = 9'h 6c;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_26_OFFSET = 9'h 70;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_27_OFFSET = 9'h 74;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_28_OFFSET = 9'h 78;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_29_OFFSET = 9'h 7c;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_30_OFFSET = 9'h 80;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_31_OFFSET = 9'h 84;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_32_OFFSET = 9'h 88;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_33_OFFSET = 9'h 8c;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_34_OFFSET = 9'h 90;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_35_OFFSET = 9'h 94;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_36_OFFSET = 9'h 98;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_37_OFFSET = 9'h 9c;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_0_OFFSET = 9'h a0;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_1_OFFSET = 9'h a4;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_2_OFFSET = 9'h a8;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_3_OFFSET = 9'h ac;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_4_OFFSET = 9'h b0;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_5_OFFSET = 9'h b4;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_6_OFFSET = 9'h b8;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_7_OFFSET = 9'h bc;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_8_OFFSET = 9'h c0;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_9_OFFSET = 9'h c4;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_10_OFFSET = 9'h c8;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_11_OFFSET = 9'h cc;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_12_OFFSET = 9'h d0;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_13_OFFSET = 9'h d4;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_14_OFFSET = 9'h d8;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_15_OFFSET = 9'h dc;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_16_OFFSET = 9'h e0;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_17_OFFSET = 9'h e4;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_18_OFFSET = 9'h e8;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_19_OFFSET = 9'h ec;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_20_OFFSET = 9'h f0;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_21_OFFSET = 9'h f4;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_22_OFFSET = 9'h f8;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_23_OFFSET = 9'h fc;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_24_OFFSET = 9'h 100;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_25_OFFSET = 9'h 104;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_26_OFFSET = 9'h 108;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_27_OFFSET = 9'h 10c;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_28_OFFSET = 9'h 110;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_29_OFFSET = 9'h 114;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_30_OFFSET = 9'h 118;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_31_OFFSET = 9'h 11c;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_32_OFFSET = 9'h 120;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_33_OFFSET = 9'h 124;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_34_OFFSET = 9'h 128;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_35_OFFSET = 9'h 12c;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_36_OFFSET = 9'h 130;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_37_OFFSET = 9'h 134;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_RAW_MODE_EN_OFFSET = 9'h 138;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_RAW_MODE_IN_CH_SEL_OFFSET = 9'h 13c;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_RAW_MODE_IN_DATA_VALID_0_OFFSET = 9'h 140;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_RAW_MODE_IN_DATA_VALID_1_OFFSET = 9'h 144;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_RAW_MODE_IN_DATA_OFFSET = 9'h 148;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_RAW_MODE_OUT_CH_MASK_0_OFFSET = 9'h 14c;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_RAW_MODE_OUT_CH_MASK_1_OFFSET = 9'h 150;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_RAW_MODE_OUT_DATA_FIFO_OFFSET = 9'h 154;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_RAW_MODE_OUT_DATA_FIFO_CTRL_OFFSET = 9'h 158;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_RAW_MODE_OUT_EN_OFFSET = 9'h 15c;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_FLOW_CONTROL_FIFO_CLEAR_OFFSET = 9'h 160;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_CHANNEL_ALLOC_TX_CFG_OFFSET = 9'h 164;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_CHANNEL_ALLOC_TX_CH_EN_0_OFFSET = 9'h 168;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_CHANNEL_ALLOC_TX_CH_EN_1_OFFSET = 9'h 16c;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_CHANNEL_ALLOC_TX_CTRL_OFFSET = 9'h 170;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_CHANNEL_ALLOC_RX_CFG_OFFSET = 9'h 174;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_CHANNEL_ALLOC_RX_CTRL_OFFSET = 9'h 178;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_CHANNEL_ALLOC_RX_CH_EN_0_OFFSET = 9'h 17c;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_CHANNEL_ALLOC_RX_CH_EN_1_OFFSET = 9'h 180;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_CTRL_OFFSET = 10'h 0;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_ISOLATED_OFFSET = 10'h 4;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_0_OFFSET = 10'h 8;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_1_OFFSET = 10'h c;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_2_OFFSET = 10'h 10;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_3_OFFSET = 10'h 14;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_4_OFFSET = 10'h 18;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_5_OFFSET = 10'h 1c;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_6_OFFSET = 10'h 20;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_7_OFFSET = 10'h 24;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_8_OFFSET = 10'h 28;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_9_OFFSET = 10'h 2c;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_10_OFFSET = 10'h 30;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_11_OFFSET = 10'h 34;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_12_OFFSET = 10'h 38;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_13_OFFSET = 10'h 3c;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_14_OFFSET = 10'h 40;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_15_OFFSET = 10'h 44;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_16_OFFSET = 10'h 48;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_17_OFFSET = 10'h 4c;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_18_OFFSET = 10'h 50;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_19_OFFSET = 10'h 54;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_20_OFFSET = 10'h 58;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_21_OFFSET = 10'h 5c;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_22_OFFSET = 10'h 60;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_23_OFFSET = 10'h 64;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_24_OFFSET = 10'h 68;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_25_OFFSET = 10'h 6c;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_26_OFFSET = 10'h 70;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_27_OFFSET = 10'h 74;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_28_OFFSET = 10'h 78;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_29_OFFSET = 10'h 7c;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_30_OFFSET = 10'h 80;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_31_OFFSET = 10'h 84;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_32_OFFSET = 10'h 88;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_33_OFFSET = 10'h 8c;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_34_OFFSET = 10'h 90;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_35_OFFSET = 10'h 94;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_36_OFFSET = 10'h 98;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL1_37_OFFSET = 10'h 9c;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_0_OFFSET = 10'h a0;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_1_OFFSET = 10'h a4;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_2_OFFSET = 10'h a8;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_3_OFFSET = 10'h ac;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_4_OFFSET = 10'h b0;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_5_OFFSET = 10'h b4;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_6_OFFSET = 10'h b8;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_7_OFFSET = 10'h bc;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_8_OFFSET = 10'h c0;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_9_OFFSET = 10'h c4;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_10_OFFSET = 10'h c8;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_11_OFFSET = 10'h cc;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_12_OFFSET = 10'h d0;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_13_OFFSET = 10'h d4;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_14_OFFSET = 10'h d8;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_15_OFFSET = 10'h dc;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_16_OFFSET = 10'h e0;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_17_OFFSET = 10'h e4;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_18_OFFSET = 10'h e8;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_19_OFFSET = 10'h ec;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_20_OFFSET = 10'h f0;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_21_OFFSET = 10'h f4;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_22_OFFSET = 10'h f8;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_23_OFFSET = 10'h fc;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_24_OFFSET = 10'h 100;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_25_OFFSET = 10'h 104;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_26_OFFSET = 10'h 108;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_27_OFFSET = 10'h 10c;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_28_OFFSET = 10'h 110;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_29_OFFSET = 10'h 114;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_30_OFFSET = 10'h 118;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_31_OFFSET = 10'h 11c;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_32_OFFSET = 10'h 120;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_33_OFFSET = 10'h 124;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_34_OFFSET = 10'h 128;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_35_OFFSET = 10'h 12c;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_36_OFFSET = 10'h 130;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL2_37_OFFSET = 10'h 134;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_0_OFFSET = 10'h 138;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_1_OFFSET = 10'h 13c;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_2_OFFSET = 10'h 140;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_3_OFFSET = 10'h 144;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_4_OFFSET = 10'h 148;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_5_OFFSET = 10'h 14c;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_6_OFFSET = 10'h 150;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_7_OFFSET = 10'h 154;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_8_OFFSET = 10'h 158;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_9_OFFSET = 10'h 15c;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_10_OFFSET = 10'h 160;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_11_OFFSET = 10'h 164;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_12_OFFSET = 10'h 168;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_13_OFFSET = 10'h 16c;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_14_OFFSET = 10'h 170;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_15_OFFSET = 10'h 174;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_16_OFFSET = 10'h 178;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_17_OFFSET = 10'h 17c;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_18_OFFSET = 10'h 180;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_19_OFFSET = 10'h 184;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_20_OFFSET = 10'h 188;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_21_OFFSET = 10'h 18c;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_22_OFFSET = 10'h 190;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_23_OFFSET = 10'h 194;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_24_OFFSET = 10'h 198;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_25_OFFSET = 10'h 19c;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_26_OFFSET = 10'h 1a0;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_27_OFFSET = 10'h 1a4;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_28_OFFSET = 10'h 1a8;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_29_OFFSET = 10'h 1ac;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_30_OFFSET = 10'h 1b0;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_31_OFFSET = 10'h 1b4;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_32_OFFSET = 10'h 1b8;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_33_OFFSET = 10'h 1bc;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_34_OFFSET = 10'h 1c0;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_35_OFFSET = 10'h 1c4;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_36_OFFSET = 10'h 1c8;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_TX_PHY_CTRL3_37_OFFSET = 10'h 1cc;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_RAW_MODE_EN_OFFSET = 10'h 1d0;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_RAW_MODE_IN_CH_SEL_OFFSET = 10'h 1d4;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_RAW_MODE_IN_DATA_VALID_0_OFFSET = 10'h 1d8;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_RAW_MODE_IN_DATA_VALID_1_OFFSET = 10'h 1dc;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_RAW_MODE_IN_DATA_OFFSET = 10'h 1e0;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_RAW_MODE_OUT_CH_MASK_0_OFFSET = 10'h 1e4;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_RAW_MODE_OUT_CH_MASK_1_OFFSET = 10'h 1e8;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_RAW_MODE_OUT_DATA_FIFO_OFFSET = 10'h 1ec;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_RAW_MODE_OUT_DATA_FIFO_CTRL_OFFSET = 10'h 1f0;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_RAW_MODE_OUT_EN_OFFSET = 10'h 1f4;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_FLOW_CONTROL_FIFO_CLEAR_OFFSET = 10'h 1f8;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_CHANNEL_ALLOC_TX_CFG_OFFSET = 10'h 1fc;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_CHANNEL_ALLOC_TX_CH_EN_0_OFFSET = 10'h 200;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_CHANNEL_ALLOC_TX_CH_EN_1_OFFSET = 10'h 204;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_CHANNEL_ALLOC_TX_CTRL_OFFSET = 10'h 208;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_CHANNEL_ALLOC_RX_CFG_OFFSET = 10'h 20c;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_CHANNEL_ALLOC_RX_CTRL_OFFSET = 10'h 210;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_CHANNEL_ALLOC_RX_CH_EN_0_OFFSET = 10'h 214;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_CHANNEL_ALLOC_RX_CH_EN_1_OFFSET = 10'h 218;
 
   // Reset values for hwext registers and their fields
   parameter logic [1:0] SERIAL_LINK_ISOLATED_RESVAL = 2'h 3;
@@ -387,6 +425,44 @@ package serial_link_reg_pkg;
     SERIAL_LINK_TX_PHY_CTRL2_35,
     SERIAL_LINK_TX_PHY_CTRL2_36,
     SERIAL_LINK_TX_PHY_CTRL2_37,
+    SERIAL_LINK_TX_PHY_CTRL3_0,
+    SERIAL_LINK_TX_PHY_CTRL3_1,
+    SERIAL_LINK_TX_PHY_CTRL3_2,
+    SERIAL_LINK_TX_PHY_CTRL3_3,
+    SERIAL_LINK_TX_PHY_CTRL3_4,
+    SERIAL_LINK_TX_PHY_CTRL3_5,
+    SERIAL_LINK_TX_PHY_CTRL3_6,
+    SERIAL_LINK_TX_PHY_CTRL3_7,
+    SERIAL_LINK_TX_PHY_CTRL3_8,
+    SERIAL_LINK_TX_PHY_CTRL3_9,
+    SERIAL_LINK_TX_PHY_CTRL3_10,
+    SERIAL_LINK_TX_PHY_CTRL3_11,
+    SERIAL_LINK_TX_PHY_CTRL3_12,
+    SERIAL_LINK_TX_PHY_CTRL3_13,
+    SERIAL_LINK_TX_PHY_CTRL3_14,
+    SERIAL_LINK_TX_PHY_CTRL3_15,
+    SERIAL_LINK_TX_PHY_CTRL3_16,
+    SERIAL_LINK_TX_PHY_CTRL3_17,
+    SERIAL_LINK_TX_PHY_CTRL3_18,
+    SERIAL_LINK_TX_PHY_CTRL3_19,
+    SERIAL_LINK_TX_PHY_CTRL3_20,
+    SERIAL_LINK_TX_PHY_CTRL3_21,
+    SERIAL_LINK_TX_PHY_CTRL3_22,
+    SERIAL_LINK_TX_PHY_CTRL3_23,
+    SERIAL_LINK_TX_PHY_CTRL3_24,
+    SERIAL_LINK_TX_PHY_CTRL3_25,
+    SERIAL_LINK_TX_PHY_CTRL3_26,
+    SERIAL_LINK_TX_PHY_CTRL3_27,
+    SERIAL_LINK_TX_PHY_CTRL3_28,
+    SERIAL_LINK_TX_PHY_CTRL3_29,
+    SERIAL_LINK_TX_PHY_CTRL3_30,
+    SERIAL_LINK_TX_PHY_CTRL3_31,
+    SERIAL_LINK_TX_PHY_CTRL3_32,
+    SERIAL_LINK_TX_PHY_CTRL3_33,
+    SERIAL_LINK_TX_PHY_CTRL3_34,
+    SERIAL_LINK_TX_PHY_CTRL3_35,
+    SERIAL_LINK_TX_PHY_CTRL3_36,
+    SERIAL_LINK_TX_PHY_CTRL3_37,
     SERIAL_LINK_RAW_MODE_EN,
     SERIAL_LINK_RAW_MODE_IN_CH_SEL,
     SERIAL_LINK_RAW_MODE_IN_DATA_VALID_0,
@@ -409,104 +485,142 @@ package serial_link_reg_pkg;
   } serial_link_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] SERIAL_LINK_PERMIT [97] = '{
-    4'b 0011, // index[ 0] SERIAL_LINK_CTRL
-    4'b 0001, // index[ 1] SERIAL_LINK_ISOLATED
-    4'b 0011, // index[ 2] SERIAL_LINK_TX_PHY_CTRL1_0
-    4'b 0011, // index[ 3] SERIAL_LINK_TX_PHY_CTRL1_1
-    4'b 0011, // index[ 4] SERIAL_LINK_TX_PHY_CTRL1_2
-    4'b 0011, // index[ 5] SERIAL_LINK_TX_PHY_CTRL1_3
-    4'b 0011, // index[ 6] SERIAL_LINK_TX_PHY_CTRL1_4
-    4'b 0011, // index[ 7] SERIAL_LINK_TX_PHY_CTRL1_5
-    4'b 0011, // index[ 8] SERIAL_LINK_TX_PHY_CTRL1_6
-    4'b 0011, // index[ 9] SERIAL_LINK_TX_PHY_CTRL1_7
-    4'b 0011, // index[10] SERIAL_LINK_TX_PHY_CTRL1_8
-    4'b 0011, // index[11] SERIAL_LINK_TX_PHY_CTRL1_9
-    4'b 0011, // index[12] SERIAL_LINK_TX_PHY_CTRL1_10
-    4'b 0011, // index[13] SERIAL_LINK_TX_PHY_CTRL1_11
-    4'b 0011, // index[14] SERIAL_LINK_TX_PHY_CTRL1_12
-    4'b 0011, // index[15] SERIAL_LINK_TX_PHY_CTRL1_13
-    4'b 0011, // index[16] SERIAL_LINK_TX_PHY_CTRL1_14
-    4'b 0011, // index[17] SERIAL_LINK_TX_PHY_CTRL1_15
-    4'b 0011, // index[18] SERIAL_LINK_TX_PHY_CTRL1_16
-    4'b 0011, // index[19] SERIAL_LINK_TX_PHY_CTRL1_17
-    4'b 0011, // index[20] SERIAL_LINK_TX_PHY_CTRL1_18
-    4'b 0011, // index[21] SERIAL_LINK_TX_PHY_CTRL1_19
-    4'b 0011, // index[22] SERIAL_LINK_TX_PHY_CTRL1_20
-    4'b 0011, // index[23] SERIAL_LINK_TX_PHY_CTRL1_21
-    4'b 0011, // index[24] SERIAL_LINK_TX_PHY_CTRL1_22
-    4'b 0011, // index[25] SERIAL_LINK_TX_PHY_CTRL1_23
-    4'b 0011, // index[26] SERIAL_LINK_TX_PHY_CTRL1_24
-    4'b 0011, // index[27] SERIAL_LINK_TX_PHY_CTRL1_25
-    4'b 0011, // index[28] SERIAL_LINK_TX_PHY_CTRL1_26
-    4'b 0011, // index[29] SERIAL_LINK_TX_PHY_CTRL1_27
-    4'b 0011, // index[30] SERIAL_LINK_TX_PHY_CTRL1_28
-    4'b 0011, // index[31] SERIAL_LINK_TX_PHY_CTRL1_29
-    4'b 0011, // index[32] SERIAL_LINK_TX_PHY_CTRL1_30
-    4'b 0011, // index[33] SERIAL_LINK_TX_PHY_CTRL1_31
-    4'b 0011, // index[34] SERIAL_LINK_TX_PHY_CTRL1_32
-    4'b 0011, // index[35] SERIAL_LINK_TX_PHY_CTRL1_33
-    4'b 0011, // index[36] SERIAL_LINK_TX_PHY_CTRL1_34
-    4'b 0011, // index[37] SERIAL_LINK_TX_PHY_CTRL1_35
-    4'b 0011, // index[38] SERIAL_LINK_TX_PHY_CTRL1_36
-    4'b 0011, // index[39] SERIAL_LINK_TX_PHY_CTRL1_37
-    4'b 0011, // index[40] SERIAL_LINK_TX_PHY_CTRL2_0
-    4'b 0011, // index[41] SERIAL_LINK_TX_PHY_CTRL2_1
-    4'b 0011, // index[42] SERIAL_LINK_TX_PHY_CTRL2_2
-    4'b 0011, // index[43] SERIAL_LINK_TX_PHY_CTRL2_3
-    4'b 0011, // index[44] SERIAL_LINK_TX_PHY_CTRL2_4
-    4'b 0011, // index[45] SERIAL_LINK_TX_PHY_CTRL2_5
-    4'b 0011, // index[46] SERIAL_LINK_TX_PHY_CTRL2_6
-    4'b 0011, // index[47] SERIAL_LINK_TX_PHY_CTRL2_7
-    4'b 0011, // index[48] SERIAL_LINK_TX_PHY_CTRL2_8
-    4'b 0011, // index[49] SERIAL_LINK_TX_PHY_CTRL2_9
-    4'b 0011, // index[50] SERIAL_LINK_TX_PHY_CTRL2_10
-    4'b 0011, // index[51] SERIAL_LINK_TX_PHY_CTRL2_11
-    4'b 0011, // index[52] SERIAL_LINK_TX_PHY_CTRL2_12
-    4'b 0011, // index[53] SERIAL_LINK_TX_PHY_CTRL2_13
-    4'b 0011, // index[54] SERIAL_LINK_TX_PHY_CTRL2_14
-    4'b 0011, // index[55] SERIAL_LINK_TX_PHY_CTRL2_15
-    4'b 0011, // index[56] SERIAL_LINK_TX_PHY_CTRL2_16
-    4'b 0011, // index[57] SERIAL_LINK_TX_PHY_CTRL2_17
-    4'b 0011, // index[58] SERIAL_LINK_TX_PHY_CTRL2_18
-    4'b 0011, // index[59] SERIAL_LINK_TX_PHY_CTRL2_19
-    4'b 0011, // index[60] SERIAL_LINK_TX_PHY_CTRL2_20
-    4'b 0011, // index[61] SERIAL_LINK_TX_PHY_CTRL2_21
-    4'b 0011, // index[62] SERIAL_LINK_TX_PHY_CTRL2_22
-    4'b 0011, // index[63] SERIAL_LINK_TX_PHY_CTRL2_23
-    4'b 0011, // index[64] SERIAL_LINK_TX_PHY_CTRL2_24
-    4'b 0011, // index[65] SERIAL_LINK_TX_PHY_CTRL2_25
-    4'b 0011, // index[66] SERIAL_LINK_TX_PHY_CTRL2_26
-    4'b 0011, // index[67] SERIAL_LINK_TX_PHY_CTRL2_27
-    4'b 0011, // index[68] SERIAL_LINK_TX_PHY_CTRL2_28
-    4'b 0011, // index[69] SERIAL_LINK_TX_PHY_CTRL2_29
-    4'b 0011, // index[70] SERIAL_LINK_TX_PHY_CTRL2_30
-    4'b 0011, // index[71] SERIAL_LINK_TX_PHY_CTRL2_31
-    4'b 0011, // index[72] SERIAL_LINK_TX_PHY_CTRL2_32
-    4'b 0011, // index[73] SERIAL_LINK_TX_PHY_CTRL2_33
-    4'b 0011, // index[74] SERIAL_LINK_TX_PHY_CTRL2_34
-    4'b 0011, // index[75] SERIAL_LINK_TX_PHY_CTRL2_35
-    4'b 0011, // index[76] SERIAL_LINK_TX_PHY_CTRL2_36
-    4'b 0011, // index[77] SERIAL_LINK_TX_PHY_CTRL2_37
-    4'b 0001, // index[78] SERIAL_LINK_RAW_MODE_EN
-    4'b 0001, // index[79] SERIAL_LINK_RAW_MODE_IN_CH_SEL
-    4'b 1111, // index[80] SERIAL_LINK_RAW_MODE_IN_DATA_VALID_0
-    4'b 0001, // index[81] SERIAL_LINK_RAW_MODE_IN_DATA_VALID_1
-    4'b 0011, // index[82] SERIAL_LINK_RAW_MODE_IN_DATA
-    4'b 1111, // index[83] SERIAL_LINK_RAW_MODE_OUT_CH_MASK_0
-    4'b 0001, // index[84] SERIAL_LINK_RAW_MODE_OUT_CH_MASK_1
-    4'b 0011, // index[85] SERIAL_LINK_RAW_MODE_OUT_DATA_FIFO
-    4'b 1111, // index[86] SERIAL_LINK_RAW_MODE_OUT_DATA_FIFO_CTRL
-    4'b 0001, // index[87] SERIAL_LINK_RAW_MODE_OUT_EN
-    4'b 0001, // index[88] SERIAL_LINK_FLOW_CONTROL_FIFO_CLEAR
-    4'b 0011, // index[89] SERIAL_LINK_CHANNEL_ALLOC_TX_CFG
-    4'b 1111, // index[90] SERIAL_LINK_CHANNEL_ALLOC_TX_CH_EN_0
-    4'b 0001, // index[91] SERIAL_LINK_CHANNEL_ALLOC_TX_CH_EN_1
-    4'b 0001, // index[92] SERIAL_LINK_CHANNEL_ALLOC_TX_CTRL
-    4'b 0111, // index[93] SERIAL_LINK_CHANNEL_ALLOC_RX_CFG
-    4'b 0001, // index[94] SERIAL_LINK_CHANNEL_ALLOC_RX_CTRL
-    4'b 1111, // index[95] SERIAL_LINK_CHANNEL_ALLOC_RX_CH_EN_0
-    4'b 0001  // index[96] SERIAL_LINK_CHANNEL_ALLOC_RX_CH_EN_1
+  parameter logic [3:0] SERIAL_LINK_PERMIT [135] = '{
+    4'b 0011, // index[  0] SERIAL_LINK_CTRL
+    4'b 0001, // index[  1] SERIAL_LINK_ISOLATED
+    4'b 0011, // index[  2] SERIAL_LINK_TX_PHY_CTRL1_0
+    4'b 0011, // index[  3] SERIAL_LINK_TX_PHY_CTRL1_1
+    4'b 0011, // index[  4] SERIAL_LINK_TX_PHY_CTRL1_2
+    4'b 0011, // index[  5] SERIAL_LINK_TX_PHY_CTRL1_3
+    4'b 0011, // index[  6] SERIAL_LINK_TX_PHY_CTRL1_4
+    4'b 0011, // index[  7] SERIAL_LINK_TX_PHY_CTRL1_5
+    4'b 0011, // index[  8] SERIAL_LINK_TX_PHY_CTRL1_6
+    4'b 0011, // index[  9] SERIAL_LINK_TX_PHY_CTRL1_7
+    4'b 0011, // index[ 10] SERIAL_LINK_TX_PHY_CTRL1_8
+    4'b 0011, // index[ 11] SERIAL_LINK_TX_PHY_CTRL1_9
+    4'b 0011, // index[ 12] SERIAL_LINK_TX_PHY_CTRL1_10
+    4'b 0011, // index[ 13] SERIAL_LINK_TX_PHY_CTRL1_11
+    4'b 0011, // index[ 14] SERIAL_LINK_TX_PHY_CTRL1_12
+    4'b 0011, // index[ 15] SERIAL_LINK_TX_PHY_CTRL1_13
+    4'b 0011, // index[ 16] SERIAL_LINK_TX_PHY_CTRL1_14
+    4'b 0011, // index[ 17] SERIAL_LINK_TX_PHY_CTRL1_15
+    4'b 0011, // index[ 18] SERIAL_LINK_TX_PHY_CTRL1_16
+    4'b 0011, // index[ 19] SERIAL_LINK_TX_PHY_CTRL1_17
+    4'b 0011, // index[ 20] SERIAL_LINK_TX_PHY_CTRL1_18
+    4'b 0011, // index[ 21] SERIAL_LINK_TX_PHY_CTRL1_19
+    4'b 0011, // index[ 22] SERIAL_LINK_TX_PHY_CTRL1_20
+    4'b 0011, // index[ 23] SERIAL_LINK_TX_PHY_CTRL1_21
+    4'b 0011, // index[ 24] SERIAL_LINK_TX_PHY_CTRL1_22
+    4'b 0011, // index[ 25] SERIAL_LINK_TX_PHY_CTRL1_23
+    4'b 0011, // index[ 26] SERIAL_LINK_TX_PHY_CTRL1_24
+    4'b 0011, // index[ 27] SERIAL_LINK_TX_PHY_CTRL1_25
+    4'b 0011, // index[ 28] SERIAL_LINK_TX_PHY_CTRL1_26
+    4'b 0011, // index[ 29] SERIAL_LINK_TX_PHY_CTRL1_27
+    4'b 0011, // index[ 30] SERIAL_LINK_TX_PHY_CTRL1_28
+    4'b 0011, // index[ 31] SERIAL_LINK_TX_PHY_CTRL1_29
+    4'b 0011, // index[ 32] SERIAL_LINK_TX_PHY_CTRL1_30
+    4'b 0011, // index[ 33] SERIAL_LINK_TX_PHY_CTRL1_31
+    4'b 0011, // index[ 34] SERIAL_LINK_TX_PHY_CTRL1_32
+    4'b 0011, // index[ 35] SERIAL_LINK_TX_PHY_CTRL1_33
+    4'b 0011, // index[ 36] SERIAL_LINK_TX_PHY_CTRL1_34
+    4'b 0011, // index[ 37] SERIAL_LINK_TX_PHY_CTRL1_35
+    4'b 0011, // index[ 38] SERIAL_LINK_TX_PHY_CTRL1_36
+    4'b 0011, // index[ 39] SERIAL_LINK_TX_PHY_CTRL1_37
+    4'b 0011, // index[ 40] SERIAL_LINK_TX_PHY_CTRL2_0
+    4'b 0011, // index[ 41] SERIAL_LINK_TX_PHY_CTRL2_1
+    4'b 0011, // index[ 42] SERIAL_LINK_TX_PHY_CTRL2_2
+    4'b 0011, // index[ 43] SERIAL_LINK_TX_PHY_CTRL2_3
+    4'b 0011, // index[ 44] SERIAL_LINK_TX_PHY_CTRL2_4
+    4'b 0011, // index[ 45] SERIAL_LINK_TX_PHY_CTRL2_5
+    4'b 0011, // index[ 46] SERIAL_LINK_TX_PHY_CTRL2_6
+    4'b 0011, // index[ 47] SERIAL_LINK_TX_PHY_CTRL2_7
+    4'b 0011, // index[ 48] SERIAL_LINK_TX_PHY_CTRL2_8
+    4'b 0011, // index[ 49] SERIAL_LINK_TX_PHY_CTRL2_9
+    4'b 0011, // index[ 50] SERIAL_LINK_TX_PHY_CTRL2_10
+    4'b 0011, // index[ 51] SERIAL_LINK_TX_PHY_CTRL2_11
+    4'b 0011, // index[ 52] SERIAL_LINK_TX_PHY_CTRL2_12
+    4'b 0011, // index[ 53] SERIAL_LINK_TX_PHY_CTRL2_13
+    4'b 0011, // index[ 54] SERIAL_LINK_TX_PHY_CTRL2_14
+    4'b 0011, // index[ 55] SERIAL_LINK_TX_PHY_CTRL2_15
+    4'b 0011, // index[ 56] SERIAL_LINK_TX_PHY_CTRL2_16
+    4'b 0011, // index[ 57] SERIAL_LINK_TX_PHY_CTRL2_17
+    4'b 0011, // index[ 58] SERIAL_LINK_TX_PHY_CTRL2_18
+    4'b 0011, // index[ 59] SERIAL_LINK_TX_PHY_CTRL2_19
+    4'b 0011, // index[ 60] SERIAL_LINK_TX_PHY_CTRL2_20
+    4'b 0011, // index[ 61] SERIAL_LINK_TX_PHY_CTRL2_21
+    4'b 0011, // index[ 62] SERIAL_LINK_TX_PHY_CTRL2_22
+    4'b 0011, // index[ 63] SERIAL_LINK_TX_PHY_CTRL2_23
+    4'b 0011, // index[ 64] SERIAL_LINK_TX_PHY_CTRL2_24
+    4'b 0011, // index[ 65] SERIAL_LINK_TX_PHY_CTRL2_25
+    4'b 0011, // index[ 66] SERIAL_LINK_TX_PHY_CTRL2_26
+    4'b 0011, // index[ 67] SERIAL_LINK_TX_PHY_CTRL2_27
+    4'b 0011, // index[ 68] SERIAL_LINK_TX_PHY_CTRL2_28
+    4'b 0011, // index[ 69] SERIAL_LINK_TX_PHY_CTRL2_29
+    4'b 0011, // index[ 70] SERIAL_LINK_TX_PHY_CTRL2_30
+    4'b 0011, // index[ 71] SERIAL_LINK_TX_PHY_CTRL2_31
+    4'b 0011, // index[ 72] SERIAL_LINK_TX_PHY_CTRL2_32
+    4'b 0011, // index[ 73] SERIAL_LINK_TX_PHY_CTRL2_33
+    4'b 0011, // index[ 74] SERIAL_LINK_TX_PHY_CTRL2_34
+    4'b 0011, // index[ 75] SERIAL_LINK_TX_PHY_CTRL2_35
+    4'b 0011, // index[ 76] SERIAL_LINK_TX_PHY_CTRL2_36
+    4'b 0011, // index[ 77] SERIAL_LINK_TX_PHY_CTRL2_37
+    4'b 0011, // index[ 78] SERIAL_LINK_TX_PHY_CTRL3_0
+    4'b 0011, // index[ 79] SERIAL_LINK_TX_PHY_CTRL3_1
+    4'b 0011, // index[ 80] SERIAL_LINK_TX_PHY_CTRL3_2
+    4'b 0011, // index[ 81] SERIAL_LINK_TX_PHY_CTRL3_3
+    4'b 0011, // index[ 82] SERIAL_LINK_TX_PHY_CTRL3_4
+    4'b 0011, // index[ 83] SERIAL_LINK_TX_PHY_CTRL3_5
+    4'b 0011, // index[ 84] SERIAL_LINK_TX_PHY_CTRL3_6
+    4'b 0011, // index[ 85] SERIAL_LINK_TX_PHY_CTRL3_7
+    4'b 0011, // index[ 86] SERIAL_LINK_TX_PHY_CTRL3_8
+    4'b 0011, // index[ 87] SERIAL_LINK_TX_PHY_CTRL3_9
+    4'b 0011, // index[ 88] SERIAL_LINK_TX_PHY_CTRL3_10
+    4'b 0011, // index[ 89] SERIAL_LINK_TX_PHY_CTRL3_11
+    4'b 0011, // index[ 90] SERIAL_LINK_TX_PHY_CTRL3_12
+    4'b 0011, // index[ 91] SERIAL_LINK_TX_PHY_CTRL3_13
+    4'b 0011, // index[ 92] SERIAL_LINK_TX_PHY_CTRL3_14
+    4'b 0011, // index[ 93] SERIAL_LINK_TX_PHY_CTRL3_15
+    4'b 0011, // index[ 94] SERIAL_LINK_TX_PHY_CTRL3_16
+    4'b 0011, // index[ 95] SERIAL_LINK_TX_PHY_CTRL3_17
+    4'b 0011, // index[ 96] SERIAL_LINK_TX_PHY_CTRL3_18
+    4'b 0011, // index[ 97] SERIAL_LINK_TX_PHY_CTRL3_19
+    4'b 0011, // index[ 98] SERIAL_LINK_TX_PHY_CTRL3_20
+    4'b 0011, // index[ 99] SERIAL_LINK_TX_PHY_CTRL3_21
+    4'b 0011, // index[100] SERIAL_LINK_TX_PHY_CTRL3_22
+    4'b 0011, // index[101] SERIAL_LINK_TX_PHY_CTRL3_23
+    4'b 0011, // index[102] SERIAL_LINK_TX_PHY_CTRL3_24
+    4'b 0011, // index[103] SERIAL_LINK_TX_PHY_CTRL3_25
+    4'b 0011, // index[104] SERIAL_LINK_TX_PHY_CTRL3_26
+    4'b 0011, // index[105] SERIAL_LINK_TX_PHY_CTRL3_27
+    4'b 0011, // index[106] SERIAL_LINK_TX_PHY_CTRL3_28
+    4'b 0011, // index[107] SERIAL_LINK_TX_PHY_CTRL3_29
+    4'b 0011, // index[108] SERIAL_LINK_TX_PHY_CTRL3_30
+    4'b 0011, // index[109] SERIAL_LINK_TX_PHY_CTRL3_31
+    4'b 0011, // index[110] SERIAL_LINK_TX_PHY_CTRL3_32
+    4'b 0011, // index[111] SERIAL_LINK_TX_PHY_CTRL3_33
+    4'b 0011, // index[112] SERIAL_LINK_TX_PHY_CTRL3_34
+    4'b 0011, // index[113] SERIAL_LINK_TX_PHY_CTRL3_35
+    4'b 0011, // index[114] SERIAL_LINK_TX_PHY_CTRL3_36
+    4'b 0011, // index[115] SERIAL_LINK_TX_PHY_CTRL3_37
+    4'b 0001, // index[116] SERIAL_LINK_RAW_MODE_EN
+    4'b 0001, // index[117] SERIAL_LINK_RAW_MODE_IN_CH_SEL
+    4'b 1111, // index[118] SERIAL_LINK_RAW_MODE_IN_DATA_VALID_0
+    4'b 0001, // index[119] SERIAL_LINK_RAW_MODE_IN_DATA_VALID_1
+    4'b 0011, // index[120] SERIAL_LINK_RAW_MODE_IN_DATA
+    4'b 1111, // index[121] SERIAL_LINK_RAW_MODE_OUT_CH_MASK_0
+    4'b 0001, // index[122] SERIAL_LINK_RAW_MODE_OUT_CH_MASK_1
+    4'b 0011, // index[123] SERIAL_LINK_RAW_MODE_OUT_DATA_FIFO
+    4'b 1111, // index[124] SERIAL_LINK_RAW_MODE_OUT_DATA_FIFO_CTRL
+    4'b 0001, // index[125] SERIAL_LINK_RAW_MODE_OUT_EN
+    4'b 0001, // index[126] SERIAL_LINK_FLOW_CONTROL_FIFO_CLEAR
+    4'b 0011, // index[127] SERIAL_LINK_CHANNEL_ALLOC_TX_CFG
+    4'b 1111, // index[128] SERIAL_LINK_CHANNEL_ALLOC_TX_CH_EN_0
+    4'b 0001, // index[129] SERIAL_LINK_CHANNEL_ALLOC_TX_CH_EN_1
+    4'b 0001, // index[130] SERIAL_LINK_CHANNEL_ALLOC_TX_CTRL
+    4'b 0111, // index[131] SERIAL_LINK_CHANNEL_ALLOC_RX_CFG
+    4'b 0001, // index[132] SERIAL_LINK_CHANNEL_ALLOC_RX_CTRL
+    4'b 1111, // index[133] SERIAL_LINK_CHANNEL_ALLOC_RX_CH_EN_0
+    4'b 0001  // index[134] SERIAL_LINK_CHANNEL_ALLOC_RX_CH_EN_1
   };
 
 endpackage

--- a/src/regs/serial_link_reg_top.sv
+++ b/src/regs/serial_link_reg_top.sv
@@ -84,348 +84,348 @@ module serial_link_reg_top #(
   logic isolated_axi_in_re;
   logic isolated_axi_out_qs;
   logic isolated_axi_out_re;
-  logic [10:0] tx_phy_ctrl1_0_qs;
-  logic [10:0] tx_phy_ctrl1_0_wd;
-  logic tx_phy_ctrl1_0_we;
-  logic [10:0] tx_phy_ctrl1_1_qs;
-  logic [10:0] tx_phy_ctrl1_1_wd;
-  logic tx_phy_ctrl1_1_we;
-  logic [10:0] tx_phy_ctrl1_2_qs;
-  logic [10:0] tx_phy_ctrl1_2_wd;
-  logic tx_phy_ctrl1_2_we;
-  logic [10:0] tx_phy_ctrl1_3_qs;
-  logic [10:0] tx_phy_ctrl1_3_wd;
-  logic tx_phy_ctrl1_3_we;
-  logic [10:0] tx_phy_ctrl1_4_qs;
-  logic [10:0] tx_phy_ctrl1_4_wd;
-  logic tx_phy_ctrl1_4_we;
-  logic [10:0] tx_phy_ctrl1_5_qs;
-  logic [10:0] tx_phy_ctrl1_5_wd;
-  logic tx_phy_ctrl1_5_we;
-  logic [10:0] tx_phy_ctrl1_6_qs;
-  logic [10:0] tx_phy_ctrl1_6_wd;
-  logic tx_phy_ctrl1_6_we;
-  logic [10:0] tx_phy_ctrl1_7_qs;
-  logic [10:0] tx_phy_ctrl1_7_wd;
-  logic tx_phy_ctrl1_7_we;
-  logic [10:0] tx_phy_ctrl1_8_qs;
-  logic [10:0] tx_phy_ctrl1_8_wd;
-  logic tx_phy_ctrl1_8_we;
-  logic [10:0] tx_phy_ctrl1_9_qs;
-  logic [10:0] tx_phy_ctrl1_9_wd;
-  logic tx_phy_ctrl1_9_we;
-  logic [10:0] tx_phy_ctrl1_10_qs;
-  logic [10:0] tx_phy_ctrl1_10_wd;
-  logic tx_phy_ctrl1_10_we;
-  logic [10:0] tx_phy_ctrl1_11_qs;
-  logic [10:0] tx_phy_ctrl1_11_wd;
-  logic tx_phy_ctrl1_11_we;
-  logic [10:0] tx_phy_ctrl1_12_qs;
-  logic [10:0] tx_phy_ctrl1_12_wd;
-  logic tx_phy_ctrl1_12_we;
-  logic [10:0] tx_phy_ctrl1_13_qs;
-  logic [10:0] tx_phy_ctrl1_13_wd;
-  logic tx_phy_ctrl1_13_we;
-  logic [10:0] tx_phy_ctrl1_14_qs;
-  logic [10:0] tx_phy_ctrl1_14_wd;
-  logic tx_phy_ctrl1_14_we;
-  logic [10:0] tx_phy_ctrl1_15_qs;
-  logic [10:0] tx_phy_ctrl1_15_wd;
-  logic tx_phy_ctrl1_15_we;
-  logic [10:0] tx_phy_ctrl1_16_qs;
-  logic [10:0] tx_phy_ctrl1_16_wd;
-  logic tx_phy_ctrl1_16_we;
-  logic [10:0] tx_phy_ctrl1_17_qs;
-  logic [10:0] tx_phy_ctrl1_17_wd;
-  logic tx_phy_ctrl1_17_we;
-  logic [10:0] tx_phy_ctrl1_18_qs;
-  logic [10:0] tx_phy_ctrl1_18_wd;
-  logic tx_phy_ctrl1_18_we;
-  logic [10:0] tx_phy_ctrl1_19_qs;
-  logic [10:0] tx_phy_ctrl1_19_wd;
-  logic tx_phy_ctrl1_19_we;
-  logic [10:0] tx_phy_ctrl1_20_qs;
-  logic [10:0] tx_phy_ctrl1_20_wd;
-  logic tx_phy_ctrl1_20_we;
-  logic [10:0] tx_phy_ctrl1_21_qs;
-  logic [10:0] tx_phy_ctrl1_21_wd;
-  logic tx_phy_ctrl1_21_we;
-  logic [10:0] tx_phy_ctrl1_22_qs;
-  logic [10:0] tx_phy_ctrl1_22_wd;
-  logic tx_phy_ctrl1_22_we;
-  logic [10:0] tx_phy_ctrl1_23_qs;
-  logic [10:0] tx_phy_ctrl1_23_wd;
-  logic tx_phy_ctrl1_23_we;
-  logic [10:0] tx_phy_ctrl1_24_qs;
-  logic [10:0] tx_phy_ctrl1_24_wd;
-  logic tx_phy_ctrl1_24_we;
-  logic [10:0] tx_phy_ctrl1_25_qs;
-  logic [10:0] tx_phy_ctrl1_25_wd;
-  logic tx_phy_ctrl1_25_we;
-  logic [10:0] tx_phy_ctrl1_26_qs;
-  logic [10:0] tx_phy_ctrl1_26_wd;
-  logic tx_phy_ctrl1_26_we;
-  logic [10:0] tx_phy_ctrl1_27_qs;
-  logic [10:0] tx_phy_ctrl1_27_wd;
-  logic tx_phy_ctrl1_27_we;
-  logic [10:0] tx_phy_ctrl1_28_qs;
-  logic [10:0] tx_phy_ctrl1_28_wd;
-  logic tx_phy_ctrl1_28_we;
-  logic [10:0] tx_phy_ctrl1_29_qs;
-  logic [10:0] tx_phy_ctrl1_29_wd;
-  logic tx_phy_ctrl1_29_we;
-  logic [10:0] tx_phy_ctrl1_30_qs;
-  logic [10:0] tx_phy_ctrl1_30_wd;
-  logic tx_phy_ctrl1_30_we;
-  logic [10:0] tx_phy_ctrl1_31_qs;
-  logic [10:0] tx_phy_ctrl1_31_wd;
-  logic tx_phy_ctrl1_31_we;
-  logic [10:0] tx_phy_ctrl1_32_qs;
-  logic [10:0] tx_phy_ctrl1_32_wd;
-  logic tx_phy_ctrl1_32_we;
-  logic [10:0] tx_phy_ctrl1_33_qs;
-  logic [10:0] tx_phy_ctrl1_33_wd;
-  logic tx_phy_ctrl1_33_we;
-  logic [10:0] tx_phy_ctrl1_34_qs;
-  logic [10:0] tx_phy_ctrl1_34_wd;
-  logic tx_phy_ctrl1_34_we;
-  logic [10:0] tx_phy_ctrl1_35_qs;
-  logic [10:0] tx_phy_ctrl1_35_wd;
-  logic tx_phy_ctrl1_35_we;
-  logic [10:0] tx_phy_ctrl1_36_qs;
-  logic [10:0] tx_phy_ctrl1_36_wd;
-  logic tx_phy_ctrl1_36_we;
-  logic [10:0] tx_phy_ctrl1_37_qs;
-  logic [10:0] tx_phy_ctrl1_37_wd;
-  logic tx_phy_ctrl1_37_we;
-  logic [10:0] tx_phy_ctrl2_0_qs;
-  logic [10:0] tx_phy_ctrl2_0_wd;
-  logic tx_phy_ctrl2_0_we;
-  logic [10:0] tx_phy_ctrl2_1_qs;
-  logic [10:0] tx_phy_ctrl2_1_wd;
-  logic tx_phy_ctrl2_1_we;
-  logic [10:0] tx_phy_ctrl2_2_qs;
-  logic [10:0] tx_phy_ctrl2_2_wd;
-  logic tx_phy_ctrl2_2_we;
-  logic [10:0] tx_phy_ctrl2_3_qs;
-  logic [10:0] tx_phy_ctrl2_3_wd;
-  logic tx_phy_ctrl2_3_we;
-  logic [10:0] tx_phy_ctrl2_4_qs;
-  logic [10:0] tx_phy_ctrl2_4_wd;
-  logic tx_phy_ctrl2_4_we;
-  logic [10:0] tx_phy_ctrl2_5_qs;
-  logic [10:0] tx_phy_ctrl2_5_wd;
-  logic tx_phy_ctrl2_5_we;
-  logic [10:0] tx_phy_ctrl2_6_qs;
-  logic [10:0] tx_phy_ctrl2_6_wd;
-  logic tx_phy_ctrl2_6_we;
-  logic [10:0] tx_phy_ctrl2_7_qs;
-  logic [10:0] tx_phy_ctrl2_7_wd;
-  logic tx_phy_ctrl2_7_we;
-  logic [10:0] tx_phy_ctrl2_8_qs;
-  logic [10:0] tx_phy_ctrl2_8_wd;
-  logic tx_phy_ctrl2_8_we;
-  logic [10:0] tx_phy_ctrl2_9_qs;
-  logic [10:0] tx_phy_ctrl2_9_wd;
-  logic tx_phy_ctrl2_9_we;
-  logic [10:0] tx_phy_ctrl2_10_qs;
-  logic [10:0] tx_phy_ctrl2_10_wd;
-  logic tx_phy_ctrl2_10_we;
-  logic [10:0] tx_phy_ctrl2_11_qs;
-  logic [10:0] tx_phy_ctrl2_11_wd;
-  logic tx_phy_ctrl2_11_we;
-  logic [10:0] tx_phy_ctrl2_12_qs;
-  logic [10:0] tx_phy_ctrl2_12_wd;
-  logic tx_phy_ctrl2_12_we;
-  logic [10:0] tx_phy_ctrl2_13_qs;
-  logic [10:0] tx_phy_ctrl2_13_wd;
-  logic tx_phy_ctrl2_13_we;
-  logic [10:0] tx_phy_ctrl2_14_qs;
-  logic [10:0] tx_phy_ctrl2_14_wd;
-  logic tx_phy_ctrl2_14_we;
-  logic [10:0] tx_phy_ctrl2_15_qs;
-  logic [10:0] tx_phy_ctrl2_15_wd;
-  logic tx_phy_ctrl2_15_we;
-  logic [10:0] tx_phy_ctrl2_16_qs;
-  logic [10:0] tx_phy_ctrl2_16_wd;
-  logic tx_phy_ctrl2_16_we;
-  logic [10:0] tx_phy_ctrl2_17_qs;
-  logic [10:0] tx_phy_ctrl2_17_wd;
-  logic tx_phy_ctrl2_17_we;
-  logic [10:0] tx_phy_ctrl2_18_qs;
-  logic [10:0] tx_phy_ctrl2_18_wd;
-  logic tx_phy_ctrl2_18_we;
-  logic [10:0] tx_phy_ctrl2_19_qs;
-  logic [10:0] tx_phy_ctrl2_19_wd;
-  logic tx_phy_ctrl2_19_we;
-  logic [10:0] tx_phy_ctrl2_20_qs;
-  logic [10:0] tx_phy_ctrl2_20_wd;
-  logic tx_phy_ctrl2_20_we;
-  logic [10:0] tx_phy_ctrl2_21_qs;
-  logic [10:0] tx_phy_ctrl2_21_wd;
-  logic tx_phy_ctrl2_21_we;
-  logic [10:0] tx_phy_ctrl2_22_qs;
-  logic [10:0] tx_phy_ctrl2_22_wd;
-  logic tx_phy_ctrl2_22_we;
-  logic [10:0] tx_phy_ctrl2_23_qs;
-  logic [10:0] tx_phy_ctrl2_23_wd;
-  logic tx_phy_ctrl2_23_we;
-  logic [10:0] tx_phy_ctrl2_24_qs;
-  logic [10:0] tx_phy_ctrl2_24_wd;
-  logic tx_phy_ctrl2_24_we;
-  logic [10:0] tx_phy_ctrl2_25_qs;
-  logic [10:0] tx_phy_ctrl2_25_wd;
-  logic tx_phy_ctrl2_25_we;
-  logic [10:0] tx_phy_ctrl2_26_qs;
-  logic [10:0] tx_phy_ctrl2_26_wd;
-  logic tx_phy_ctrl2_26_we;
-  logic [10:0] tx_phy_ctrl2_27_qs;
-  logic [10:0] tx_phy_ctrl2_27_wd;
-  logic tx_phy_ctrl2_27_we;
-  logic [10:0] tx_phy_ctrl2_28_qs;
-  logic [10:0] tx_phy_ctrl2_28_wd;
-  logic tx_phy_ctrl2_28_we;
-  logic [10:0] tx_phy_ctrl2_29_qs;
-  logic [10:0] tx_phy_ctrl2_29_wd;
-  logic tx_phy_ctrl2_29_we;
-  logic [10:0] tx_phy_ctrl2_30_qs;
-  logic [10:0] tx_phy_ctrl2_30_wd;
-  logic tx_phy_ctrl2_30_we;
-  logic [10:0] tx_phy_ctrl2_31_qs;
-  logic [10:0] tx_phy_ctrl2_31_wd;
-  logic tx_phy_ctrl2_31_we;
-  logic [10:0] tx_phy_ctrl2_32_qs;
-  logic [10:0] tx_phy_ctrl2_32_wd;
-  logic tx_phy_ctrl2_32_we;
-  logic [10:0] tx_phy_ctrl2_33_qs;
-  logic [10:0] tx_phy_ctrl2_33_wd;
-  logic tx_phy_ctrl2_33_we;
-  logic [10:0] tx_phy_ctrl2_34_qs;
-  logic [10:0] tx_phy_ctrl2_34_wd;
-  logic tx_phy_ctrl2_34_we;
-  logic [10:0] tx_phy_ctrl2_35_qs;
-  logic [10:0] tx_phy_ctrl2_35_wd;
-  logic tx_phy_ctrl2_35_we;
-  logic [10:0] tx_phy_ctrl2_36_qs;
-  logic [10:0] tx_phy_ctrl2_36_wd;
-  logic tx_phy_ctrl2_36_we;
-  logic [10:0] tx_phy_ctrl2_37_qs;
-  logic [10:0] tx_phy_ctrl2_37_wd;
-  logic tx_phy_ctrl2_37_we;
-  logic [10:0] tx_phy_ctrl3_0_qs;
-  logic [10:0] tx_phy_ctrl3_0_wd;
-  logic tx_phy_ctrl3_0_we;
-  logic [10:0] tx_phy_ctrl3_1_qs;
-  logic [10:0] tx_phy_ctrl3_1_wd;
-  logic tx_phy_ctrl3_1_we;
-  logic [10:0] tx_phy_ctrl3_2_qs;
-  logic [10:0] tx_phy_ctrl3_2_wd;
-  logic tx_phy_ctrl3_2_we;
-  logic [10:0] tx_phy_ctrl3_3_qs;
-  logic [10:0] tx_phy_ctrl3_3_wd;
-  logic tx_phy_ctrl3_3_we;
-  logic [10:0] tx_phy_ctrl3_4_qs;
-  logic [10:0] tx_phy_ctrl3_4_wd;
-  logic tx_phy_ctrl3_4_we;
-  logic [10:0] tx_phy_ctrl3_5_qs;
-  logic [10:0] tx_phy_ctrl3_5_wd;
-  logic tx_phy_ctrl3_5_we;
-  logic [10:0] tx_phy_ctrl3_6_qs;
-  logic [10:0] tx_phy_ctrl3_6_wd;
-  logic tx_phy_ctrl3_6_we;
-  logic [10:0] tx_phy_ctrl3_7_qs;
-  logic [10:0] tx_phy_ctrl3_7_wd;
-  logic tx_phy_ctrl3_7_we;
-  logic [10:0] tx_phy_ctrl3_8_qs;
-  logic [10:0] tx_phy_ctrl3_8_wd;
-  logic tx_phy_ctrl3_8_we;
-  logic [10:0] tx_phy_ctrl3_9_qs;
-  logic [10:0] tx_phy_ctrl3_9_wd;
-  logic tx_phy_ctrl3_9_we;
-  logic [10:0] tx_phy_ctrl3_10_qs;
-  logic [10:0] tx_phy_ctrl3_10_wd;
-  logic tx_phy_ctrl3_10_we;
-  logic [10:0] tx_phy_ctrl3_11_qs;
-  logic [10:0] tx_phy_ctrl3_11_wd;
-  logic tx_phy_ctrl3_11_we;
-  logic [10:0] tx_phy_ctrl3_12_qs;
-  logic [10:0] tx_phy_ctrl3_12_wd;
-  logic tx_phy_ctrl3_12_we;
-  logic [10:0] tx_phy_ctrl3_13_qs;
-  logic [10:0] tx_phy_ctrl3_13_wd;
-  logic tx_phy_ctrl3_13_we;
-  logic [10:0] tx_phy_ctrl3_14_qs;
-  logic [10:0] tx_phy_ctrl3_14_wd;
-  logic tx_phy_ctrl3_14_we;
-  logic [10:0] tx_phy_ctrl3_15_qs;
-  logic [10:0] tx_phy_ctrl3_15_wd;
-  logic tx_phy_ctrl3_15_we;
-  logic [10:0] tx_phy_ctrl3_16_qs;
-  logic [10:0] tx_phy_ctrl3_16_wd;
-  logic tx_phy_ctrl3_16_we;
-  logic [10:0] tx_phy_ctrl3_17_qs;
-  logic [10:0] tx_phy_ctrl3_17_wd;
-  logic tx_phy_ctrl3_17_we;
-  logic [10:0] tx_phy_ctrl3_18_qs;
-  logic [10:0] tx_phy_ctrl3_18_wd;
-  logic tx_phy_ctrl3_18_we;
-  logic [10:0] tx_phy_ctrl3_19_qs;
-  logic [10:0] tx_phy_ctrl3_19_wd;
-  logic tx_phy_ctrl3_19_we;
-  logic [10:0] tx_phy_ctrl3_20_qs;
-  logic [10:0] tx_phy_ctrl3_20_wd;
-  logic tx_phy_ctrl3_20_we;
-  logic [10:0] tx_phy_ctrl3_21_qs;
-  logic [10:0] tx_phy_ctrl3_21_wd;
-  logic tx_phy_ctrl3_21_we;
-  logic [10:0] tx_phy_ctrl3_22_qs;
-  logic [10:0] tx_phy_ctrl3_22_wd;
-  logic tx_phy_ctrl3_22_we;
-  logic [10:0] tx_phy_ctrl3_23_qs;
-  logic [10:0] tx_phy_ctrl3_23_wd;
-  logic tx_phy_ctrl3_23_we;
-  logic [10:0] tx_phy_ctrl3_24_qs;
-  logic [10:0] tx_phy_ctrl3_24_wd;
-  logic tx_phy_ctrl3_24_we;
-  logic [10:0] tx_phy_ctrl3_25_qs;
-  logic [10:0] tx_phy_ctrl3_25_wd;
-  logic tx_phy_ctrl3_25_we;
-  logic [10:0] tx_phy_ctrl3_26_qs;
-  logic [10:0] tx_phy_ctrl3_26_wd;
-  logic tx_phy_ctrl3_26_we;
-  logic [10:0] tx_phy_ctrl3_27_qs;
-  logic [10:0] tx_phy_ctrl3_27_wd;
-  logic tx_phy_ctrl3_27_we;
-  logic [10:0] tx_phy_ctrl3_28_qs;
-  logic [10:0] tx_phy_ctrl3_28_wd;
-  logic tx_phy_ctrl3_28_we;
-  logic [10:0] tx_phy_ctrl3_29_qs;
-  logic [10:0] tx_phy_ctrl3_29_wd;
-  logic tx_phy_ctrl3_29_we;
-  logic [10:0] tx_phy_ctrl3_30_qs;
-  logic [10:0] tx_phy_ctrl3_30_wd;
-  logic tx_phy_ctrl3_30_we;
-  logic [10:0] tx_phy_ctrl3_31_qs;
-  logic [10:0] tx_phy_ctrl3_31_wd;
-  logic tx_phy_ctrl3_31_we;
-  logic [10:0] tx_phy_ctrl3_32_qs;
-  logic [10:0] tx_phy_ctrl3_32_wd;
-  logic tx_phy_ctrl3_32_we;
-  logic [10:0] tx_phy_ctrl3_33_qs;
-  logic [10:0] tx_phy_ctrl3_33_wd;
-  logic tx_phy_ctrl3_33_we;
-  logic [10:0] tx_phy_ctrl3_34_qs;
-  logic [10:0] tx_phy_ctrl3_34_wd;
-  logic tx_phy_ctrl3_34_we;
-  logic [10:0] tx_phy_ctrl3_35_qs;
-  logic [10:0] tx_phy_ctrl3_35_wd;
-  logic tx_phy_ctrl3_35_we;
-  logic [10:0] tx_phy_ctrl3_36_qs;
-  logic [10:0] tx_phy_ctrl3_36_wd;
-  logic tx_phy_ctrl3_36_we;
-  logic [10:0] tx_phy_ctrl3_37_qs;
-  logic [10:0] tx_phy_ctrl3_37_wd;
-  logic tx_phy_ctrl3_37_we;
+  logic [10:0] tx_phy_clk_div_0_qs;
+  logic [10:0] tx_phy_clk_div_0_wd;
+  logic tx_phy_clk_div_0_we;
+  logic [10:0] tx_phy_clk_div_1_qs;
+  logic [10:0] tx_phy_clk_div_1_wd;
+  logic tx_phy_clk_div_1_we;
+  logic [10:0] tx_phy_clk_div_2_qs;
+  logic [10:0] tx_phy_clk_div_2_wd;
+  logic tx_phy_clk_div_2_we;
+  logic [10:0] tx_phy_clk_div_3_qs;
+  logic [10:0] tx_phy_clk_div_3_wd;
+  logic tx_phy_clk_div_3_we;
+  logic [10:0] tx_phy_clk_div_4_qs;
+  logic [10:0] tx_phy_clk_div_4_wd;
+  logic tx_phy_clk_div_4_we;
+  logic [10:0] tx_phy_clk_div_5_qs;
+  logic [10:0] tx_phy_clk_div_5_wd;
+  logic tx_phy_clk_div_5_we;
+  logic [10:0] tx_phy_clk_div_6_qs;
+  logic [10:0] tx_phy_clk_div_6_wd;
+  logic tx_phy_clk_div_6_we;
+  logic [10:0] tx_phy_clk_div_7_qs;
+  logic [10:0] tx_phy_clk_div_7_wd;
+  logic tx_phy_clk_div_7_we;
+  logic [10:0] tx_phy_clk_div_8_qs;
+  logic [10:0] tx_phy_clk_div_8_wd;
+  logic tx_phy_clk_div_8_we;
+  logic [10:0] tx_phy_clk_div_9_qs;
+  logic [10:0] tx_phy_clk_div_9_wd;
+  logic tx_phy_clk_div_9_we;
+  logic [10:0] tx_phy_clk_div_10_qs;
+  logic [10:0] tx_phy_clk_div_10_wd;
+  logic tx_phy_clk_div_10_we;
+  logic [10:0] tx_phy_clk_div_11_qs;
+  logic [10:0] tx_phy_clk_div_11_wd;
+  logic tx_phy_clk_div_11_we;
+  logic [10:0] tx_phy_clk_div_12_qs;
+  logic [10:0] tx_phy_clk_div_12_wd;
+  logic tx_phy_clk_div_12_we;
+  logic [10:0] tx_phy_clk_div_13_qs;
+  logic [10:0] tx_phy_clk_div_13_wd;
+  logic tx_phy_clk_div_13_we;
+  logic [10:0] tx_phy_clk_div_14_qs;
+  logic [10:0] tx_phy_clk_div_14_wd;
+  logic tx_phy_clk_div_14_we;
+  logic [10:0] tx_phy_clk_div_15_qs;
+  logic [10:0] tx_phy_clk_div_15_wd;
+  logic tx_phy_clk_div_15_we;
+  logic [10:0] tx_phy_clk_div_16_qs;
+  logic [10:0] tx_phy_clk_div_16_wd;
+  logic tx_phy_clk_div_16_we;
+  logic [10:0] tx_phy_clk_div_17_qs;
+  logic [10:0] tx_phy_clk_div_17_wd;
+  logic tx_phy_clk_div_17_we;
+  logic [10:0] tx_phy_clk_div_18_qs;
+  logic [10:0] tx_phy_clk_div_18_wd;
+  logic tx_phy_clk_div_18_we;
+  logic [10:0] tx_phy_clk_div_19_qs;
+  logic [10:0] tx_phy_clk_div_19_wd;
+  logic tx_phy_clk_div_19_we;
+  logic [10:0] tx_phy_clk_div_20_qs;
+  logic [10:0] tx_phy_clk_div_20_wd;
+  logic tx_phy_clk_div_20_we;
+  logic [10:0] tx_phy_clk_div_21_qs;
+  logic [10:0] tx_phy_clk_div_21_wd;
+  logic tx_phy_clk_div_21_we;
+  logic [10:0] tx_phy_clk_div_22_qs;
+  logic [10:0] tx_phy_clk_div_22_wd;
+  logic tx_phy_clk_div_22_we;
+  logic [10:0] tx_phy_clk_div_23_qs;
+  logic [10:0] tx_phy_clk_div_23_wd;
+  logic tx_phy_clk_div_23_we;
+  logic [10:0] tx_phy_clk_div_24_qs;
+  logic [10:0] tx_phy_clk_div_24_wd;
+  logic tx_phy_clk_div_24_we;
+  logic [10:0] tx_phy_clk_div_25_qs;
+  logic [10:0] tx_phy_clk_div_25_wd;
+  logic tx_phy_clk_div_25_we;
+  logic [10:0] tx_phy_clk_div_26_qs;
+  logic [10:0] tx_phy_clk_div_26_wd;
+  logic tx_phy_clk_div_26_we;
+  logic [10:0] tx_phy_clk_div_27_qs;
+  logic [10:0] tx_phy_clk_div_27_wd;
+  logic tx_phy_clk_div_27_we;
+  logic [10:0] tx_phy_clk_div_28_qs;
+  logic [10:0] tx_phy_clk_div_28_wd;
+  logic tx_phy_clk_div_28_we;
+  logic [10:0] tx_phy_clk_div_29_qs;
+  logic [10:0] tx_phy_clk_div_29_wd;
+  logic tx_phy_clk_div_29_we;
+  logic [10:0] tx_phy_clk_div_30_qs;
+  logic [10:0] tx_phy_clk_div_30_wd;
+  logic tx_phy_clk_div_30_we;
+  logic [10:0] tx_phy_clk_div_31_qs;
+  logic [10:0] tx_phy_clk_div_31_wd;
+  logic tx_phy_clk_div_31_we;
+  logic [10:0] tx_phy_clk_div_32_qs;
+  logic [10:0] tx_phy_clk_div_32_wd;
+  logic tx_phy_clk_div_32_we;
+  logic [10:0] tx_phy_clk_div_33_qs;
+  logic [10:0] tx_phy_clk_div_33_wd;
+  logic tx_phy_clk_div_33_we;
+  logic [10:0] tx_phy_clk_div_34_qs;
+  logic [10:0] tx_phy_clk_div_34_wd;
+  logic tx_phy_clk_div_34_we;
+  logic [10:0] tx_phy_clk_div_35_qs;
+  logic [10:0] tx_phy_clk_div_35_wd;
+  logic tx_phy_clk_div_35_we;
+  logic [10:0] tx_phy_clk_div_36_qs;
+  logic [10:0] tx_phy_clk_div_36_wd;
+  logic tx_phy_clk_div_36_we;
+  logic [10:0] tx_phy_clk_div_37_qs;
+  logic [10:0] tx_phy_clk_div_37_wd;
+  logic tx_phy_clk_div_37_we;
+  logic [10:0] tx_phy_clk_start_0_qs;
+  logic [10:0] tx_phy_clk_start_0_wd;
+  logic tx_phy_clk_start_0_we;
+  logic [10:0] tx_phy_clk_start_1_qs;
+  logic [10:0] tx_phy_clk_start_1_wd;
+  logic tx_phy_clk_start_1_we;
+  logic [10:0] tx_phy_clk_start_2_qs;
+  logic [10:0] tx_phy_clk_start_2_wd;
+  logic tx_phy_clk_start_2_we;
+  logic [10:0] tx_phy_clk_start_3_qs;
+  logic [10:0] tx_phy_clk_start_3_wd;
+  logic tx_phy_clk_start_3_we;
+  logic [10:0] tx_phy_clk_start_4_qs;
+  logic [10:0] tx_phy_clk_start_4_wd;
+  logic tx_phy_clk_start_4_we;
+  logic [10:0] tx_phy_clk_start_5_qs;
+  logic [10:0] tx_phy_clk_start_5_wd;
+  logic tx_phy_clk_start_5_we;
+  logic [10:0] tx_phy_clk_start_6_qs;
+  logic [10:0] tx_phy_clk_start_6_wd;
+  logic tx_phy_clk_start_6_we;
+  logic [10:0] tx_phy_clk_start_7_qs;
+  logic [10:0] tx_phy_clk_start_7_wd;
+  logic tx_phy_clk_start_7_we;
+  logic [10:0] tx_phy_clk_start_8_qs;
+  logic [10:0] tx_phy_clk_start_8_wd;
+  logic tx_phy_clk_start_8_we;
+  logic [10:0] tx_phy_clk_start_9_qs;
+  logic [10:0] tx_phy_clk_start_9_wd;
+  logic tx_phy_clk_start_9_we;
+  logic [10:0] tx_phy_clk_start_10_qs;
+  logic [10:0] tx_phy_clk_start_10_wd;
+  logic tx_phy_clk_start_10_we;
+  logic [10:0] tx_phy_clk_start_11_qs;
+  logic [10:0] tx_phy_clk_start_11_wd;
+  logic tx_phy_clk_start_11_we;
+  logic [10:0] tx_phy_clk_start_12_qs;
+  logic [10:0] tx_phy_clk_start_12_wd;
+  logic tx_phy_clk_start_12_we;
+  logic [10:0] tx_phy_clk_start_13_qs;
+  logic [10:0] tx_phy_clk_start_13_wd;
+  logic tx_phy_clk_start_13_we;
+  logic [10:0] tx_phy_clk_start_14_qs;
+  logic [10:0] tx_phy_clk_start_14_wd;
+  logic tx_phy_clk_start_14_we;
+  logic [10:0] tx_phy_clk_start_15_qs;
+  logic [10:0] tx_phy_clk_start_15_wd;
+  logic tx_phy_clk_start_15_we;
+  logic [10:0] tx_phy_clk_start_16_qs;
+  logic [10:0] tx_phy_clk_start_16_wd;
+  logic tx_phy_clk_start_16_we;
+  logic [10:0] tx_phy_clk_start_17_qs;
+  logic [10:0] tx_phy_clk_start_17_wd;
+  logic tx_phy_clk_start_17_we;
+  logic [10:0] tx_phy_clk_start_18_qs;
+  logic [10:0] tx_phy_clk_start_18_wd;
+  logic tx_phy_clk_start_18_we;
+  logic [10:0] tx_phy_clk_start_19_qs;
+  logic [10:0] tx_phy_clk_start_19_wd;
+  logic tx_phy_clk_start_19_we;
+  logic [10:0] tx_phy_clk_start_20_qs;
+  logic [10:0] tx_phy_clk_start_20_wd;
+  logic tx_phy_clk_start_20_we;
+  logic [10:0] tx_phy_clk_start_21_qs;
+  logic [10:0] tx_phy_clk_start_21_wd;
+  logic tx_phy_clk_start_21_we;
+  logic [10:0] tx_phy_clk_start_22_qs;
+  logic [10:0] tx_phy_clk_start_22_wd;
+  logic tx_phy_clk_start_22_we;
+  logic [10:0] tx_phy_clk_start_23_qs;
+  logic [10:0] tx_phy_clk_start_23_wd;
+  logic tx_phy_clk_start_23_we;
+  logic [10:0] tx_phy_clk_start_24_qs;
+  logic [10:0] tx_phy_clk_start_24_wd;
+  logic tx_phy_clk_start_24_we;
+  logic [10:0] tx_phy_clk_start_25_qs;
+  logic [10:0] tx_phy_clk_start_25_wd;
+  logic tx_phy_clk_start_25_we;
+  logic [10:0] tx_phy_clk_start_26_qs;
+  logic [10:0] tx_phy_clk_start_26_wd;
+  logic tx_phy_clk_start_26_we;
+  logic [10:0] tx_phy_clk_start_27_qs;
+  logic [10:0] tx_phy_clk_start_27_wd;
+  logic tx_phy_clk_start_27_we;
+  logic [10:0] tx_phy_clk_start_28_qs;
+  logic [10:0] tx_phy_clk_start_28_wd;
+  logic tx_phy_clk_start_28_we;
+  logic [10:0] tx_phy_clk_start_29_qs;
+  logic [10:0] tx_phy_clk_start_29_wd;
+  logic tx_phy_clk_start_29_we;
+  logic [10:0] tx_phy_clk_start_30_qs;
+  logic [10:0] tx_phy_clk_start_30_wd;
+  logic tx_phy_clk_start_30_we;
+  logic [10:0] tx_phy_clk_start_31_qs;
+  logic [10:0] tx_phy_clk_start_31_wd;
+  logic tx_phy_clk_start_31_we;
+  logic [10:0] tx_phy_clk_start_32_qs;
+  logic [10:0] tx_phy_clk_start_32_wd;
+  logic tx_phy_clk_start_32_we;
+  logic [10:0] tx_phy_clk_start_33_qs;
+  logic [10:0] tx_phy_clk_start_33_wd;
+  logic tx_phy_clk_start_33_we;
+  logic [10:0] tx_phy_clk_start_34_qs;
+  logic [10:0] tx_phy_clk_start_34_wd;
+  logic tx_phy_clk_start_34_we;
+  logic [10:0] tx_phy_clk_start_35_qs;
+  logic [10:0] tx_phy_clk_start_35_wd;
+  logic tx_phy_clk_start_35_we;
+  logic [10:0] tx_phy_clk_start_36_qs;
+  logic [10:0] tx_phy_clk_start_36_wd;
+  logic tx_phy_clk_start_36_we;
+  logic [10:0] tx_phy_clk_start_37_qs;
+  logic [10:0] tx_phy_clk_start_37_wd;
+  logic tx_phy_clk_start_37_we;
+  logic [10:0] tx_phy_clk_end_0_qs;
+  logic [10:0] tx_phy_clk_end_0_wd;
+  logic tx_phy_clk_end_0_we;
+  logic [10:0] tx_phy_clk_end_1_qs;
+  logic [10:0] tx_phy_clk_end_1_wd;
+  logic tx_phy_clk_end_1_we;
+  logic [10:0] tx_phy_clk_end_2_qs;
+  logic [10:0] tx_phy_clk_end_2_wd;
+  logic tx_phy_clk_end_2_we;
+  logic [10:0] tx_phy_clk_end_3_qs;
+  logic [10:0] tx_phy_clk_end_3_wd;
+  logic tx_phy_clk_end_3_we;
+  logic [10:0] tx_phy_clk_end_4_qs;
+  logic [10:0] tx_phy_clk_end_4_wd;
+  logic tx_phy_clk_end_4_we;
+  logic [10:0] tx_phy_clk_end_5_qs;
+  logic [10:0] tx_phy_clk_end_5_wd;
+  logic tx_phy_clk_end_5_we;
+  logic [10:0] tx_phy_clk_end_6_qs;
+  logic [10:0] tx_phy_clk_end_6_wd;
+  logic tx_phy_clk_end_6_we;
+  logic [10:0] tx_phy_clk_end_7_qs;
+  logic [10:0] tx_phy_clk_end_7_wd;
+  logic tx_phy_clk_end_7_we;
+  logic [10:0] tx_phy_clk_end_8_qs;
+  logic [10:0] tx_phy_clk_end_8_wd;
+  logic tx_phy_clk_end_8_we;
+  logic [10:0] tx_phy_clk_end_9_qs;
+  logic [10:0] tx_phy_clk_end_9_wd;
+  logic tx_phy_clk_end_9_we;
+  logic [10:0] tx_phy_clk_end_10_qs;
+  logic [10:0] tx_phy_clk_end_10_wd;
+  logic tx_phy_clk_end_10_we;
+  logic [10:0] tx_phy_clk_end_11_qs;
+  logic [10:0] tx_phy_clk_end_11_wd;
+  logic tx_phy_clk_end_11_we;
+  logic [10:0] tx_phy_clk_end_12_qs;
+  logic [10:0] tx_phy_clk_end_12_wd;
+  logic tx_phy_clk_end_12_we;
+  logic [10:0] tx_phy_clk_end_13_qs;
+  logic [10:0] tx_phy_clk_end_13_wd;
+  logic tx_phy_clk_end_13_we;
+  logic [10:0] tx_phy_clk_end_14_qs;
+  logic [10:0] tx_phy_clk_end_14_wd;
+  logic tx_phy_clk_end_14_we;
+  logic [10:0] tx_phy_clk_end_15_qs;
+  logic [10:0] tx_phy_clk_end_15_wd;
+  logic tx_phy_clk_end_15_we;
+  logic [10:0] tx_phy_clk_end_16_qs;
+  logic [10:0] tx_phy_clk_end_16_wd;
+  logic tx_phy_clk_end_16_we;
+  logic [10:0] tx_phy_clk_end_17_qs;
+  logic [10:0] tx_phy_clk_end_17_wd;
+  logic tx_phy_clk_end_17_we;
+  logic [10:0] tx_phy_clk_end_18_qs;
+  logic [10:0] tx_phy_clk_end_18_wd;
+  logic tx_phy_clk_end_18_we;
+  logic [10:0] tx_phy_clk_end_19_qs;
+  logic [10:0] tx_phy_clk_end_19_wd;
+  logic tx_phy_clk_end_19_we;
+  logic [10:0] tx_phy_clk_end_20_qs;
+  logic [10:0] tx_phy_clk_end_20_wd;
+  logic tx_phy_clk_end_20_we;
+  logic [10:0] tx_phy_clk_end_21_qs;
+  logic [10:0] tx_phy_clk_end_21_wd;
+  logic tx_phy_clk_end_21_we;
+  logic [10:0] tx_phy_clk_end_22_qs;
+  logic [10:0] tx_phy_clk_end_22_wd;
+  logic tx_phy_clk_end_22_we;
+  logic [10:0] tx_phy_clk_end_23_qs;
+  logic [10:0] tx_phy_clk_end_23_wd;
+  logic tx_phy_clk_end_23_we;
+  logic [10:0] tx_phy_clk_end_24_qs;
+  logic [10:0] tx_phy_clk_end_24_wd;
+  logic tx_phy_clk_end_24_we;
+  logic [10:0] tx_phy_clk_end_25_qs;
+  logic [10:0] tx_phy_clk_end_25_wd;
+  logic tx_phy_clk_end_25_we;
+  logic [10:0] tx_phy_clk_end_26_qs;
+  logic [10:0] tx_phy_clk_end_26_wd;
+  logic tx_phy_clk_end_26_we;
+  logic [10:0] tx_phy_clk_end_27_qs;
+  logic [10:0] tx_phy_clk_end_27_wd;
+  logic tx_phy_clk_end_27_we;
+  logic [10:0] tx_phy_clk_end_28_qs;
+  logic [10:0] tx_phy_clk_end_28_wd;
+  logic tx_phy_clk_end_28_we;
+  logic [10:0] tx_phy_clk_end_29_qs;
+  logic [10:0] tx_phy_clk_end_29_wd;
+  logic tx_phy_clk_end_29_we;
+  logic [10:0] tx_phy_clk_end_30_qs;
+  logic [10:0] tx_phy_clk_end_30_wd;
+  logic tx_phy_clk_end_30_we;
+  logic [10:0] tx_phy_clk_end_31_qs;
+  logic [10:0] tx_phy_clk_end_31_wd;
+  logic tx_phy_clk_end_31_we;
+  logic [10:0] tx_phy_clk_end_32_qs;
+  logic [10:0] tx_phy_clk_end_32_wd;
+  logic tx_phy_clk_end_32_we;
+  logic [10:0] tx_phy_clk_end_33_qs;
+  logic [10:0] tx_phy_clk_end_33_wd;
+  logic tx_phy_clk_end_33_we;
+  logic [10:0] tx_phy_clk_end_34_qs;
+  logic [10:0] tx_phy_clk_end_34_wd;
+  logic tx_phy_clk_end_34_we;
+  logic [10:0] tx_phy_clk_end_35_qs;
+  logic [10:0] tx_phy_clk_end_35_wd;
+  logic tx_phy_clk_end_35_we;
+  logic [10:0] tx_phy_clk_end_36_qs;
+  logic [10:0] tx_phy_clk_end_36_wd;
+  logic tx_phy_clk_end_36_we;
+  logic [10:0] tx_phy_clk_end_37_qs;
+  logic [10:0] tx_phy_clk_end_37_wd;
+  logic tx_phy_clk_end_37_we;
   logic raw_mode_en_wd;
   logic raw_mode_en_we;
   logic [5:0] raw_mode_in_ch_sel_wd;
@@ -993,20 +993,20 @@ module serial_link_reg_top #(
 
 
 
-  // Subregister 0 of Multireg tx_phy_ctrl1
-  // R[tx_phy_ctrl1_0]: V(False)
+  // Subregister 0 of Multireg tx_phy_clk_div
+  // R[tx_phy_clk_div_0]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h8)
-  ) u_tx_phy_ctrl1_0 (
+  ) u_tx_phy_clk_div_0 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl1_0_we),
-    .wd     (tx_phy_ctrl1_0_wd),
+    .we     (tx_phy_clk_div_0_we),
+    .wd     (tx_phy_clk_div_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -1014,53 +1014,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl1[0].q ),
+    .q      (reg2hw.tx_phy_clk_div[0].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl1_0_qs)
+    .qs     (tx_phy_clk_div_0_qs)
   );
 
-  // Subregister 1 of Multireg tx_phy_ctrl1
-  // R[tx_phy_ctrl1_1]: V(False)
-
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h8)
-  ) u_tx_phy_ctrl1_1 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl1_1_we),
-    .wd     (tx_phy_ctrl1_1_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl1[1].q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl1_1_qs)
-  );
-
-  // Subregister 2 of Multireg tx_phy_ctrl1
-  // R[tx_phy_ctrl1_2]: V(False)
+  // Subregister 1 of Multireg tx_phy_clk_div
+  // R[tx_phy_clk_div_1]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h8)
-  ) u_tx_phy_ctrl1_2 (
+  ) u_tx_phy_clk_div_1 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl1_2_we),
-    .wd     (tx_phy_ctrl1_2_wd),
+    .we     (tx_phy_clk_div_1_we),
+    .wd     (tx_phy_clk_div_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -1068,53 +1041,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl1[2].q ),
+    .q      (reg2hw.tx_phy_clk_div[1].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl1_2_qs)
+    .qs     (tx_phy_clk_div_1_qs)
   );
 
-  // Subregister 3 of Multireg tx_phy_ctrl1
-  // R[tx_phy_ctrl1_3]: V(False)
-
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h8)
-  ) u_tx_phy_ctrl1_3 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl1_3_we),
-    .wd     (tx_phy_ctrl1_3_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl1[3].q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl1_3_qs)
-  );
-
-  // Subregister 4 of Multireg tx_phy_ctrl1
-  // R[tx_phy_ctrl1_4]: V(False)
+  // Subregister 2 of Multireg tx_phy_clk_div
+  // R[tx_phy_clk_div_2]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h8)
-  ) u_tx_phy_ctrl1_4 (
+  ) u_tx_phy_clk_div_2 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl1_4_we),
-    .wd     (tx_phy_ctrl1_4_wd),
+    .we     (tx_phy_clk_div_2_we),
+    .wd     (tx_phy_clk_div_2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -1122,53 +1068,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl1[4].q ),
+    .q      (reg2hw.tx_phy_clk_div[2].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl1_4_qs)
+    .qs     (tx_phy_clk_div_2_qs)
   );
 
-  // Subregister 5 of Multireg tx_phy_ctrl1
-  // R[tx_phy_ctrl1_5]: V(False)
-
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h8)
-  ) u_tx_phy_ctrl1_5 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl1_5_we),
-    .wd     (tx_phy_ctrl1_5_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl1[5].q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl1_5_qs)
-  );
-
-  // Subregister 6 of Multireg tx_phy_ctrl1
-  // R[tx_phy_ctrl1_6]: V(False)
+  // Subregister 3 of Multireg tx_phy_clk_div
+  // R[tx_phy_clk_div_3]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h8)
-  ) u_tx_phy_ctrl1_6 (
+  ) u_tx_phy_clk_div_3 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl1_6_we),
-    .wd     (tx_phy_ctrl1_6_wd),
+    .we     (tx_phy_clk_div_3_we),
+    .wd     (tx_phy_clk_div_3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -1176,53 +1095,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl1[6].q ),
+    .q      (reg2hw.tx_phy_clk_div[3].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl1_6_qs)
+    .qs     (tx_phy_clk_div_3_qs)
   );
 
-  // Subregister 7 of Multireg tx_phy_ctrl1
-  // R[tx_phy_ctrl1_7]: V(False)
-
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h8)
-  ) u_tx_phy_ctrl1_7 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl1_7_we),
-    .wd     (tx_phy_ctrl1_7_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl1[7].q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl1_7_qs)
-  );
-
-  // Subregister 8 of Multireg tx_phy_ctrl1
-  // R[tx_phy_ctrl1_8]: V(False)
+  // Subregister 4 of Multireg tx_phy_clk_div
+  // R[tx_phy_clk_div_4]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h8)
-  ) u_tx_phy_ctrl1_8 (
+  ) u_tx_phy_clk_div_4 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl1_8_we),
-    .wd     (tx_phy_ctrl1_8_wd),
+    .we     (tx_phy_clk_div_4_we),
+    .wd     (tx_phy_clk_div_4_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -1230,53 +1122,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl1[8].q ),
+    .q      (reg2hw.tx_phy_clk_div[4].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl1_8_qs)
+    .qs     (tx_phy_clk_div_4_qs)
   );
 
-  // Subregister 9 of Multireg tx_phy_ctrl1
-  // R[tx_phy_ctrl1_9]: V(False)
-
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h8)
-  ) u_tx_phy_ctrl1_9 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl1_9_we),
-    .wd     (tx_phy_ctrl1_9_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl1[9].q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl1_9_qs)
-  );
-
-  // Subregister 10 of Multireg tx_phy_ctrl1
-  // R[tx_phy_ctrl1_10]: V(False)
+  // Subregister 5 of Multireg tx_phy_clk_div
+  // R[tx_phy_clk_div_5]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h8)
-  ) u_tx_phy_ctrl1_10 (
+  ) u_tx_phy_clk_div_5 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl1_10_we),
-    .wd     (tx_phy_ctrl1_10_wd),
+    .we     (tx_phy_clk_div_5_we),
+    .wd     (tx_phy_clk_div_5_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -1284,53 +1149,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl1[10].q ),
+    .q      (reg2hw.tx_phy_clk_div[5].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl1_10_qs)
+    .qs     (tx_phy_clk_div_5_qs)
   );
 
-  // Subregister 11 of Multireg tx_phy_ctrl1
-  // R[tx_phy_ctrl1_11]: V(False)
-
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h8)
-  ) u_tx_phy_ctrl1_11 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl1_11_we),
-    .wd     (tx_phy_ctrl1_11_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl1[11].q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl1_11_qs)
-  );
-
-  // Subregister 12 of Multireg tx_phy_ctrl1
-  // R[tx_phy_ctrl1_12]: V(False)
+  // Subregister 6 of Multireg tx_phy_clk_div
+  // R[tx_phy_clk_div_6]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h8)
-  ) u_tx_phy_ctrl1_12 (
+  ) u_tx_phy_clk_div_6 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl1_12_we),
-    .wd     (tx_phy_ctrl1_12_wd),
+    .we     (tx_phy_clk_div_6_we),
+    .wd     (tx_phy_clk_div_6_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -1338,53 +1176,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl1[12].q ),
+    .q      (reg2hw.tx_phy_clk_div[6].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl1_12_qs)
+    .qs     (tx_phy_clk_div_6_qs)
   );
 
-  // Subregister 13 of Multireg tx_phy_ctrl1
-  // R[tx_phy_ctrl1_13]: V(False)
-
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h8)
-  ) u_tx_phy_ctrl1_13 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl1_13_we),
-    .wd     (tx_phy_ctrl1_13_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl1[13].q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl1_13_qs)
-  );
-
-  // Subregister 14 of Multireg tx_phy_ctrl1
-  // R[tx_phy_ctrl1_14]: V(False)
+  // Subregister 7 of Multireg tx_phy_clk_div
+  // R[tx_phy_clk_div_7]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h8)
-  ) u_tx_phy_ctrl1_14 (
+  ) u_tx_phy_clk_div_7 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl1_14_we),
-    .wd     (tx_phy_ctrl1_14_wd),
+    .we     (tx_phy_clk_div_7_we),
+    .wd     (tx_phy_clk_div_7_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -1392,53 +1203,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl1[14].q ),
+    .q      (reg2hw.tx_phy_clk_div[7].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl1_14_qs)
+    .qs     (tx_phy_clk_div_7_qs)
   );
 
-  // Subregister 15 of Multireg tx_phy_ctrl1
-  // R[tx_phy_ctrl1_15]: V(False)
-
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h8)
-  ) u_tx_phy_ctrl1_15 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl1_15_we),
-    .wd     (tx_phy_ctrl1_15_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl1[15].q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl1_15_qs)
-  );
-
-  // Subregister 16 of Multireg tx_phy_ctrl1
-  // R[tx_phy_ctrl1_16]: V(False)
+  // Subregister 8 of Multireg tx_phy_clk_div
+  // R[tx_phy_clk_div_8]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h8)
-  ) u_tx_phy_ctrl1_16 (
+  ) u_tx_phy_clk_div_8 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl1_16_we),
-    .wd     (tx_phy_ctrl1_16_wd),
+    .we     (tx_phy_clk_div_8_we),
+    .wd     (tx_phy_clk_div_8_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -1446,53 +1230,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl1[16].q ),
+    .q      (reg2hw.tx_phy_clk_div[8].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl1_16_qs)
+    .qs     (tx_phy_clk_div_8_qs)
   );
 
-  // Subregister 17 of Multireg tx_phy_ctrl1
-  // R[tx_phy_ctrl1_17]: V(False)
-
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h8)
-  ) u_tx_phy_ctrl1_17 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl1_17_we),
-    .wd     (tx_phy_ctrl1_17_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl1[17].q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl1_17_qs)
-  );
-
-  // Subregister 18 of Multireg tx_phy_ctrl1
-  // R[tx_phy_ctrl1_18]: V(False)
+  // Subregister 9 of Multireg tx_phy_clk_div
+  // R[tx_phy_clk_div_9]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h8)
-  ) u_tx_phy_ctrl1_18 (
+  ) u_tx_phy_clk_div_9 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl1_18_we),
-    .wd     (tx_phy_ctrl1_18_wd),
+    .we     (tx_phy_clk_div_9_we),
+    .wd     (tx_phy_clk_div_9_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -1500,53 +1257,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl1[18].q ),
+    .q      (reg2hw.tx_phy_clk_div[9].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl1_18_qs)
+    .qs     (tx_phy_clk_div_9_qs)
   );
 
-  // Subregister 19 of Multireg tx_phy_ctrl1
-  // R[tx_phy_ctrl1_19]: V(False)
-
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h8)
-  ) u_tx_phy_ctrl1_19 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl1_19_we),
-    .wd     (tx_phy_ctrl1_19_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl1[19].q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl1_19_qs)
-  );
-
-  // Subregister 20 of Multireg tx_phy_ctrl1
-  // R[tx_phy_ctrl1_20]: V(False)
+  // Subregister 10 of Multireg tx_phy_clk_div
+  // R[tx_phy_clk_div_10]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h8)
-  ) u_tx_phy_ctrl1_20 (
+  ) u_tx_phy_clk_div_10 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl1_20_we),
-    .wd     (tx_phy_ctrl1_20_wd),
+    .we     (tx_phy_clk_div_10_we),
+    .wd     (tx_phy_clk_div_10_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -1554,53 +1284,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl1[20].q ),
+    .q      (reg2hw.tx_phy_clk_div[10].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl1_20_qs)
+    .qs     (tx_phy_clk_div_10_qs)
   );
 
-  // Subregister 21 of Multireg tx_phy_ctrl1
-  // R[tx_phy_ctrl1_21]: V(False)
-
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h8)
-  ) u_tx_phy_ctrl1_21 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl1_21_we),
-    .wd     (tx_phy_ctrl1_21_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl1[21].q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl1_21_qs)
-  );
-
-  // Subregister 22 of Multireg tx_phy_ctrl1
-  // R[tx_phy_ctrl1_22]: V(False)
+  // Subregister 11 of Multireg tx_phy_clk_div
+  // R[tx_phy_clk_div_11]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h8)
-  ) u_tx_phy_ctrl1_22 (
+  ) u_tx_phy_clk_div_11 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl1_22_we),
-    .wd     (tx_phy_ctrl1_22_wd),
+    .we     (tx_phy_clk_div_11_we),
+    .wd     (tx_phy_clk_div_11_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -1608,53 +1311,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl1[22].q ),
+    .q      (reg2hw.tx_phy_clk_div[11].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl1_22_qs)
+    .qs     (tx_phy_clk_div_11_qs)
   );
 
-  // Subregister 23 of Multireg tx_phy_ctrl1
-  // R[tx_phy_ctrl1_23]: V(False)
-
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h8)
-  ) u_tx_phy_ctrl1_23 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl1_23_we),
-    .wd     (tx_phy_ctrl1_23_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl1[23].q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl1_23_qs)
-  );
-
-  // Subregister 24 of Multireg tx_phy_ctrl1
-  // R[tx_phy_ctrl1_24]: V(False)
+  // Subregister 12 of Multireg tx_phy_clk_div
+  // R[tx_phy_clk_div_12]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h8)
-  ) u_tx_phy_ctrl1_24 (
+  ) u_tx_phy_clk_div_12 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl1_24_we),
-    .wd     (tx_phy_ctrl1_24_wd),
+    .we     (tx_phy_clk_div_12_we),
+    .wd     (tx_phy_clk_div_12_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -1662,53 +1338,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl1[24].q ),
+    .q      (reg2hw.tx_phy_clk_div[12].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl1_24_qs)
+    .qs     (tx_phy_clk_div_12_qs)
   );
 
-  // Subregister 25 of Multireg tx_phy_ctrl1
-  // R[tx_phy_ctrl1_25]: V(False)
-
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h8)
-  ) u_tx_phy_ctrl1_25 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl1_25_we),
-    .wd     (tx_phy_ctrl1_25_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl1[25].q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl1_25_qs)
-  );
-
-  // Subregister 26 of Multireg tx_phy_ctrl1
-  // R[tx_phy_ctrl1_26]: V(False)
+  // Subregister 13 of Multireg tx_phy_clk_div
+  // R[tx_phy_clk_div_13]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h8)
-  ) u_tx_phy_ctrl1_26 (
+  ) u_tx_phy_clk_div_13 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl1_26_we),
-    .wd     (tx_phy_ctrl1_26_wd),
+    .we     (tx_phy_clk_div_13_we),
+    .wd     (tx_phy_clk_div_13_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -1716,53 +1365,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl1[26].q ),
+    .q      (reg2hw.tx_phy_clk_div[13].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl1_26_qs)
+    .qs     (tx_phy_clk_div_13_qs)
   );
 
-  // Subregister 27 of Multireg tx_phy_ctrl1
-  // R[tx_phy_ctrl1_27]: V(False)
-
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h8)
-  ) u_tx_phy_ctrl1_27 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl1_27_we),
-    .wd     (tx_phy_ctrl1_27_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl1[27].q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl1_27_qs)
-  );
-
-  // Subregister 28 of Multireg tx_phy_ctrl1
-  // R[tx_phy_ctrl1_28]: V(False)
+  // Subregister 14 of Multireg tx_phy_clk_div
+  // R[tx_phy_clk_div_14]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h8)
-  ) u_tx_phy_ctrl1_28 (
+  ) u_tx_phy_clk_div_14 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl1_28_we),
-    .wd     (tx_phy_ctrl1_28_wd),
+    .we     (tx_phy_clk_div_14_we),
+    .wd     (tx_phy_clk_div_14_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -1770,53 +1392,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl1[28].q ),
+    .q      (reg2hw.tx_phy_clk_div[14].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl1_28_qs)
+    .qs     (tx_phy_clk_div_14_qs)
   );
 
-  // Subregister 29 of Multireg tx_phy_ctrl1
-  // R[tx_phy_ctrl1_29]: V(False)
-
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h8)
-  ) u_tx_phy_ctrl1_29 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl1_29_we),
-    .wd     (tx_phy_ctrl1_29_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl1[29].q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl1_29_qs)
-  );
-
-  // Subregister 30 of Multireg tx_phy_ctrl1
-  // R[tx_phy_ctrl1_30]: V(False)
+  // Subregister 15 of Multireg tx_phy_clk_div
+  // R[tx_phy_clk_div_15]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h8)
-  ) u_tx_phy_ctrl1_30 (
+  ) u_tx_phy_clk_div_15 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl1_30_we),
-    .wd     (tx_phy_ctrl1_30_wd),
+    .we     (tx_phy_clk_div_15_we),
+    .wd     (tx_phy_clk_div_15_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -1824,53 +1419,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl1[30].q ),
+    .q      (reg2hw.tx_phy_clk_div[15].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl1_30_qs)
+    .qs     (tx_phy_clk_div_15_qs)
   );
 
-  // Subregister 31 of Multireg tx_phy_ctrl1
-  // R[tx_phy_ctrl1_31]: V(False)
-
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h8)
-  ) u_tx_phy_ctrl1_31 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl1_31_we),
-    .wd     (tx_phy_ctrl1_31_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl1[31].q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl1_31_qs)
-  );
-
-  // Subregister 32 of Multireg tx_phy_ctrl1
-  // R[tx_phy_ctrl1_32]: V(False)
+  // Subregister 16 of Multireg tx_phy_clk_div
+  // R[tx_phy_clk_div_16]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h8)
-  ) u_tx_phy_ctrl1_32 (
+  ) u_tx_phy_clk_div_16 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl1_32_we),
-    .wd     (tx_phy_ctrl1_32_wd),
+    .we     (tx_phy_clk_div_16_we),
+    .wd     (tx_phy_clk_div_16_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -1878,53 +1446,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl1[32].q ),
+    .q      (reg2hw.tx_phy_clk_div[16].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl1_32_qs)
+    .qs     (tx_phy_clk_div_16_qs)
   );
 
-  // Subregister 33 of Multireg tx_phy_ctrl1
-  // R[tx_phy_ctrl1_33]: V(False)
-
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h8)
-  ) u_tx_phy_ctrl1_33 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl1_33_we),
-    .wd     (tx_phy_ctrl1_33_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl1[33].q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl1_33_qs)
-  );
-
-  // Subregister 34 of Multireg tx_phy_ctrl1
-  // R[tx_phy_ctrl1_34]: V(False)
+  // Subregister 17 of Multireg tx_phy_clk_div
+  // R[tx_phy_clk_div_17]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h8)
-  ) u_tx_phy_ctrl1_34 (
+  ) u_tx_phy_clk_div_17 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl1_34_we),
-    .wd     (tx_phy_ctrl1_34_wd),
+    .we     (tx_phy_clk_div_17_we),
+    .wd     (tx_phy_clk_div_17_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -1932,53 +1473,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl1[34].q ),
+    .q      (reg2hw.tx_phy_clk_div[17].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl1_34_qs)
+    .qs     (tx_phy_clk_div_17_qs)
   );
 
-  // Subregister 35 of Multireg tx_phy_ctrl1
-  // R[tx_phy_ctrl1_35]: V(False)
-
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h8)
-  ) u_tx_phy_ctrl1_35 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl1_35_we),
-    .wd     (tx_phy_ctrl1_35_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl1[35].q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl1_35_qs)
-  );
-
-  // Subregister 36 of Multireg tx_phy_ctrl1
-  // R[tx_phy_ctrl1_36]: V(False)
+  // Subregister 18 of Multireg tx_phy_clk_div
+  // R[tx_phy_clk_div_18]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h8)
-  ) u_tx_phy_ctrl1_36 (
+  ) u_tx_phy_clk_div_18 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl1_36_we),
-    .wd     (tx_phy_ctrl1_36_wd),
+    .we     (tx_phy_clk_div_18_we),
+    .wd     (tx_phy_clk_div_18_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -1986,26 +1500,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl1[36].q ),
+    .q      (reg2hw.tx_phy_clk_div[18].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl1_36_qs)
+    .qs     (tx_phy_clk_div_18_qs)
   );
 
-  // Subregister 37 of Multireg tx_phy_ctrl1
-  // R[tx_phy_ctrl1_37]: V(False)
+  // Subregister 19 of Multireg tx_phy_clk_div
+  // R[tx_phy_clk_div_19]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h8)
-  ) u_tx_phy_ctrl1_37 (
+  ) u_tx_phy_clk_div_19 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl1_37_we),
-    .wd     (tx_phy_ctrl1_37_wd),
+    .we     (tx_phy_clk_div_19_we),
+    .wd     (tx_phy_clk_div_19_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2013,28 +1527,514 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl1[37].q ),
+    .q      (reg2hw.tx_phy_clk_div[19].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl1_37_qs)
+    .qs     (tx_phy_clk_div_19_qs)
+  );
+
+  // Subregister 20 of Multireg tx_phy_clk_div
+  // R[tx_phy_clk_div_20]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h8)
+  ) u_tx_phy_clk_div_20 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_clk_div_20_we),
+    .wd     (tx_phy_clk_div_20_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_clk_div[20].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_clk_div_20_qs)
+  );
+
+  // Subregister 21 of Multireg tx_phy_clk_div
+  // R[tx_phy_clk_div_21]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h8)
+  ) u_tx_phy_clk_div_21 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_clk_div_21_we),
+    .wd     (tx_phy_clk_div_21_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_clk_div[21].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_clk_div_21_qs)
+  );
+
+  // Subregister 22 of Multireg tx_phy_clk_div
+  // R[tx_phy_clk_div_22]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h8)
+  ) u_tx_phy_clk_div_22 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_clk_div_22_we),
+    .wd     (tx_phy_clk_div_22_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_clk_div[22].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_clk_div_22_qs)
+  );
+
+  // Subregister 23 of Multireg tx_phy_clk_div
+  // R[tx_phy_clk_div_23]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h8)
+  ) u_tx_phy_clk_div_23 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_clk_div_23_we),
+    .wd     (tx_phy_clk_div_23_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_clk_div[23].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_clk_div_23_qs)
+  );
+
+  // Subregister 24 of Multireg tx_phy_clk_div
+  // R[tx_phy_clk_div_24]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h8)
+  ) u_tx_phy_clk_div_24 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_clk_div_24_we),
+    .wd     (tx_phy_clk_div_24_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_clk_div[24].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_clk_div_24_qs)
+  );
+
+  // Subregister 25 of Multireg tx_phy_clk_div
+  // R[tx_phy_clk_div_25]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h8)
+  ) u_tx_phy_clk_div_25 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_clk_div_25_we),
+    .wd     (tx_phy_clk_div_25_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_clk_div[25].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_clk_div_25_qs)
+  );
+
+  // Subregister 26 of Multireg tx_phy_clk_div
+  // R[tx_phy_clk_div_26]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h8)
+  ) u_tx_phy_clk_div_26 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_clk_div_26_we),
+    .wd     (tx_phy_clk_div_26_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_clk_div[26].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_clk_div_26_qs)
+  );
+
+  // Subregister 27 of Multireg tx_phy_clk_div
+  // R[tx_phy_clk_div_27]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h8)
+  ) u_tx_phy_clk_div_27 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_clk_div_27_we),
+    .wd     (tx_phy_clk_div_27_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_clk_div[27].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_clk_div_27_qs)
+  );
+
+  // Subregister 28 of Multireg tx_phy_clk_div
+  // R[tx_phy_clk_div_28]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h8)
+  ) u_tx_phy_clk_div_28 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_clk_div_28_we),
+    .wd     (tx_phy_clk_div_28_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_clk_div[28].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_clk_div_28_qs)
+  );
+
+  // Subregister 29 of Multireg tx_phy_clk_div
+  // R[tx_phy_clk_div_29]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h8)
+  ) u_tx_phy_clk_div_29 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_clk_div_29_we),
+    .wd     (tx_phy_clk_div_29_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_clk_div[29].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_clk_div_29_qs)
+  );
+
+  // Subregister 30 of Multireg tx_phy_clk_div
+  // R[tx_phy_clk_div_30]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h8)
+  ) u_tx_phy_clk_div_30 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_clk_div_30_we),
+    .wd     (tx_phy_clk_div_30_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_clk_div[30].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_clk_div_30_qs)
+  );
+
+  // Subregister 31 of Multireg tx_phy_clk_div
+  // R[tx_phy_clk_div_31]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h8)
+  ) u_tx_phy_clk_div_31 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_clk_div_31_we),
+    .wd     (tx_phy_clk_div_31_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_clk_div[31].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_clk_div_31_qs)
+  );
+
+  // Subregister 32 of Multireg tx_phy_clk_div
+  // R[tx_phy_clk_div_32]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h8)
+  ) u_tx_phy_clk_div_32 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_clk_div_32_we),
+    .wd     (tx_phy_clk_div_32_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_clk_div[32].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_clk_div_32_qs)
+  );
+
+  // Subregister 33 of Multireg tx_phy_clk_div
+  // R[tx_phy_clk_div_33]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h8)
+  ) u_tx_phy_clk_div_33 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_clk_div_33_we),
+    .wd     (tx_phy_clk_div_33_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_clk_div[33].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_clk_div_33_qs)
+  );
+
+  // Subregister 34 of Multireg tx_phy_clk_div
+  // R[tx_phy_clk_div_34]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h8)
+  ) u_tx_phy_clk_div_34 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_clk_div_34_we),
+    .wd     (tx_phy_clk_div_34_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_clk_div[34].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_clk_div_34_qs)
+  );
+
+  // Subregister 35 of Multireg tx_phy_clk_div
+  // R[tx_phy_clk_div_35]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h8)
+  ) u_tx_phy_clk_div_35 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_clk_div_35_we),
+    .wd     (tx_phy_clk_div_35_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_clk_div[35].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_clk_div_35_qs)
+  );
+
+  // Subregister 36 of Multireg tx_phy_clk_div
+  // R[tx_phy_clk_div_36]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h8)
+  ) u_tx_phy_clk_div_36 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_clk_div_36_we),
+    .wd     (tx_phy_clk_div_36_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_clk_div[36].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_clk_div_36_qs)
+  );
+
+  // Subregister 37 of Multireg tx_phy_clk_div
+  // R[tx_phy_clk_div_37]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h8)
+  ) u_tx_phy_clk_div_37 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_clk_div_37_we),
+    .wd     (tx_phy_clk_div_37_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_clk_div[37].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_clk_div_37_qs)
   );
 
 
 
-  // Subregister 0 of Multireg tx_phy_ctrl2
-  // R[tx_phy_ctrl2_0]: V(False)
+  // Subregister 0 of Multireg tx_phy_clk_start
+  // R[tx_phy_clk_start_0]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_0 (
+  ) u_tx_phy_clk_start_0 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_0_we),
-    .wd     (tx_phy_ctrl2_0_wd),
+    .we     (tx_phy_clk_start_0_we),
+    .wd     (tx_phy_clk_start_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2042,53 +2042,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[0].q ),
+    .q      (reg2hw.tx_phy_clk_start[0].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_0_qs)
+    .qs     (tx_phy_clk_start_0_qs)
   );
 
-  // Subregister 1 of Multireg tx_phy_ctrl2
-  // R[tx_phy_ctrl2_1]: V(False)
-
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_1 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl2_1_we),
-    .wd     (tx_phy_ctrl2_1_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[1].q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl2_1_qs)
-  );
-
-  // Subregister 2 of Multireg tx_phy_ctrl2
-  // R[tx_phy_ctrl2_2]: V(False)
+  // Subregister 1 of Multireg tx_phy_clk_start
+  // R[tx_phy_clk_start_1]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_2 (
+  ) u_tx_phy_clk_start_1 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_2_we),
-    .wd     (tx_phy_ctrl2_2_wd),
+    .we     (tx_phy_clk_start_1_we),
+    .wd     (tx_phy_clk_start_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2096,53 +2069,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[2].q ),
+    .q      (reg2hw.tx_phy_clk_start[1].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_2_qs)
+    .qs     (tx_phy_clk_start_1_qs)
   );
 
-  // Subregister 3 of Multireg tx_phy_ctrl2
-  // R[tx_phy_ctrl2_3]: V(False)
-
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_3 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl2_3_we),
-    .wd     (tx_phy_ctrl2_3_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[3].q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl2_3_qs)
-  );
-
-  // Subregister 4 of Multireg tx_phy_ctrl2
-  // R[tx_phy_ctrl2_4]: V(False)
+  // Subregister 2 of Multireg tx_phy_clk_start
+  // R[tx_phy_clk_start_2]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_4 (
+  ) u_tx_phy_clk_start_2 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_4_we),
-    .wd     (tx_phy_ctrl2_4_wd),
+    .we     (tx_phy_clk_start_2_we),
+    .wd     (tx_phy_clk_start_2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2150,53 +2096,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[4].q ),
+    .q      (reg2hw.tx_phy_clk_start[2].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_4_qs)
+    .qs     (tx_phy_clk_start_2_qs)
   );
 
-  // Subregister 5 of Multireg tx_phy_ctrl2
-  // R[tx_phy_ctrl2_5]: V(False)
-
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_5 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl2_5_we),
-    .wd     (tx_phy_ctrl2_5_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[5].q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl2_5_qs)
-  );
-
-  // Subregister 6 of Multireg tx_phy_ctrl2
-  // R[tx_phy_ctrl2_6]: V(False)
+  // Subregister 3 of Multireg tx_phy_clk_start
+  // R[tx_phy_clk_start_3]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_6 (
+  ) u_tx_phy_clk_start_3 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_6_we),
-    .wd     (tx_phy_ctrl2_6_wd),
+    .we     (tx_phy_clk_start_3_we),
+    .wd     (tx_phy_clk_start_3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2204,53 +2123,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[6].q ),
+    .q      (reg2hw.tx_phy_clk_start[3].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_6_qs)
+    .qs     (tx_phy_clk_start_3_qs)
   );
 
-  // Subregister 7 of Multireg tx_phy_ctrl2
-  // R[tx_phy_ctrl2_7]: V(False)
-
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_7 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl2_7_we),
-    .wd     (tx_phy_ctrl2_7_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[7].q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl2_7_qs)
-  );
-
-  // Subregister 8 of Multireg tx_phy_ctrl2
-  // R[tx_phy_ctrl2_8]: V(False)
+  // Subregister 4 of Multireg tx_phy_clk_start
+  // R[tx_phy_clk_start_4]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_8 (
+  ) u_tx_phy_clk_start_4 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_8_we),
-    .wd     (tx_phy_ctrl2_8_wd),
+    .we     (tx_phy_clk_start_4_we),
+    .wd     (tx_phy_clk_start_4_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2258,53 +2150,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[8].q ),
+    .q      (reg2hw.tx_phy_clk_start[4].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_8_qs)
+    .qs     (tx_phy_clk_start_4_qs)
   );
 
-  // Subregister 9 of Multireg tx_phy_ctrl2
-  // R[tx_phy_ctrl2_9]: V(False)
-
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_9 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl2_9_we),
-    .wd     (tx_phy_ctrl2_9_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[9].q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl2_9_qs)
-  );
-
-  // Subregister 10 of Multireg tx_phy_ctrl2
-  // R[tx_phy_ctrl2_10]: V(False)
+  // Subregister 5 of Multireg tx_phy_clk_start
+  // R[tx_phy_clk_start_5]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_10 (
+  ) u_tx_phy_clk_start_5 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_10_we),
-    .wd     (tx_phy_ctrl2_10_wd),
+    .we     (tx_phy_clk_start_5_we),
+    .wd     (tx_phy_clk_start_5_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2312,53 +2177,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[10].q ),
+    .q      (reg2hw.tx_phy_clk_start[5].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_10_qs)
+    .qs     (tx_phy_clk_start_5_qs)
   );
 
-  // Subregister 11 of Multireg tx_phy_ctrl2
-  // R[tx_phy_ctrl2_11]: V(False)
-
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_11 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl2_11_we),
-    .wd     (tx_phy_ctrl2_11_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[11].q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl2_11_qs)
-  );
-
-  // Subregister 12 of Multireg tx_phy_ctrl2
-  // R[tx_phy_ctrl2_12]: V(False)
+  // Subregister 6 of Multireg tx_phy_clk_start
+  // R[tx_phy_clk_start_6]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_12 (
+  ) u_tx_phy_clk_start_6 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_12_we),
-    .wd     (tx_phy_ctrl2_12_wd),
+    .we     (tx_phy_clk_start_6_we),
+    .wd     (tx_phy_clk_start_6_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2366,26 +2204,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[12].q ),
+    .q      (reg2hw.tx_phy_clk_start[6].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_12_qs)
+    .qs     (tx_phy_clk_start_6_qs)
   );
 
-  // Subregister 13 of Multireg tx_phy_ctrl2
-  // R[tx_phy_ctrl2_13]: V(False)
+  // Subregister 7 of Multireg tx_phy_clk_start
+  // R[tx_phy_clk_start_7]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_13 (
+  ) u_tx_phy_clk_start_7 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_13_we),
-    .wd     (tx_phy_ctrl2_13_wd),
+    .we     (tx_phy_clk_start_7_we),
+    .wd     (tx_phy_clk_start_7_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2393,26 +2231,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[13].q ),
+    .q      (reg2hw.tx_phy_clk_start[7].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_13_qs)
+    .qs     (tx_phy_clk_start_7_qs)
   );
 
-  // Subregister 14 of Multireg tx_phy_ctrl2
-  // R[tx_phy_ctrl2_14]: V(False)
+  // Subregister 8 of Multireg tx_phy_clk_start
+  // R[tx_phy_clk_start_8]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_14 (
+  ) u_tx_phy_clk_start_8 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_14_we),
-    .wd     (tx_phy_ctrl2_14_wd),
+    .we     (tx_phy_clk_start_8_we),
+    .wd     (tx_phy_clk_start_8_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2420,26 +2258,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[14].q ),
+    .q      (reg2hw.tx_phy_clk_start[8].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_14_qs)
+    .qs     (tx_phy_clk_start_8_qs)
   );
 
-  // Subregister 15 of Multireg tx_phy_ctrl2
-  // R[tx_phy_ctrl2_15]: V(False)
+  // Subregister 9 of Multireg tx_phy_clk_start
+  // R[tx_phy_clk_start_9]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_15 (
+  ) u_tx_phy_clk_start_9 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_15_we),
-    .wd     (tx_phy_ctrl2_15_wd),
+    .we     (tx_phy_clk_start_9_we),
+    .wd     (tx_phy_clk_start_9_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2447,26 +2285,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[15].q ),
+    .q      (reg2hw.tx_phy_clk_start[9].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_15_qs)
+    .qs     (tx_phy_clk_start_9_qs)
   );
 
-  // Subregister 16 of Multireg tx_phy_ctrl2
-  // R[tx_phy_ctrl2_16]: V(False)
+  // Subregister 10 of Multireg tx_phy_clk_start
+  // R[tx_phy_clk_start_10]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_16 (
+  ) u_tx_phy_clk_start_10 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_16_we),
-    .wd     (tx_phy_ctrl2_16_wd),
+    .we     (tx_phy_clk_start_10_we),
+    .wd     (tx_phy_clk_start_10_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2474,26 +2312,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[16].q ),
+    .q      (reg2hw.tx_phy_clk_start[10].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_16_qs)
+    .qs     (tx_phy_clk_start_10_qs)
   );
 
-  // Subregister 17 of Multireg tx_phy_ctrl2
-  // R[tx_phy_ctrl2_17]: V(False)
+  // Subregister 11 of Multireg tx_phy_clk_start
+  // R[tx_phy_clk_start_11]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_17 (
+  ) u_tx_phy_clk_start_11 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_17_we),
-    .wd     (tx_phy_ctrl2_17_wd),
+    .we     (tx_phy_clk_start_11_we),
+    .wd     (tx_phy_clk_start_11_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2501,26 +2339,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[17].q ),
+    .q      (reg2hw.tx_phy_clk_start[11].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_17_qs)
+    .qs     (tx_phy_clk_start_11_qs)
   );
 
-  // Subregister 18 of Multireg tx_phy_ctrl2
-  // R[tx_phy_ctrl2_18]: V(False)
+  // Subregister 12 of Multireg tx_phy_clk_start
+  // R[tx_phy_clk_start_12]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_18 (
+  ) u_tx_phy_clk_start_12 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_18_we),
-    .wd     (tx_phy_ctrl2_18_wd),
+    .we     (tx_phy_clk_start_12_we),
+    .wd     (tx_phy_clk_start_12_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2528,26 +2366,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[18].q ),
+    .q      (reg2hw.tx_phy_clk_start[12].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_18_qs)
+    .qs     (tx_phy_clk_start_12_qs)
   );
 
-  // Subregister 19 of Multireg tx_phy_ctrl2
-  // R[tx_phy_ctrl2_19]: V(False)
+  // Subregister 13 of Multireg tx_phy_clk_start
+  // R[tx_phy_clk_start_13]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_19 (
+  ) u_tx_phy_clk_start_13 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_19_we),
-    .wd     (tx_phy_ctrl2_19_wd),
+    .we     (tx_phy_clk_start_13_we),
+    .wd     (tx_phy_clk_start_13_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2555,26 +2393,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[19].q ),
+    .q      (reg2hw.tx_phy_clk_start[13].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_19_qs)
+    .qs     (tx_phy_clk_start_13_qs)
   );
 
-  // Subregister 20 of Multireg tx_phy_ctrl2
-  // R[tx_phy_ctrl2_20]: V(False)
+  // Subregister 14 of Multireg tx_phy_clk_start
+  // R[tx_phy_clk_start_14]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_20 (
+  ) u_tx_phy_clk_start_14 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_20_we),
-    .wd     (tx_phy_ctrl2_20_wd),
+    .we     (tx_phy_clk_start_14_we),
+    .wd     (tx_phy_clk_start_14_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2582,26 +2420,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[20].q ),
+    .q      (reg2hw.tx_phy_clk_start[14].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_20_qs)
+    .qs     (tx_phy_clk_start_14_qs)
   );
 
-  // Subregister 21 of Multireg tx_phy_ctrl2
-  // R[tx_phy_ctrl2_21]: V(False)
+  // Subregister 15 of Multireg tx_phy_clk_start
+  // R[tx_phy_clk_start_15]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_21 (
+  ) u_tx_phy_clk_start_15 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_21_we),
-    .wd     (tx_phy_ctrl2_21_wd),
+    .we     (tx_phy_clk_start_15_we),
+    .wd     (tx_phy_clk_start_15_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2609,26 +2447,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[21].q ),
+    .q      (reg2hw.tx_phy_clk_start[15].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_21_qs)
+    .qs     (tx_phy_clk_start_15_qs)
   );
 
-  // Subregister 22 of Multireg tx_phy_ctrl2
-  // R[tx_phy_ctrl2_22]: V(False)
+  // Subregister 16 of Multireg tx_phy_clk_start
+  // R[tx_phy_clk_start_16]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_22 (
+  ) u_tx_phy_clk_start_16 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_22_we),
-    .wd     (tx_phy_ctrl2_22_wd),
+    .we     (tx_phy_clk_start_16_we),
+    .wd     (tx_phy_clk_start_16_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2636,26 +2474,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[22].q ),
+    .q      (reg2hw.tx_phy_clk_start[16].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_22_qs)
+    .qs     (tx_phy_clk_start_16_qs)
   );
 
-  // Subregister 23 of Multireg tx_phy_ctrl2
-  // R[tx_phy_ctrl2_23]: V(False)
+  // Subregister 17 of Multireg tx_phy_clk_start
+  // R[tx_phy_clk_start_17]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_23 (
+  ) u_tx_phy_clk_start_17 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_23_we),
-    .wd     (tx_phy_ctrl2_23_wd),
+    .we     (tx_phy_clk_start_17_we),
+    .wd     (tx_phy_clk_start_17_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2663,26 +2501,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[23].q ),
+    .q      (reg2hw.tx_phy_clk_start[17].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_23_qs)
+    .qs     (tx_phy_clk_start_17_qs)
   );
 
-  // Subregister 24 of Multireg tx_phy_ctrl2
-  // R[tx_phy_ctrl2_24]: V(False)
+  // Subregister 18 of Multireg tx_phy_clk_start
+  // R[tx_phy_clk_start_18]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_24 (
+  ) u_tx_phy_clk_start_18 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_24_we),
-    .wd     (tx_phy_ctrl2_24_wd),
+    .we     (tx_phy_clk_start_18_we),
+    .wd     (tx_phy_clk_start_18_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2690,26 +2528,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[24].q ),
+    .q      (reg2hw.tx_phy_clk_start[18].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_24_qs)
+    .qs     (tx_phy_clk_start_18_qs)
   );
 
-  // Subregister 25 of Multireg tx_phy_ctrl2
-  // R[tx_phy_ctrl2_25]: V(False)
+  // Subregister 19 of Multireg tx_phy_clk_start
+  // R[tx_phy_clk_start_19]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_25 (
+  ) u_tx_phy_clk_start_19 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_25_we),
-    .wd     (tx_phy_ctrl2_25_wd),
+    .we     (tx_phy_clk_start_19_we),
+    .wd     (tx_phy_clk_start_19_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2717,26 +2555,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[25].q ),
+    .q      (reg2hw.tx_phy_clk_start[19].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_25_qs)
+    .qs     (tx_phy_clk_start_19_qs)
   );
 
-  // Subregister 26 of Multireg tx_phy_ctrl2
-  // R[tx_phy_ctrl2_26]: V(False)
+  // Subregister 20 of Multireg tx_phy_clk_start
+  // R[tx_phy_clk_start_20]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_26 (
+  ) u_tx_phy_clk_start_20 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_26_we),
-    .wd     (tx_phy_ctrl2_26_wd),
+    .we     (tx_phy_clk_start_20_we),
+    .wd     (tx_phy_clk_start_20_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2744,26 +2582,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[26].q ),
+    .q      (reg2hw.tx_phy_clk_start[20].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_26_qs)
+    .qs     (tx_phy_clk_start_20_qs)
   );
 
-  // Subregister 27 of Multireg tx_phy_ctrl2
-  // R[tx_phy_ctrl2_27]: V(False)
+  // Subregister 21 of Multireg tx_phy_clk_start
+  // R[tx_phy_clk_start_21]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_27 (
+  ) u_tx_phy_clk_start_21 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_27_we),
-    .wd     (tx_phy_ctrl2_27_wd),
+    .we     (tx_phy_clk_start_21_we),
+    .wd     (tx_phy_clk_start_21_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2771,26 +2609,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[27].q ),
+    .q      (reg2hw.tx_phy_clk_start[21].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_27_qs)
+    .qs     (tx_phy_clk_start_21_qs)
   );
 
-  // Subregister 28 of Multireg tx_phy_ctrl2
-  // R[tx_phy_ctrl2_28]: V(False)
+  // Subregister 22 of Multireg tx_phy_clk_start
+  // R[tx_phy_clk_start_22]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_28 (
+  ) u_tx_phy_clk_start_22 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_28_we),
-    .wd     (tx_phy_ctrl2_28_wd),
+    .we     (tx_phy_clk_start_22_we),
+    .wd     (tx_phy_clk_start_22_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2798,26 +2636,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[28].q ),
+    .q      (reg2hw.tx_phy_clk_start[22].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_28_qs)
+    .qs     (tx_phy_clk_start_22_qs)
   );
 
-  // Subregister 29 of Multireg tx_phy_ctrl2
-  // R[tx_phy_ctrl2_29]: V(False)
+  // Subregister 23 of Multireg tx_phy_clk_start
+  // R[tx_phy_clk_start_23]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_29 (
+  ) u_tx_phy_clk_start_23 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_29_we),
-    .wd     (tx_phy_ctrl2_29_wd),
+    .we     (tx_phy_clk_start_23_we),
+    .wd     (tx_phy_clk_start_23_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2825,26 +2663,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[29].q ),
+    .q      (reg2hw.tx_phy_clk_start[23].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_29_qs)
+    .qs     (tx_phy_clk_start_23_qs)
   );
 
-  // Subregister 30 of Multireg tx_phy_ctrl2
-  // R[tx_phy_ctrl2_30]: V(False)
+  // Subregister 24 of Multireg tx_phy_clk_start
+  // R[tx_phy_clk_start_24]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_30 (
+  ) u_tx_phy_clk_start_24 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_30_we),
-    .wd     (tx_phy_ctrl2_30_wd),
+    .we     (tx_phy_clk_start_24_we),
+    .wd     (tx_phy_clk_start_24_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2852,26 +2690,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[30].q ),
+    .q      (reg2hw.tx_phy_clk_start[24].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_30_qs)
+    .qs     (tx_phy_clk_start_24_qs)
   );
 
-  // Subregister 31 of Multireg tx_phy_ctrl2
-  // R[tx_phy_ctrl2_31]: V(False)
+  // Subregister 25 of Multireg tx_phy_clk_start
+  // R[tx_phy_clk_start_25]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_31 (
+  ) u_tx_phy_clk_start_25 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_31_we),
-    .wd     (tx_phy_ctrl2_31_wd),
+    .we     (tx_phy_clk_start_25_we),
+    .wd     (tx_phy_clk_start_25_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2879,26 +2717,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[31].q ),
+    .q      (reg2hw.tx_phy_clk_start[25].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_31_qs)
+    .qs     (tx_phy_clk_start_25_qs)
   );
 
-  // Subregister 32 of Multireg tx_phy_ctrl2
-  // R[tx_phy_ctrl2_32]: V(False)
+  // Subregister 26 of Multireg tx_phy_clk_start
+  // R[tx_phy_clk_start_26]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_32 (
+  ) u_tx_phy_clk_start_26 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_32_we),
-    .wd     (tx_phy_ctrl2_32_wd),
+    .we     (tx_phy_clk_start_26_we),
+    .wd     (tx_phy_clk_start_26_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2906,26 +2744,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[32].q ),
+    .q      (reg2hw.tx_phy_clk_start[26].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_32_qs)
+    .qs     (tx_phy_clk_start_26_qs)
   );
 
-  // Subregister 33 of Multireg tx_phy_ctrl2
-  // R[tx_phy_ctrl2_33]: V(False)
+  // Subregister 27 of Multireg tx_phy_clk_start
+  // R[tx_phy_clk_start_27]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_33 (
+  ) u_tx_phy_clk_start_27 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_33_we),
-    .wd     (tx_phy_ctrl2_33_wd),
+    .we     (tx_phy_clk_start_27_we),
+    .wd     (tx_phy_clk_start_27_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2933,26 +2771,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[33].q ),
+    .q      (reg2hw.tx_phy_clk_start[27].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_33_qs)
+    .qs     (tx_phy_clk_start_27_qs)
   );
 
-  // Subregister 34 of Multireg tx_phy_ctrl2
-  // R[tx_phy_ctrl2_34]: V(False)
+  // Subregister 28 of Multireg tx_phy_clk_start
+  // R[tx_phy_clk_start_28]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_34 (
+  ) u_tx_phy_clk_start_28 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_34_we),
-    .wd     (tx_phy_ctrl2_34_wd),
+    .we     (tx_phy_clk_start_28_we),
+    .wd     (tx_phy_clk_start_28_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2960,26 +2798,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[34].q ),
+    .q      (reg2hw.tx_phy_clk_start[28].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_34_qs)
+    .qs     (tx_phy_clk_start_28_qs)
   );
 
-  // Subregister 35 of Multireg tx_phy_ctrl2
-  // R[tx_phy_ctrl2_35]: V(False)
+  // Subregister 29 of Multireg tx_phy_clk_start
+  // R[tx_phy_clk_start_29]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_35 (
+  ) u_tx_phy_clk_start_29 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_35_we),
-    .wd     (tx_phy_ctrl2_35_wd),
+    .we     (tx_phy_clk_start_29_we),
+    .wd     (tx_phy_clk_start_29_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2987,26 +2825,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[35].q ),
+    .q      (reg2hw.tx_phy_clk_start[29].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_35_qs)
+    .qs     (tx_phy_clk_start_29_qs)
   );
 
-  // Subregister 36 of Multireg tx_phy_ctrl2
-  // R[tx_phy_ctrl2_36]: V(False)
+  // Subregister 30 of Multireg tx_phy_clk_start
+  // R[tx_phy_clk_start_30]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_36 (
+  ) u_tx_phy_clk_start_30 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_36_we),
-    .wd     (tx_phy_ctrl2_36_wd),
+    .we     (tx_phy_clk_start_30_we),
+    .wd     (tx_phy_clk_start_30_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3014,26 +2852,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[36].q ),
+    .q      (reg2hw.tx_phy_clk_start[30].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_36_qs)
+    .qs     (tx_phy_clk_start_30_qs)
   );
 
-  // Subregister 37 of Multireg tx_phy_ctrl2
-  // R[tx_phy_ctrl2_37]: V(False)
+  // Subregister 31 of Multireg tx_phy_clk_start
+  // R[tx_phy_clk_start_31]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_37 (
+  ) u_tx_phy_clk_start_31 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_37_we),
-    .wd     (tx_phy_ctrl2_37_wd),
+    .we     (tx_phy_clk_start_31_we),
+    .wd     (tx_phy_clk_start_31_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3041,28 +2879,190 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[37].q ),
+    .q      (reg2hw.tx_phy_clk_start[31].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_37_qs)
+    .qs     (tx_phy_clk_start_31_qs)
+  );
+
+  // Subregister 32 of Multireg tx_phy_clk_start
+  // R[tx_phy_clk_start_32]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h2)
+  ) u_tx_phy_clk_start_32 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_clk_start_32_we),
+    .wd     (tx_phy_clk_start_32_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_clk_start[32].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_clk_start_32_qs)
+  );
+
+  // Subregister 33 of Multireg tx_phy_clk_start
+  // R[tx_phy_clk_start_33]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h2)
+  ) u_tx_phy_clk_start_33 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_clk_start_33_we),
+    .wd     (tx_phy_clk_start_33_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_clk_start[33].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_clk_start_33_qs)
+  );
+
+  // Subregister 34 of Multireg tx_phy_clk_start
+  // R[tx_phy_clk_start_34]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h2)
+  ) u_tx_phy_clk_start_34 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_clk_start_34_we),
+    .wd     (tx_phy_clk_start_34_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_clk_start[34].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_clk_start_34_qs)
+  );
+
+  // Subregister 35 of Multireg tx_phy_clk_start
+  // R[tx_phy_clk_start_35]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h2)
+  ) u_tx_phy_clk_start_35 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_clk_start_35_we),
+    .wd     (tx_phy_clk_start_35_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_clk_start[35].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_clk_start_35_qs)
+  );
+
+  // Subregister 36 of Multireg tx_phy_clk_start
+  // R[tx_phy_clk_start_36]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h2)
+  ) u_tx_phy_clk_start_36 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_clk_start_36_we),
+    .wd     (tx_phy_clk_start_36_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_clk_start[36].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_clk_start_36_qs)
+  );
+
+  // Subregister 37 of Multireg tx_phy_clk_start
+  // R[tx_phy_clk_start_37]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h2)
+  ) u_tx_phy_clk_start_37 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_clk_start_37_we),
+    .wd     (tx_phy_clk_start_37_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_clk_start[37].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_clk_start_37_qs)
   );
 
 
 
-  // Subregister 0 of Multireg tx_phy_ctrl3
-  // R[tx_phy_ctrl3_0]: V(False)
+  // Subregister 0 of Multireg tx_phy_clk_end
+  // R[tx_phy_clk_end_0]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl3_0 (
+  ) u_tx_phy_clk_end_0 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl3_0_we),
-    .wd     (tx_phy_ctrl3_0_wd),
+    .we     (tx_phy_clk_end_0_we),
+    .wd     (tx_phy_clk_end_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3070,26 +3070,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl3[0].q ),
+    .q      (reg2hw.tx_phy_clk_end[0].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl3_0_qs)
+    .qs     (tx_phy_clk_end_0_qs)
   );
 
-  // Subregister 1 of Multireg tx_phy_ctrl3
-  // R[tx_phy_ctrl3_1]: V(False)
+  // Subregister 1 of Multireg tx_phy_clk_end
+  // R[tx_phy_clk_end_1]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl3_1 (
+  ) u_tx_phy_clk_end_1 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl3_1_we),
-    .wd     (tx_phy_ctrl3_1_wd),
+    .we     (tx_phy_clk_end_1_we),
+    .wd     (tx_phy_clk_end_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3097,26 +3097,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl3[1].q ),
+    .q      (reg2hw.tx_phy_clk_end[1].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl3_1_qs)
+    .qs     (tx_phy_clk_end_1_qs)
   );
 
-  // Subregister 2 of Multireg tx_phy_ctrl3
-  // R[tx_phy_ctrl3_2]: V(False)
+  // Subregister 2 of Multireg tx_phy_clk_end
+  // R[tx_phy_clk_end_2]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl3_2 (
+  ) u_tx_phy_clk_end_2 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl3_2_we),
-    .wd     (tx_phy_ctrl3_2_wd),
+    .we     (tx_phy_clk_end_2_we),
+    .wd     (tx_phy_clk_end_2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3124,26 +3124,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl3[2].q ),
+    .q      (reg2hw.tx_phy_clk_end[2].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl3_2_qs)
+    .qs     (tx_phy_clk_end_2_qs)
   );
 
-  // Subregister 3 of Multireg tx_phy_ctrl3
-  // R[tx_phy_ctrl3_3]: V(False)
+  // Subregister 3 of Multireg tx_phy_clk_end
+  // R[tx_phy_clk_end_3]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl3_3 (
+  ) u_tx_phy_clk_end_3 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl3_3_we),
-    .wd     (tx_phy_ctrl3_3_wd),
+    .we     (tx_phy_clk_end_3_we),
+    .wd     (tx_phy_clk_end_3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3151,26 +3151,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl3[3].q ),
+    .q      (reg2hw.tx_phy_clk_end[3].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl3_3_qs)
+    .qs     (tx_phy_clk_end_3_qs)
   );
 
-  // Subregister 4 of Multireg tx_phy_ctrl3
-  // R[tx_phy_ctrl3_4]: V(False)
+  // Subregister 4 of Multireg tx_phy_clk_end
+  // R[tx_phy_clk_end_4]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl3_4 (
+  ) u_tx_phy_clk_end_4 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl3_4_we),
-    .wd     (tx_phy_ctrl3_4_wd),
+    .we     (tx_phy_clk_end_4_we),
+    .wd     (tx_phy_clk_end_4_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3178,26 +3178,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl3[4].q ),
+    .q      (reg2hw.tx_phy_clk_end[4].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl3_4_qs)
+    .qs     (tx_phy_clk_end_4_qs)
   );
 
-  // Subregister 5 of Multireg tx_phy_ctrl3
-  // R[tx_phy_ctrl3_5]: V(False)
+  // Subregister 5 of Multireg tx_phy_clk_end
+  // R[tx_phy_clk_end_5]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl3_5 (
+  ) u_tx_phy_clk_end_5 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl3_5_we),
-    .wd     (tx_phy_ctrl3_5_wd),
+    .we     (tx_phy_clk_end_5_we),
+    .wd     (tx_phy_clk_end_5_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3205,26 +3205,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl3[5].q ),
+    .q      (reg2hw.tx_phy_clk_end[5].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl3_5_qs)
+    .qs     (tx_phy_clk_end_5_qs)
   );
 
-  // Subregister 6 of Multireg tx_phy_ctrl3
-  // R[tx_phy_ctrl3_6]: V(False)
+  // Subregister 6 of Multireg tx_phy_clk_end
+  // R[tx_phy_clk_end_6]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl3_6 (
+  ) u_tx_phy_clk_end_6 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl3_6_we),
-    .wd     (tx_phy_ctrl3_6_wd),
+    .we     (tx_phy_clk_end_6_we),
+    .wd     (tx_phy_clk_end_6_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3232,26 +3232,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl3[6].q ),
+    .q      (reg2hw.tx_phy_clk_end[6].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl3_6_qs)
+    .qs     (tx_phy_clk_end_6_qs)
   );
 
-  // Subregister 7 of Multireg tx_phy_ctrl3
-  // R[tx_phy_ctrl3_7]: V(False)
+  // Subregister 7 of Multireg tx_phy_clk_end
+  // R[tx_phy_clk_end_7]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl3_7 (
+  ) u_tx_phy_clk_end_7 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl3_7_we),
-    .wd     (tx_phy_ctrl3_7_wd),
+    .we     (tx_phy_clk_end_7_we),
+    .wd     (tx_phy_clk_end_7_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3259,26 +3259,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl3[7].q ),
+    .q      (reg2hw.tx_phy_clk_end[7].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl3_7_qs)
+    .qs     (tx_phy_clk_end_7_qs)
   );
 
-  // Subregister 8 of Multireg tx_phy_ctrl3
-  // R[tx_phy_ctrl3_8]: V(False)
+  // Subregister 8 of Multireg tx_phy_clk_end
+  // R[tx_phy_clk_end_8]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl3_8 (
+  ) u_tx_phy_clk_end_8 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl3_8_we),
-    .wd     (tx_phy_ctrl3_8_wd),
+    .we     (tx_phy_clk_end_8_we),
+    .wd     (tx_phy_clk_end_8_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3286,26 +3286,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl3[8].q ),
+    .q      (reg2hw.tx_phy_clk_end[8].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl3_8_qs)
+    .qs     (tx_phy_clk_end_8_qs)
   );
 
-  // Subregister 9 of Multireg tx_phy_ctrl3
-  // R[tx_phy_ctrl3_9]: V(False)
+  // Subregister 9 of Multireg tx_phy_clk_end
+  // R[tx_phy_clk_end_9]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl3_9 (
+  ) u_tx_phy_clk_end_9 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl3_9_we),
-    .wd     (tx_phy_ctrl3_9_wd),
+    .we     (tx_phy_clk_end_9_we),
+    .wd     (tx_phy_clk_end_9_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3313,26 +3313,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl3[9].q ),
+    .q      (reg2hw.tx_phy_clk_end[9].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl3_9_qs)
+    .qs     (tx_phy_clk_end_9_qs)
   );
 
-  // Subregister 10 of Multireg tx_phy_ctrl3
-  // R[tx_phy_ctrl3_10]: V(False)
+  // Subregister 10 of Multireg tx_phy_clk_end
+  // R[tx_phy_clk_end_10]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl3_10 (
+  ) u_tx_phy_clk_end_10 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl3_10_we),
-    .wd     (tx_phy_ctrl3_10_wd),
+    .we     (tx_phy_clk_end_10_we),
+    .wd     (tx_phy_clk_end_10_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3340,26 +3340,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl3[10].q ),
+    .q      (reg2hw.tx_phy_clk_end[10].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl3_10_qs)
+    .qs     (tx_phy_clk_end_10_qs)
   );
 
-  // Subregister 11 of Multireg tx_phy_ctrl3
-  // R[tx_phy_ctrl3_11]: V(False)
+  // Subregister 11 of Multireg tx_phy_clk_end
+  // R[tx_phy_clk_end_11]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl3_11 (
+  ) u_tx_phy_clk_end_11 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl3_11_we),
-    .wd     (tx_phy_ctrl3_11_wd),
+    .we     (tx_phy_clk_end_11_we),
+    .wd     (tx_phy_clk_end_11_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3367,26 +3367,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl3[11].q ),
+    .q      (reg2hw.tx_phy_clk_end[11].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl3_11_qs)
+    .qs     (tx_phy_clk_end_11_qs)
   );
 
-  // Subregister 12 of Multireg tx_phy_ctrl3
-  // R[tx_phy_ctrl3_12]: V(False)
+  // Subregister 12 of Multireg tx_phy_clk_end
+  // R[tx_phy_clk_end_12]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl3_12 (
+  ) u_tx_phy_clk_end_12 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl3_12_we),
-    .wd     (tx_phy_ctrl3_12_wd),
+    .we     (tx_phy_clk_end_12_we),
+    .wd     (tx_phy_clk_end_12_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3394,26 +3394,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl3[12].q ),
+    .q      (reg2hw.tx_phy_clk_end[12].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl3_12_qs)
+    .qs     (tx_phy_clk_end_12_qs)
   );
 
-  // Subregister 13 of Multireg tx_phy_ctrl3
-  // R[tx_phy_ctrl3_13]: V(False)
+  // Subregister 13 of Multireg tx_phy_clk_end
+  // R[tx_phy_clk_end_13]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl3_13 (
+  ) u_tx_phy_clk_end_13 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl3_13_we),
-    .wd     (tx_phy_ctrl3_13_wd),
+    .we     (tx_phy_clk_end_13_we),
+    .wd     (tx_phy_clk_end_13_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3421,26 +3421,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl3[13].q ),
+    .q      (reg2hw.tx_phy_clk_end[13].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl3_13_qs)
+    .qs     (tx_phy_clk_end_13_qs)
   );
 
-  // Subregister 14 of Multireg tx_phy_ctrl3
-  // R[tx_phy_ctrl3_14]: V(False)
+  // Subregister 14 of Multireg tx_phy_clk_end
+  // R[tx_phy_clk_end_14]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl3_14 (
+  ) u_tx_phy_clk_end_14 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl3_14_we),
-    .wd     (tx_phy_ctrl3_14_wd),
+    .we     (tx_phy_clk_end_14_we),
+    .wd     (tx_phy_clk_end_14_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3448,26 +3448,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl3[14].q ),
+    .q      (reg2hw.tx_phy_clk_end[14].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl3_14_qs)
+    .qs     (tx_phy_clk_end_14_qs)
   );
 
-  // Subregister 15 of Multireg tx_phy_ctrl3
-  // R[tx_phy_ctrl3_15]: V(False)
+  // Subregister 15 of Multireg tx_phy_clk_end
+  // R[tx_phy_clk_end_15]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl3_15 (
+  ) u_tx_phy_clk_end_15 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl3_15_we),
-    .wd     (tx_phy_ctrl3_15_wd),
+    .we     (tx_phy_clk_end_15_we),
+    .wd     (tx_phy_clk_end_15_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3475,26 +3475,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl3[15].q ),
+    .q      (reg2hw.tx_phy_clk_end[15].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl3_15_qs)
+    .qs     (tx_phy_clk_end_15_qs)
   );
 
-  // Subregister 16 of Multireg tx_phy_ctrl3
-  // R[tx_phy_ctrl3_16]: V(False)
+  // Subregister 16 of Multireg tx_phy_clk_end
+  // R[tx_phy_clk_end_16]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl3_16 (
+  ) u_tx_phy_clk_end_16 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl3_16_we),
-    .wd     (tx_phy_ctrl3_16_wd),
+    .we     (tx_phy_clk_end_16_we),
+    .wd     (tx_phy_clk_end_16_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3502,26 +3502,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl3[16].q ),
+    .q      (reg2hw.tx_phy_clk_end[16].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl3_16_qs)
+    .qs     (tx_phy_clk_end_16_qs)
   );
 
-  // Subregister 17 of Multireg tx_phy_ctrl3
-  // R[tx_phy_ctrl3_17]: V(False)
+  // Subregister 17 of Multireg tx_phy_clk_end
+  // R[tx_phy_clk_end_17]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl3_17 (
+  ) u_tx_phy_clk_end_17 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl3_17_we),
-    .wd     (tx_phy_ctrl3_17_wd),
+    .we     (tx_phy_clk_end_17_we),
+    .wd     (tx_phy_clk_end_17_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3529,26 +3529,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl3[17].q ),
+    .q      (reg2hw.tx_phy_clk_end[17].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl3_17_qs)
+    .qs     (tx_phy_clk_end_17_qs)
   );
 
-  // Subregister 18 of Multireg tx_phy_ctrl3
-  // R[tx_phy_ctrl3_18]: V(False)
+  // Subregister 18 of Multireg tx_phy_clk_end
+  // R[tx_phy_clk_end_18]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl3_18 (
+  ) u_tx_phy_clk_end_18 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl3_18_we),
-    .wd     (tx_phy_ctrl3_18_wd),
+    .we     (tx_phy_clk_end_18_we),
+    .wd     (tx_phy_clk_end_18_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3556,26 +3556,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl3[18].q ),
+    .q      (reg2hw.tx_phy_clk_end[18].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl3_18_qs)
+    .qs     (tx_phy_clk_end_18_qs)
   );
 
-  // Subregister 19 of Multireg tx_phy_ctrl3
-  // R[tx_phy_ctrl3_19]: V(False)
+  // Subregister 19 of Multireg tx_phy_clk_end
+  // R[tx_phy_clk_end_19]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl3_19 (
+  ) u_tx_phy_clk_end_19 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl3_19_we),
-    .wd     (tx_phy_ctrl3_19_wd),
+    .we     (tx_phy_clk_end_19_we),
+    .wd     (tx_phy_clk_end_19_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3583,26 +3583,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl3[19].q ),
+    .q      (reg2hw.tx_phy_clk_end[19].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl3_19_qs)
+    .qs     (tx_phy_clk_end_19_qs)
   );
 
-  // Subregister 20 of Multireg tx_phy_ctrl3
-  // R[tx_phy_ctrl3_20]: V(False)
+  // Subregister 20 of Multireg tx_phy_clk_end
+  // R[tx_phy_clk_end_20]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl3_20 (
+  ) u_tx_phy_clk_end_20 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl3_20_we),
-    .wd     (tx_phy_ctrl3_20_wd),
+    .we     (tx_phy_clk_end_20_we),
+    .wd     (tx_phy_clk_end_20_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3610,26 +3610,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl3[20].q ),
+    .q      (reg2hw.tx_phy_clk_end[20].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl3_20_qs)
+    .qs     (tx_phy_clk_end_20_qs)
   );
 
-  // Subregister 21 of Multireg tx_phy_ctrl3
-  // R[tx_phy_ctrl3_21]: V(False)
+  // Subregister 21 of Multireg tx_phy_clk_end
+  // R[tx_phy_clk_end_21]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl3_21 (
+  ) u_tx_phy_clk_end_21 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl3_21_we),
-    .wd     (tx_phy_ctrl3_21_wd),
+    .we     (tx_phy_clk_end_21_we),
+    .wd     (tx_phy_clk_end_21_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3637,26 +3637,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl3[21].q ),
+    .q      (reg2hw.tx_phy_clk_end[21].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl3_21_qs)
+    .qs     (tx_phy_clk_end_21_qs)
   );
 
-  // Subregister 22 of Multireg tx_phy_ctrl3
-  // R[tx_phy_ctrl3_22]: V(False)
+  // Subregister 22 of Multireg tx_phy_clk_end
+  // R[tx_phy_clk_end_22]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl3_22 (
+  ) u_tx_phy_clk_end_22 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl3_22_we),
-    .wd     (tx_phy_ctrl3_22_wd),
+    .we     (tx_phy_clk_end_22_we),
+    .wd     (tx_phy_clk_end_22_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3664,26 +3664,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl3[22].q ),
+    .q      (reg2hw.tx_phy_clk_end[22].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl3_22_qs)
+    .qs     (tx_phy_clk_end_22_qs)
   );
 
-  // Subregister 23 of Multireg tx_phy_ctrl3
-  // R[tx_phy_ctrl3_23]: V(False)
+  // Subregister 23 of Multireg tx_phy_clk_end
+  // R[tx_phy_clk_end_23]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl3_23 (
+  ) u_tx_phy_clk_end_23 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl3_23_we),
-    .wd     (tx_phy_ctrl3_23_wd),
+    .we     (tx_phy_clk_end_23_we),
+    .wd     (tx_phy_clk_end_23_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3691,26 +3691,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl3[23].q ),
+    .q      (reg2hw.tx_phy_clk_end[23].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl3_23_qs)
+    .qs     (tx_phy_clk_end_23_qs)
   );
 
-  // Subregister 24 of Multireg tx_phy_ctrl3
-  // R[tx_phy_ctrl3_24]: V(False)
+  // Subregister 24 of Multireg tx_phy_clk_end
+  // R[tx_phy_clk_end_24]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl3_24 (
+  ) u_tx_phy_clk_end_24 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl3_24_we),
-    .wd     (tx_phy_ctrl3_24_wd),
+    .we     (tx_phy_clk_end_24_we),
+    .wd     (tx_phy_clk_end_24_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3718,26 +3718,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl3[24].q ),
+    .q      (reg2hw.tx_phy_clk_end[24].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl3_24_qs)
+    .qs     (tx_phy_clk_end_24_qs)
   );
 
-  // Subregister 25 of Multireg tx_phy_ctrl3
-  // R[tx_phy_ctrl3_25]: V(False)
+  // Subregister 25 of Multireg tx_phy_clk_end
+  // R[tx_phy_clk_end_25]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl3_25 (
+  ) u_tx_phy_clk_end_25 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl3_25_we),
-    .wd     (tx_phy_ctrl3_25_wd),
+    .we     (tx_phy_clk_end_25_we),
+    .wd     (tx_phy_clk_end_25_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3745,26 +3745,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl3[25].q ),
+    .q      (reg2hw.tx_phy_clk_end[25].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl3_25_qs)
+    .qs     (tx_phy_clk_end_25_qs)
   );
 
-  // Subregister 26 of Multireg tx_phy_ctrl3
-  // R[tx_phy_ctrl3_26]: V(False)
+  // Subregister 26 of Multireg tx_phy_clk_end
+  // R[tx_phy_clk_end_26]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl3_26 (
+  ) u_tx_phy_clk_end_26 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl3_26_we),
-    .wd     (tx_phy_ctrl3_26_wd),
+    .we     (tx_phy_clk_end_26_we),
+    .wd     (tx_phy_clk_end_26_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3772,26 +3772,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl3[26].q ),
+    .q      (reg2hw.tx_phy_clk_end[26].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl3_26_qs)
+    .qs     (tx_phy_clk_end_26_qs)
   );
 
-  // Subregister 27 of Multireg tx_phy_ctrl3
-  // R[tx_phy_ctrl3_27]: V(False)
+  // Subregister 27 of Multireg tx_phy_clk_end
+  // R[tx_phy_clk_end_27]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl3_27 (
+  ) u_tx_phy_clk_end_27 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl3_27_we),
-    .wd     (tx_phy_ctrl3_27_wd),
+    .we     (tx_phy_clk_end_27_we),
+    .wd     (tx_phy_clk_end_27_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3799,26 +3799,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl3[27].q ),
+    .q      (reg2hw.tx_phy_clk_end[27].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl3_27_qs)
+    .qs     (tx_phy_clk_end_27_qs)
   );
 
-  // Subregister 28 of Multireg tx_phy_ctrl3
-  // R[tx_phy_ctrl3_28]: V(False)
+  // Subregister 28 of Multireg tx_phy_clk_end
+  // R[tx_phy_clk_end_28]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl3_28 (
+  ) u_tx_phy_clk_end_28 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl3_28_we),
-    .wd     (tx_phy_ctrl3_28_wd),
+    .we     (tx_phy_clk_end_28_we),
+    .wd     (tx_phy_clk_end_28_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3826,26 +3826,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl3[28].q ),
+    .q      (reg2hw.tx_phy_clk_end[28].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl3_28_qs)
+    .qs     (tx_phy_clk_end_28_qs)
   );
 
-  // Subregister 29 of Multireg tx_phy_ctrl3
-  // R[tx_phy_ctrl3_29]: V(False)
+  // Subregister 29 of Multireg tx_phy_clk_end
+  // R[tx_phy_clk_end_29]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl3_29 (
+  ) u_tx_phy_clk_end_29 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl3_29_we),
-    .wd     (tx_phy_ctrl3_29_wd),
+    .we     (tx_phy_clk_end_29_we),
+    .wd     (tx_phy_clk_end_29_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3853,26 +3853,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl3[29].q ),
+    .q      (reg2hw.tx_phy_clk_end[29].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl3_29_qs)
+    .qs     (tx_phy_clk_end_29_qs)
   );
 
-  // Subregister 30 of Multireg tx_phy_ctrl3
-  // R[tx_phy_ctrl3_30]: V(False)
+  // Subregister 30 of Multireg tx_phy_clk_end
+  // R[tx_phy_clk_end_30]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl3_30 (
+  ) u_tx_phy_clk_end_30 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl3_30_we),
-    .wd     (tx_phy_ctrl3_30_wd),
+    .we     (tx_phy_clk_end_30_we),
+    .wd     (tx_phy_clk_end_30_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3880,26 +3880,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl3[30].q ),
+    .q      (reg2hw.tx_phy_clk_end[30].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl3_30_qs)
+    .qs     (tx_phy_clk_end_30_qs)
   );
 
-  // Subregister 31 of Multireg tx_phy_ctrl3
-  // R[tx_phy_ctrl3_31]: V(False)
+  // Subregister 31 of Multireg tx_phy_clk_end
+  // R[tx_phy_clk_end_31]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl3_31 (
+  ) u_tx_phy_clk_end_31 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl3_31_we),
-    .wd     (tx_phy_ctrl3_31_wd),
+    .we     (tx_phy_clk_end_31_we),
+    .wd     (tx_phy_clk_end_31_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3907,26 +3907,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl3[31].q ),
+    .q      (reg2hw.tx_phy_clk_end[31].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl3_31_qs)
+    .qs     (tx_phy_clk_end_31_qs)
   );
 
-  // Subregister 32 of Multireg tx_phy_ctrl3
-  // R[tx_phy_ctrl3_32]: V(False)
+  // Subregister 32 of Multireg tx_phy_clk_end
+  // R[tx_phy_clk_end_32]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl3_32 (
+  ) u_tx_phy_clk_end_32 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl3_32_we),
-    .wd     (tx_phy_ctrl3_32_wd),
+    .we     (tx_phy_clk_end_32_we),
+    .wd     (tx_phy_clk_end_32_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3934,26 +3934,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl3[32].q ),
+    .q      (reg2hw.tx_phy_clk_end[32].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl3_32_qs)
+    .qs     (tx_phy_clk_end_32_qs)
   );
 
-  // Subregister 33 of Multireg tx_phy_ctrl3
-  // R[tx_phy_ctrl3_33]: V(False)
+  // Subregister 33 of Multireg tx_phy_clk_end
+  // R[tx_phy_clk_end_33]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl3_33 (
+  ) u_tx_phy_clk_end_33 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl3_33_we),
-    .wd     (tx_phy_ctrl3_33_wd),
+    .we     (tx_phy_clk_end_33_we),
+    .wd     (tx_phy_clk_end_33_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3961,26 +3961,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl3[33].q ),
+    .q      (reg2hw.tx_phy_clk_end[33].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl3_33_qs)
+    .qs     (tx_phy_clk_end_33_qs)
   );
 
-  // Subregister 34 of Multireg tx_phy_ctrl3
-  // R[tx_phy_ctrl3_34]: V(False)
+  // Subregister 34 of Multireg tx_phy_clk_end
+  // R[tx_phy_clk_end_34]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl3_34 (
+  ) u_tx_phy_clk_end_34 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl3_34_we),
-    .wd     (tx_phy_ctrl3_34_wd),
+    .we     (tx_phy_clk_end_34_we),
+    .wd     (tx_phy_clk_end_34_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3988,26 +3988,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl3[34].q ),
+    .q      (reg2hw.tx_phy_clk_end[34].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl3_34_qs)
+    .qs     (tx_phy_clk_end_34_qs)
   );
 
-  // Subregister 35 of Multireg tx_phy_ctrl3
-  // R[tx_phy_ctrl3_35]: V(False)
+  // Subregister 35 of Multireg tx_phy_clk_end
+  // R[tx_phy_clk_end_35]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl3_35 (
+  ) u_tx_phy_clk_end_35 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl3_35_we),
-    .wd     (tx_phy_ctrl3_35_wd),
+    .we     (tx_phy_clk_end_35_we),
+    .wd     (tx_phy_clk_end_35_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4015,26 +4015,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl3[35].q ),
+    .q      (reg2hw.tx_phy_clk_end[35].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl3_35_qs)
+    .qs     (tx_phy_clk_end_35_qs)
   );
 
-  // Subregister 36 of Multireg tx_phy_ctrl3
-  // R[tx_phy_ctrl3_36]: V(False)
+  // Subregister 36 of Multireg tx_phy_clk_end
+  // R[tx_phy_clk_end_36]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl3_36 (
+  ) u_tx_phy_clk_end_36 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl3_36_we),
-    .wd     (tx_phy_ctrl3_36_wd),
+    .we     (tx_phy_clk_end_36_we),
+    .wd     (tx_phy_clk_end_36_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4042,26 +4042,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl3[36].q ),
+    .q      (reg2hw.tx_phy_clk_end[36].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl3_36_qs)
+    .qs     (tx_phy_clk_end_36_qs)
   );
 
-  // Subregister 37 of Multireg tx_phy_ctrl3
-  // R[tx_phy_ctrl3_37]: V(False)
+  // Subregister 37 of Multireg tx_phy_clk_end
+  // R[tx_phy_clk_end_37]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl3_37 (
+  ) u_tx_phy_clk_end_37 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl3_37_we),
-    .wd     (tx_phy_ctrl3_37_wd),
+    .we     (tx_phy_clk_end_37_we),
+    .wd     (tx_phy_clk_end_37_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4069,10 +4069,10 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl3[37].q ),
+    .q      (reg2hw.tx_phy_clk_end[37].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl3_37_qs)
+    .qs     (tx_phy_clk_end_37_qs)
   );
 
 
@@ -8029,120 +8029,120 @@ module serial_link_reg_top #(
     addr_hit = '0;
     addr_hit[  0] = (reg_addr == SERIAL_LINK_CTRL_OFFSET);
     addr_hit[  1] = (reg_addr == SERIAL_LINK_ISOLATED_OFFSET);
-    addr_hit[  2] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_0_OFFSET);
-    addr_hit[  3] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_1_OFFSET);
-    addr_hit[  4] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_2_OFFSET);
-    addr_hit[  5] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_3_OFFSET);
-    addr_hit[  6] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_4_OFFSET);
-    addr_hit[  7] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_5_OFFSET);
-    addr_hit[  8] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_6_OFFSET);
-    addr_hit[  9] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_7_OFFSET);
-    addr_hit[ 10] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_8_OFFSET);
-    addr_hit[ 11] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_9_OFFSET);
-    addr_hit[ 12] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_10_OFFSET);
-    addr_hit[ 13] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_11_OFFSET);
-    addr_hit[ 14] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_12_OFFSET);
-    addr_hit[ 15] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_13_OFFSET);
-    addr_hit[ 16] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_14_OFFSET);
-    addr_hit[ 17] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_15_OFFSET);
-    addr_hit[ 18] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_16_OFFSET);
-    addr_hit[ 19] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_17_OFFSET);
-    addr_hit[ 20] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_18_OFFSET);
-    addr_hit[ 21] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_19_OFFSET);
-    addr_hit[ 22] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_20_OFFSET);
-    addr_hit[ 23] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_21_OFFSET);
-    addr_hit[ 24] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_22_OFFSET);
-    addr_hit[ 25] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_23_OFFSET);
-    addr_hit[ 26] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_24_OFFSET);
-    addr_hit[ 27] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_25_OFFSET);
-    addr_hit[ 28] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_26_OFFSET);
-    addr_hit[ 29] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_27_OFFSET);
-    addr_hit[ 30] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_28_OFFSET);
-    addr_hit[ 31] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_29_OFFSET);
-    addr_hit[ 32] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_30_OFFSET);
-    addr_hit[ 33] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_31_OFFSET);
-    addr_hit[ 34] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_32_OFFSET);
-    addr_hit[ 35] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_33_OFFSET);
-    addr_hit[ 36] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_34_OFFSET);
-    addr_hit[ 37] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_35_OFFSET);
-    addr_hit[ 38] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_36_OFFSET);
-    addr_hit[ 39] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_37_OFFSET);
-    addr_hit[ 40] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_0_OFFSET);
-    addr_hit[ 41] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_1_OFFSET);
-    addr_hit[ 42] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_2_OFFSET);
-    addr_hit[ 43] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_3_OFFSET);
-    addr_hit[ 44] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_4_OFFSET);
-    addr_hit[ 45] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_5_OFFSET);
-    addr_hit[ 46] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_6_OFFSET);
-    addr_hit[ 47] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_7_OFFSET);
-    addr_hit[ 48] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_8_OFFSET);
-    addr_hit[ 49] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_9_OFFSET);
-    addr_hit[ 50] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_10_OFFSET);
-    addr_hit[ 51] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_11_OFFSET);
-    addr_hit[ 52] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_12_OFFSET);
-    addr_hit[ 53] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_13_OFFSET);
-    addr_hit[ 54] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_14_OFFSET);
-    addr_hit[ 55] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_15_OFFSET);
-    addr_hit[ 56] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_16_OFFSET);
-    addr_hit[ 57] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_17_OFFSET);
-    addr_hit[ 58] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_18_OFFSET);
-    addr_hit[ 59] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_19_OFFSET);
-    addr_hit[ 60] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_20_OFFSET);
-    addr_hit[ 61] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_21_OFFSET);
-    addr_hit[ 62] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_22_OFFSET);
-    addr_hit[ 63] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_23_OFFSET);
-    addr_hit[ 64] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_24_OFFSET);
-    addr_hit[ 65] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_25_OFFSET);
-    addr_hit[ 66] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_26_OFFSET);
-    addr_hit[ 67] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_27_OFFSET);
-    addr_hit[ 68] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_28_OFFSET);
-    addr_hit[ 69] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_29_OFFSET);
-    addr_hit[ 70] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_30_OFFSET);
-    addr_hit[ 71] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_31_OFFSET);
-    addr_hit[ 72] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_32_OFFSET);
-    addr_hit[ 73] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_33_OFFSET);
-    addr_hit[ 74] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_34_OFFSET);
-    addr_hit[ 75] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_35_OFFSET);
-    addr_hit[ 76] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_36_OFFSET);
-    addr_hit[ 77] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_37_OFFSET);
-    addr_hit[ 78] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_0_OFFSET);
-    addr_hit[ 79] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_1_OFFSET);
-    addr_hit[ 80] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_2_OFFSET);
-    addr_hit[ 81] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_3_OFFSET);
-    addr_hit[ 82] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_4_OFFSET);
-    addr_hit[ 83] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_5_OFFSET);
-    addr_hit[ 84] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_6_OFFSET);
-    addr_hit[ 85] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_7_OFFSET);
-    addr_hit[ 86] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_8_OFFSET);
-    addr_hit[ 87] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_9_OFFSET);
-    addr_hit[ 88] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_10_OFFSET);
-    addr_hit[ 89] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_11_OFFSET);
-    addr_hit[ 90] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_12_OFFSET);
-    addr_hit[ 91] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_13_OFFSET);
-    addr_hit[ 92] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_14_OFFSET);
-    addr_hit[ 93] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_15_OFFSET);
-    addr_hit[ 94] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_16_OFFSET);
-    addr_hit[ 95] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_17_OFFSET);
-    addr_hit[ 96] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_18_OFFSET);
-    addr_hit[ 97] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_19_OFFSET);
-    addr_hit[ 98] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_20_OFFSET);
-    addr_hit[ 99] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_21_OFFSET);
-    addr_hit[100] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_22_OFFSET);
-    addr_hit[101] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_23_OFFSET);
-    addr_hit[102] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_24_OFFSET);
-    addr_hit[103] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_25_OFFSET);
-    addr_hit[104] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_26_OFFSET);
-    addr_hit[105] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_27_OFFSET);
-    addr_hit[106] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_28_OFFSET);
-    addr_hit[107] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_29_OFFSET);
-    addr_hit[108] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_30_OFFSET);
-    addr_hit[109] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_31_OFFSET);
-    addr_hit[110] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_32_OFFSET);
-    addr_hit[111] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_33_OFFSET);
-    addr_hit[112] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_34_OFFSET);
-    addr_hit[113] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_35_OFFSET);
-    addr_hit[114] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_36_OFFSET);
-    addr_hit[115] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_37_OFFSET);
+    addr_hit[  2] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_DIV_0_OFFSET);
+    addr_hit[  3] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_DIV_1_OFFSET);
+    addr_hit[  4] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_DIV_2_OFFSET);
+    addr_hit[  5] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_DIV_3_OFFSET);
+    addr_hit[  6] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_DIV_4_OFFSET);
+    addr_hit[  7] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_DIV_5_OFFSET);
+    addr_hit[  8] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_DIV_6_OFFSET);
+    addr_hit[  9] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_DIV_7_OFFSET);
+    addr_hit[ 10] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_DIV_8_OFFSET);
+    addr_hit[ 11] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_DIV_9_OFFSET);
+    addr_hit[ 12] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_DIV_10_OFFSET);
+    addr_hit[ 13] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_DIV_11_OFFSET);
+    addr_hit[ 14] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_DIV_12_OFFSET);
+    addr_hit[ 15] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_DIV_13_OFFSET);
+    addr_hit[ 16] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_DIV_14_OFFSET);
+    addr_hit[ 17] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_DIV_15_OFFSET);
+    addr_hit[ 18] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_DIV_16_OFFSET);
+    addr_hit[ 19] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_DIV_17_OFFSET);
+    addr_hit[ 20] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_DIV_18_OFFSET);
+    addr_hit[ 21] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_DIV_19_OFFSET);
+    addr_hit[ 22] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_DIV_20_OFFSET);
+    addr_hit[ 23] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_DIV_21_OFFSET);
+    addr_hit[ 24] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_DIV_22_OFFSET);
+    addr_hit[ 25] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_DIV_23_OFFSET);
+    addr_hit[ 26] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_DIV_24_OFFSET);
+    addr_hit[ 27] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_DIV_25_OFFSET);
+    addr_hit[ 28] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_DIV_26_OFFSET);
+    addr_hit[ 29] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_DIV_27_OFFSET);
+    addr_hit[ 30] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_DIV_28_OFFSET);
+    addr_hit[ 31] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_DIV_29_OFFSET);
+    addr_hit[ 32] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_DIV_30_OFFSET);
+    addr_hit[ 33] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_DIV_31_OFFSET);
+    addr_hit[ 34] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_DIV_32_OFFSET);
+    addr_hit[ 35] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_DIV_33_OFFSET);
+    addr_hit[ 36] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_DIV_34_OFFSET);
+    addr_hit[ 37] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_DIV_35_OFFSET);
+    addr_hit[ 38] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_DIV_36_OFFSET);
+    addr_hit[ 39] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_DIV_37_OFFSET);
+    addr_hit[ 40] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_START_0_OFFSET);
+    addr_hit[ 41] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_START_1_OFFSET);
+    addr_hit[ 42] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_START_2_OFFSET);
+    addr_hit[ 43] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_START_3_OFFSET);
+    addr_hit[ 44] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_START_4_OFFSET);
+    addr_hit[ 45] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_START_5_OFFSET);
+    addr_hit[ 46] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_START_6_OFFSET);
+    addr_hit[ 47] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_START_7_OFFSET);
+    addr_hit[ 48] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_START_8_OFFSET);
+    addr_hit[ 49] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_START_9_OFFSET);
+    addr_hit[ 50] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_START_10_OFFSET);
+    addr_hit[ 51] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_START_11_OFFSET);
+    addr_hit[ 52] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_START_12_OFFSET);
+    addr_hit[ 53] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_START_13_OFFSET);
+    addr_hit[ 54] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_START_14_OFFSET);
+    addr_hit[ 55] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_START_15_OFFSET);
+    addr_hit[ 56] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_START_16_OFFSET);
+    addr_hit[ 57] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_START_17_OFFSET);
+    addr_hit[ 58] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_START_18_OFFSET);
+    addr_hit[ 59] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_START_19_OFFSET);
+    addr_hit[ 60] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_START_20_OFFSET);
+    addr_hit[ 61] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_START_21_OFFSET);
+    addr_hit[ 62] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_START_22_OFFSET);
+    addr_hit[ 63] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_START_23_OFFSET);
+    addr_hit[ 64] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_START_24_OFFSET);
+    addr_hit[ 65] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_START_25_OFFSET);
+    addr_hit[ 66] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_START_26_OFFSET);
+    addr_hit[ 67] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_START_27_OFFSET);
+    addr_hit[ 68] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_START_28_OFFSET);
+    addr_hit[ 69] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_START_29_OFFSET);
+    addr_hit[ 70] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_START_30_OFFSET);
+    addr_hit[ 71] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_START_31_OFFSET);
+    addr_hit[ 72] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_START_32_OFFSET);
+    addr_hit[ 73] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_START_33_OFFSET);
+    addr_hit[ 74] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_START_34_OFFSET);
+    addr_hit[ 75] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_START_35_OFFSET);
+    addr_hit[ 76] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_START_36_OFFSET);
+    addr_hit[ 77] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_START_37_OFFSET);
+    addr_hit[ 78] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_END_0_OFFSET);
+    addr_hit[ 79] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_END_1_OFFSET);
+    addr_hit[ 80] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_END_2_OFFSET);
+    addr_hit[ 81] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_END_3_OFFSET);
+    addr_hit[ 82] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_END_4_OFFSET);
+    addr_hit[ 83] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_END_5_OFFSET);
+    addr_hit[ 84] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_END_6_OFFSET);
+    addr_hit[ 85] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_END_7_OFFSET);
+    addr_hit[ 86] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_END_8_OFFSET);
+    addr_hit[ 87] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_END_9_OFFSET);
+    addr_hit[ 88] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_END_10_OFFSET);
+    addr_hit[ 89] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_END_11_OFFSET);
+    addr_hit[ 90] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_END_12_OFFSET);
+    addr_hit[ 91] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_END_13_OFFSET);
+    addr_hit[ 92] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_END_14_OFFSET);
+    addr_hit[ 93] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_END_15_OFFSET);
+    addr_hit[ 94] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_END_16_OFFSET);
+    addr_hit[ 95] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_END_17_OFFSET);
+    addr_hit[ 96] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_END_18_OFFSET);
+    addr_hit[ 97] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_END_19_OFFSET);
+    addr_hit[ 98] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_END_20_OFFSET);
+    addr_hit[ 99] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_END_21_OFFSET);
+    addr_hit[100] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_END_22_OFFSET);
+    addr_hit[101] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_END_23_OFFSET);
+    addr_hit[102] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_END_24_OFFSET);
+    addr_hit[103] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_END_25_OFFSET);
+    addr_hit[104] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_END_26_OFFSET);
+    addr_hit[105] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_END_27_OFFSET);
+    addr_hit[106] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_END_28_OFFSET);
+    addr_hit[107] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_END_29_OFFSET);
+    addr_hit[108] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_END_30_OFFSET);
+    addr_hit[109] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_END_31_OFFSET);
+    addr_hit[110] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_END_32_OFFSET);
+    addr_hit[111] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_END_33_OFFSET);
+    addr_hit[112] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_END_34_OFFSET);
+    addr_hit[113] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_END_35_OFFSET);
+    addr_hit[114] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_END_36_OFFSET);
+    addr_hit[115] = (reg_addr == SERIAL_LINK_TX_PHY_CLK_END_37_OFFSET);
     addr_hit[116] = (reg_addr == SERIAL_LINK_RAW_MODE_EN_OFFSET);
     addr_hit[117] = (reg_addr == SERIAL_LINK_RAW_MODE_IN_CH_SEL_OFFSET);
     addr_hit[118] = (reg_addr == SERIAL_LINK_RAW_MODE_IN_DATA_VALID_0_OFFSET);
@@ -8322,347 +8322,347 @@ module serial_link_reg_top #(
 
   assign isolated_axi_out_re = addr_hit[1] & reg_re & !reg_error;
 
-  assign tx_phy_ctrl1_0_we = addr_hit[2] & reg_we & !reg_error;
-  assign tx_phy_ctrl1_0_wd = reg_wdata[10:0];
+  assign tx_phy_clk_div_0_we = addr_hit[2] & reg_we & !reg_error;
+  assign tx_phy_clk_div_0_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl1_1_we = addr_hit[3] & reg_we & !reg_error;
-  assign tx_phy_ctrl1_1_wd = reg_wdata[10:0];
+  assign tx_phy_clk_div_1_we = addr_hit[3] & reg_we & !reg_error;
+  assign tx_phy_clk_div_1_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl1_2_we = addr_hit[4] & reg_we & !reg_error;
-  assign tx_phy_ctrl1_2_wd = reg_wdata[10:0];
+  assign tx_phy_clk_div_2_we = addr_hit[4] & reg_we & !reg_error;
+  assign tx_phy_clk_div_2_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl1_3_we = addr_hit[5] & reg_we & !reg_error;
-  assign tx_phy_ctrl1_3_wd = reg_wdata[10:0];
+  assign tx_phy_clk_div_3_we = addr_hit[5] & reg_we & !reg_error;
+  assign tx_phy_clk_div_3_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl1_4_we = addr_hit[6] & reg_we & !reg_error;
-  assign tx_phy_ctrl1_4_wd = reg_wdata[10:0];
+  assign tx_phy_clk_div_4_we = addr_hit[6] & reg_we & !reg_error;
+  assign tx_phy_clk_div_4_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl1_5_we = addr_hit[7] & reg_we & !reg_error;
-  assign tx_phy_ctrl1_5_wd = reg_wdata[10:0];
+  assign tx_phy_clk_div_5_we = addr_hit[7] & reg_we & !reg_error;
+  assign tx_phy_clk_div_5_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl1_6_we = addr_hit[8] & reg_we & !reg_error;
-  assign tx_phy_ctrl1_6_wd = reg_wdata[10:0];
+  assign tx_phy_clk_div_6_we = addr_hit[8] & reg_we & !reg_error;
+  assign tx_phy_clk_div_6_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl1_7_we = addr_hit[9] & reg_we & !reg_error;
-  assign tx_phy_ctrl1_7_wd = reg_wdata[10:0];
+  assign tx_phy_clk_div_7_we = addr_hit[9] & reg_we & !reg_error;
+  assign tx_phy_clk_div_7_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl1_8_we = addr_hit[10] & reg_we & !reg_error;
-  assign tx_phy_ctrl1_8_wd = reg_wdata[10:0];
+  assign tx_phy_clk_div_8_we = addr_hit[10] & reg_we & !reg_error;
+  assign tx_phy_clk_div_8_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl1_9_we = addr_hit[11] & reg_we & !reg_error;
-  assign tx_phy_ctrl1_9_wd = reg_wdata[10:0];
+  assign tx_phy_clk_div_9_we = addr_hit[11] & reg_we & !reg_error;
+  assign tx_phy_clk_div_9_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl1_10_we = addr_hit[12] & reg_we & !reg_error;
-  assign tx_phy_ctrl1_10_wd = reg_wdata[10:0];
+  assign tx_phy_clk_div_10_we = addr_hit[12] & reg_we & !reg_error;
+  assign tx_phy_clk_div_10_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl1_11_we = addr_hit[13] & reg_we & !reg_error;
-  assign tx_phy_ctrl1_11_wd = reg_wdata[10:0];
+  assign tx_phy_clk_div_11_we = addr_hit[13] & reg_we & !reg_error;
+  assign tx_phy_clk_div_11_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl1_12_we = addr_hit[14] & reg_we & !reg_error;
-  assign tx_phy_ctrl1_12_wd = reg_wdata[10:0];
+  assign tx_phy_clk_div_12_we = addr_hit[14] & reg_we & !reg_error;
+  assign tx_phy_clk_div_12_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl1_13_we = addr_hit[15] & reg_we & !reg_error;
-  assign tx_phy_ctrl1_13_wd = reg_wdata[10:0];
+  assign tx_phy_clk_div_13_we = addr_hit[15] & reg_we & !reg_error;
+  assign tx_phy_clk_div_13_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl1_14_we = addr_hit[16] & reg_we & !reg_error;
-  assign tx_phy_ctrl1_14_wd = reg_wdata[10:0];
+  assign tx_phy_clk_div_14_we = addr_hit[16] & reg_we & !reg_error;
+  assign tx_phy_clk_div_14_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl1_15_we = addr_hit[17] & reg_we & !reg_error;
-  assign tx_phy_ctrl1_15_wd = reg_wdata[10:0];
+  assign tx_phy_clk_div_15_we = addr_hit[17] & reg_we & !reg_error;
+  assign tx_phy_clk_div_15_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl1_16_we = addr_hit[18] & reg_we & !reg_error;
-  assign tx_phy_ctrl1_16_wd = reg_wdata[10:0];
+  assign tx_phy_clk_div_16_we = addr_hit[18] & reg_we & !reg_error;
+  assign tx_phy_clk_div_16_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl1_17_we = addr_hit[19] & reg_we & !reg_error;
-  assign tx_phy_ctrl1_17_wd = reg_wdata[10:0];
+  assign tx_phy_clk_div_17_we = addr_hit[19] & reg_we & !reg_error;
+  assign tx_phy_clk_div_17_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl1_18_we = addr_hit[20] & reg_we & !reg_error;
-  assign tx_phy_ctrl1_18_wd = reg_wdata[10:0];
+  assign tx_phy_clk_div_18_we = addr_hit[20] & reg_we & !reg_error;
+  assign tx_phy_clk_div_18_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl1_19_we = addr_hit[21] & reg_we & !reg_error;
-  assign tx_phy_ctrl1_19_wd = reg_wdata[10:0];
+  assign tx_phy_clk_div_19_we = addr_hit[21] & reg_we & !reg_error;
+  assign tx_phy_clk_div_19_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl1_20_we = addr_hit[22] & reg_we & !reg_error;
-  assign tx_phy_ctrl1_20_wd = reg_wdata[10:0];
+  assign tx_phy_clk_div_20_we = addr_hit[22] & reg_we & !reg_error;
+  assign tx_phy_clk_div_20_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl1_21_we = addr_hit[23] & reg_we & !reg_error;
-  assign tx_phy_ctrl1_21_wd = reg_wdata[10:0];
+  assign tx_phy_clk_div_21_we = addr_hit[23] & reg_we & !reg_error;
+  assign tx_phy_clk_div_21_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl1_22_we = addr_hit[24] & reg_we & !reg_error;
-  assign tx_phy_ctrl1_22_wd = reg_wdata[10:0];
+  assign tx_phy_clk_div_22_we = addr_hit[24] & reg_we & !reg_error;
+  assign tx_phy_clk_div_22_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl1_23_we = addr_hit[25] & reg_we & !reg_error;
-  assign tx_phy_ctrl1_23_wd = reg_wdata[10:0];
+  assign tx_phy_clk_div_23_we = addr_hit[25] & reg_we & !reg_error;
+  assign tx_phy_clk_div_23_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl1_24_we = addr_hit[26] & reg_we & !reg_error;
-  assign tx_phy_ctrl1_24_wd = reg_wdata[10:0];
+  assign tx_phy_clk_div_24_we = addr_hit[26] & reg_we & !reg_error;
+  assign tx_phy_clk_div_24_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl1_25_we = addr_hit[27] & reg_we & !reg_error;
-  assign tx_phy_ctrl1_25_wd = reg_wdata[10:0];
+  assign tx_phy_clk_div_25_we = addr_hit[27] & reg_we & !reg_error;
+  assign tx_phy_clk_div_25_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl1_26_we = addr_hit[28] & reg_we & !reg_error;
-  assign tx_phy_ctrl1_26_wd = reg_wdata[10:0];
+  assign tx_phy_clk_div_26_we = addr_hit[28] & reg_we & !reg_error;
+  assign tx_phy_clk_div_26_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl1_27_we = addr_hit[29] & reg_we & !reg_error;
-  assign tx_phy_ctrl1_27_wd = reg_wdata[10:0];
+  assign tx_phy_clk_div_27_we = addr_hit[29] & reg_we & !reg_error;
+  assign tx_phy_clk_div_27_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl1_28_we = addr_hit[30] & reg_we & !reg_error;
-  assign tx_phy_ctrl1_28_wd = reg_wdata[10:0];
+  assign tx_phy_clk_div_28_we = addr_hit[30] & reg_we & !reg_error;
+  assign tx_phy_clk_div_28_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl1_29_we = addr_hit[31] & reg_we & !reg_error;
-  assign tx_phy_ctrl1_29_wd = reg_wdata[10:0];
+  assign tx_phy_clk_div_29_we = addr_hit[31] & reg_we & !reg_error;
+  assign tx_phy_clk_div_29_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl1_30_we = addr_hit[32] & reg_we & !reg_error;
-  assign tx_phy_ctrl1_30_wd = reg_wdata[10:0];
+  assign tx_phy_clk_div_30_we = addr_hit[32] & reg_we & !reg_error;
+  assign tx_phy_clk_div_30_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl1_31_we = addr_hit[33] & reg_we & !reg_error;
-  assign tx_phy_ctrl1_31_wd = reg_wdata[10:0];
+  assign tx_phy_clk_div_31_we = addr_hit[33] & reg_we & !reg_error;
+  assign tx_phy_clk_div_31_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl1_32_we = addr_hit[34] & reg_we & !reg_error;
-  assign tx_phy_ctrl1_32_wd = reg_wdata[10:0];
+  assign tx_phy_clk_div_32_we = addr_hit[34] & reg_we & !reg_error;
+  assign tx_phy_clk_div_32_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl1_33_we = addr_hit[35] & reg_we & !reg_error;
-  assign tx_phy_ctrl1_33_wd = reg_wdata[10:0];
+  assign tx_phy_clk_div_33_we = addr_hit[35] & reg_we & !reg_error;
+  assign tx_phy_clk_div_33_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl1_34_we = addr_hit[36] & reg_we & !reg_error;
-  assign tx_phy_ctrl1_34_wd = reg_wdata[10:0];
+  assign tx_phy_clk_div_34_we = addr_hit[36] & reg_we & !reg_error;
+  assign tx_phy_clk_div_34_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl1_35_we = addr_hit[37] & reg_we & !reg_error;
-  assign tx_phy_ctrl1_35_wd = reg_wdata[10:0];
+  assign tx_phy_clk_div_35_we = addr_hit[37] & reg_we & !reg_error;
+  assign tx_phy_clk_div_35_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl1_36_we = addr_hit[38] & reg_we & !reg_error;
-  assign tx_phy_ctrl1_36_wd = reg_wdata[10:0];
+  assign tx_phy_clk_div_36_we = addr_hit[38] & reg_we & !reg_error;
+  assign tx_phy_clk_div_36_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl1_37_we = addr_hit[39] & reg_we & !reg_error;
-  assign tx_phy_ctrl1_37_wd = reg_wdata[10:0];
+  assign tx_phy_clk_div_37_we = addr_hit[39] & reg_we & !reg_error;
+  assign tx_phy_clk_div_37_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_0_we = addr_hit[40] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_0_wd = reg_wdata[10:0];
+  assign tx_phy_clk_start_0_we = addr_hit[40] & reg_we & !reg_error;
+  assign tx_phy_clk_start_0_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_1_we = addr_hit[41] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_1_wd = reg_wdata[10:0];
+  assign tx_phy_clk_start_1_we = addr_hit[41] & reg_we & !reg_error;
+  assign tx_phy_clk_start_1_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_2_we = addr_hit[42] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_2_wd = reg_wdata[10:0];
+  assign tx_phy_clk_start_2_we = addr_hit[42] & reg_we & !reg_error;
+  assign tx_phy_clk_start_2_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_3_we = addr_hit[43] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_3_wd = reg_wdata[10:0];
+  assign tx_phy_clk_start_3_we = addr_hit[43] & reg_we & !reg_error;
+  assign tx_phy_clk_start_3_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_4_we = addr_hit[44] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_4_wd = reg_wdata[10:0];
+  assign tx_phy_clk_start_4_we = addr_hit[44] & reg_we & !reg_error;
+  assign tx_phy_clk_start_4_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_5_we = addr_hit[45] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_5_wd = reg_wdata[10:0];
+  assign tx_phy_clk_start_5_we = addr_hit[45] & reg_we & !reg_error;
+  assign tx_phy_clk_start_5_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_6_we = addr_hit[46] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_6_wd = reg_wdata[10:0];
+  assign tx_phy_clk_start_6_we = addr_hit[46] & reg_we & !reg_error;
+  assign tx_phy_clk_start_6_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_7_we = addr_hit[47] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_7_wd = reg_wdata[10:0];
+  assign tx_phy_clk_start_7_we = addr_hit[47] & reg_we & !reg_error;
+  assign tx_phy_clk_start_7_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_8_we = addr_hit[48] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_8_wd = reg_wdata[10:0];
+  assign tx_phy_clk_start_8_we = addr_hit[48] & reg_we & !reg_error;
+  assign tx_phy_clk_start_8_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_9_we = addr_hit[49] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_9_wd = reg_wdata[10:0];
+  assign tx_phy_clk_start_9_we = addr_hit[49] & reg_we & !reg_error;
+  assign tx_phy_clk_start_9_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_10_we = addr_hit[50] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_10_wd = reg_wdata[10:0];
+  assign tx_phy_clk_start_10_we = addr_hit[50] & reg_we & !reg_error;
+  assign tx_phy_clk_start_10_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_11_we = addr_hit[51] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_11_wd = reg_wdata[10:0];
+  assign tx_phy_clk_start_11_we = addr_hit[51] & reg_we & !reg_error;
+  assign tx_phy_clk_start_11_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_12_we = addr_hit[52] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_12_wd = reg_wdata[10:0];
+  assign tx_phy_clk_start_12_we = addr_hit[52] & reg_we & !reg_error;
+  assign tx_phy_clk_start_12_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_13_we = addr_hit[53] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_13_wd = reg_wdata[10:0];
+  assign tx_phy_clk_start_13_we = addr_hit[53] & reg_we & !reg_error;
+  assign tx_phy_clk_start_13_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_14_we = addr_hit[54] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_14_wd = reg_wdata[10:0];
+  assign tx_phy_clk_start_14_we = addr_hit[54] & reg_we & !reg_error;
+  assign tx_phy_clk_start_14_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_15_we = addr_hit[55] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_15_wd = reg_wdata[10:0];
+  assign tx_phy_clk_start_15_we = addr_hit[55] & reg_we & !reg_error;
+  assign tx_phy_clk_start_15_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_16_we = addr_hit[56] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_16_wd = reg_wdata[10:0];
+  assign tx_phy_clk_start_16_we = addr_hit[56] & reg_we & !reg_error;
+  assign tx_phy_clk_start_16_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_17_we = addr_hit[57] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_17_wd = reg_wdata[10:0];
+  assign tx_phy_clk_start_17_we = addr_hit[57] & reg_we & !reg_error;
+  assign tx_phy_clk_start_17_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_18_we = addr_hit[58] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_18_wd = reg_wdata[10:0];
+  assign tx_phy_clk_start_18_we = addr_hit[58] & reg_we & !reg_error;
+  assign tx_phy_clk_start_18_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_19_we = addr_hit[59] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_19_wd = reg_wdata[10:0];
+  assign tx_phy_clk_start_19_we = addr_hit[59] & reg_we & !reg_error;
+  assign tx_phy_clk_start_19_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_20_we = addr_hit[60] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_20_wd = reg_wdata[10:0];
+  assign tx_phy_clk_start_20_we = addr_hit[60] & reg_we & !reg_error;
+  assign tx_phy_clk_start_20_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_21_we = addr_hit[61] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_21_wd = reg_wdata[10:0];
+  assign tx_phy_clk_start_21_we = addr_hit[61] & reg_we & !reg_error;
+  assign tx_phy_clk_start_21_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_22_we = addr_hit[62] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_22_wd = reg_wdata[10:0];
+  assign tx_phy_clk_start_22_we = addr_hit[62] & reg_we & !reg_error;
+  assign tx_phy_clk_start_22_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_23_we = addr_hit[63] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_23_wd = reg_wdata[10:0];
+  assign tx_phy_clk_start_23_we = addr_hit[63] & reg_we & !reg_error;
+  assign tx_phy_clk_start_23_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_24_we = addr_hit[64] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_24_wd = reg_wdata[10:0];
+  assign tx_phy_clk_start_24_we = addr_hit[64] & reg_we & !reg_error;
+  assign tx_phy_clk_start_24_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_25_we = addr_hit[65] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_25_wd = reg_wdata[10:0];
+  assign tx_phy_clk_start_25_we = addr_hit[65] & reg_we & !reg_error;
+  assign tx_phy_clk_start_25_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_26_we = addr_hit[66] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_26_wd = reg_wdata[10:0];
+  assign tx_phy_clk_start_26_we = addr_hit[66] & reg_we & !reg_error;
+  assign tx_phy_clk_start_26_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_27_we = addr_hit[67] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_27_wd = reg_wdata[10:0];
+  assign tx_phy_clk_start_27_we = addr_hit[67] & reg_we & !reg_error;
+  assign tx_phy_clk_start_27_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_28_we = addr_hit[68] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_28_wd = reg_wdata[10:0];
+  assign tx_phy_clk_start_28_we = addr_hit[68] & reg_we & !reg_error;
+  assign tx_phy_clk_start_28_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_29_we = addr_hit[69] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_29_wd = reg_wdata[10:0];
+  assign tx_phy_clk_start_29_we = addr_hit[69] & reg_we & !reg_error;
+  assign tx_phy_clk_start_29_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_30_we = addr_hit[70] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_30_wd = reg_wdata[10:0];
+  assign tx_phy_clk_start_30_we = addr_hit[70] & reg_we & !reg_error;
+  assign tx_phy_clk_start_30_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_31_we = addr_hit[71] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_31_wd = reg_wdata[10:0];
+  assign tx_phy_clk_start_31_we = addr_hit[71] & reg_we & !reg_error;
+  assign tx_phy_clk_start_31_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_32_we = addr_hit[72] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_32_wd = reg_wdata[10:0];
+  assign tx_phy_clk_start_32_we = addr_hit[72] & reg_we & !reg_error;
+  assign tx_phy_clk_start_32_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_33_we = addr_hit[73] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_33_wd = reg_wdata[10:0];
+  assign tx_phy_clk_start_33_we = addr_hit[73] & reg_we & !reg_error;
+  assign tx_phy_clk_start_33_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_34_we = addr_hit[74] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_34_wd = reg_wdata[10:0];
+  assign tx_phy_clk_start_34_we = addr_hit[74] & reg_we & !reg_error;
+  assign tx_phy_clk_start_34_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_35_we = addr_hit[75] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_35_wd = reg_wdata[10:0];
+  assign tx_phy_clk_start_35_we = addr_hit[75] & reg_we & !reg_error;
+  assign tx_phy_clk_start_35_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_36_we = addr_hit[76] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_36_wd = reg_wdata[10:0];
+  assign tx_phy_clk_start_36_we = addr_hit[76] & reg_we & !reg_error;
+  assign tx_phy_clk_start_36_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_37_we = addr_hit[77] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_37_wd = reg_wdata[10:0];
+  assign tx_phy_clk_start_37_we = addr_hit[77] & reg_we & !reg_error;
+  assign tx_phy_clk_start_37_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl3_0_we = addr_hit[78] & reg_we & !reg_error;
-  assign tx_phy_ctrl3_0_wd = reg_wdata[10:0];
+  assign tx_phy_clk_end_0_we = addr_hit[78] & reg_we & !reg_error;
+  assign tx_phy_clk_end_0_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl3_1_we = addr_hit[79] & reg_we & !reg_error;
-  assign tx_phy_ctrl3_1_wd = reg_wdata[10:0];
+  assign tx_phy_clk_end_1_we = addr_hit[79] & reg_we & !reg_error;
+  assign tx_phy_clk_end_1_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl3_2_we = addr_hit[80] & reg_we & !reg_error;
-  assign tx_phy_ctrl3_2_wd = reg_wdata[10:0];
+  assign tx_phy_clk_end_2_we = addr_hit[80] & reg_we & !reg_error;
+  assign tx_phy_clk_end_2_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl3_3_we = addr_hit[81] & reg_we & !reg_error;
-  assign tx_phy_ctrl3_3_wd = reg_wdata[10:0];
+  assign tx_phy_clk_end_3_we = addr_hit[81] & reg_we & !reg_error;
+  assign tx_phy_clk_end_3_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl3_4_we = addr_hit[82] & reg_we & !reg_error;
-  assign tx_phy_ctrl3_4_wd = reg_wdata[10:0];
+  assign tx_phy_clk_end_4_we = addr_hit[82] & reg_we & !reg_error;
+  assign tx_phy_clk_end_4_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl3_5_we = addr_hit[83] & reg_we & !reg_error;
-  assign tx_phy_ctrl3_5_wd = reg_wdata[10:0];
+  assign tx_phy_clk_end_5_we = addr_hit[83] & reg_we & !reg_error;
+  assign tx_phy_clk_end_5_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl3_6_we = addr_hit[84] & reg_we & !reg_error;
-  assign tx_phy_ctrl3_6_wd = reg_wdata[10:0];
+  assign tx_phy_clk_end_6_we = addr_hit[84] & reg_we & !reg_error;
+  assign tx_phy_clk_end_6_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl3_7_we = addr_hit[85] & reg_we & !reg_error;
-  assign tx_phy_ctrl3_7_wd = reg_wdata[10:0];
+  assign tx_phy_clk_end_7_we = addr_hit[85] & reg_we & !reg_error;
+  assign tx_phy_clk_end_7_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl3_8_we = addr_hit[86] & reg_we & !reg_error;
-  assign tx_phy_ctrl3_8_wd = reg_wdata[10:0];
+  assign tx_phy_clk_end_8_we = addr_hit[86] & reg_we & !reg_error;
+  assign tx_phy_clk_end_8_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl3_9_we = addr_hit[87] & reg_we & !reg_error;
-  assign tx_phy_ctrl3_9_wd = reg_wdata[10:0];
+  assign tx_phy_clk_end_9_we = addr_hit[87] & reg_we & !reg_error;
+  assign tx_phy_clk_end_9_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl3_10_we = addr_hit[88] & reg_we & !reg_error;
-  assign tx_phy_ctrl3_10_wd = reg_wdata[10:0];
+  assign tx_phy_clk_end_10_we = addr_hit[88] & reg_we & !reg_error;
+  assign tx_phy_clk_end_10_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl3_11_we = addr_hit[89] & reg_we & !reg_error;
-  assign tx_phy_ctrl3_11_wd = reg_wdata[10:0];
+  assign tx_phy_clk_end_11_we = addr_hit[89] & reg_we & !reg_error;
+  assign tx_phy_clk_end_11_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl3_12_we = addr_hit[90] & reg_we & !reg_error;
-  assign tx_phy_ctrl3_12_wd = reg_wdata[10:0];
+  assign tx_phy_clk_end_12_we = addr_hit[90] & reg_we & !reg_error;
+  assign tx_phy_clk_end_12_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl3_13_we = addr_hit[91] & reg_we & !reg_error;
-  assign tx_phy_ctrl3_13_wd = reg_wdata[10:0];
+  assign tx_phy_clk_end_13_we = addr_hit[91] & reg_we & !reg_error;
+  assign tx_phy_clk_end_13_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl3_14_we = addr_hit[92] & reg_we & !reg_error;
-  assign tx_phy_ctrl3_14_wd = reg_wdata[10:0];
+  assign tx_phy_clk_end_14_we = addr_hit[92] & reg_we & !reg_error;
+  assign tx_phy_clk_end_14_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl3_15_we = addr_hit[93] & reg_we & !reg_error;
-  assign tx_phy_ctrl3_15_wd = reg_wdata[10:0];
+  assign tx_phy_clk_end_15_we = addr_hit[93] & reg_we & !reg_error;
+  assign tx_phy_clk_end_15_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl3_16_we = addr_hit[94] & reg_we & !reg_error;
-  assign tx_phy_ctrl3_16_wd = reg_wdata[10:0];
+  assign tx_phy_clk_end_16_we = addr_hit[94] & reg_we & !reg_error;
+  assign tx_phy_clk_end_16_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl3_17_we = addr_hit[95] & reg_we & !reg_error;
-  assign tx_phy_ctrl3_17_wd = reg_wdata[10:0];
+  assign tx_phy_clk_end_17_we = addr_hit[95] & reg_we & !reg_error;
+  assign tx_phy_clk_end_17_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl3_18_we = addr_hit[96] & reg_we & !reg_error;
-  assign tx_phy_ctrl3_18_wd = reg_wdata[10:0];
+  assign tx_phy_clk_end_18_we = addr_hit[96] & reg_we & !reg_error;
+  assign tx_phy_clk_end_18_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl3_19_we = addr_hit[97] & reg_we & !reg_error;
-  assign tx_phy_ctrl3_19_wd = reg_wdata[10:0];
+  assign tx_phy_clk_end_19_we = addr_hit[97] & reg_we & !reg_error;
+  assign tx_phy_clk_end_19_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl3_20_we = addr_hit[98] & reg_we & !reg_error;
-  assign tx_phy_ctrl3_20_wd = reg_wdata[10:0];
+  assign tx_phy_clk_end_20_we = addr_hit[98] & reg_we & !reg_error;
+  assign tx_phy_clk_end_20_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl3_21_we = addr_hit[99] & reg_we & !reg_error;
-  assign tx_phy_ctrl3_21_wd = reg_wdata[10:0];
+  assign tx_phy_clk_end_21_we = addr_hit[99] & reg_we & !reg_error;
+  assign tx_phy_clk_end_21_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl3_22_we = addr_hit[100] & reg_we & !reg_error;
-  assign tx_phy_ctrl3_22_wd = reg_wdata[10:0];
+  assign tx_phy_clk_end_22_we = addr_hit[100] & reg_we & !reg_error;
+  assign tx_phy_clk_end_22_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl3_23_we = addr_hit[101] & reg_we & !reg_error;
-  assign tx_phy_ctrl3_23_wd = reg_wdata[10:0];
+  assign tx_phy_clk_end_23_we = addr_hit[101] & reg_we & !reg_error;
+  assign tx_phy_clk_end_23_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl3_24_we = addr_hit[102] & reg_we & !reg_error;
-  assign tx_phy_ctrl3_24_wd = reg_wdata[10:0];
+  assign tx_phy_clk_end_24_we = addr_hit[102] & reg_we & !reg_error;
+  assign tx_phy_clk_end_24_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl3_25_we = addr_hit[103] & reg_we & !reg_error;
-  assign tx_phy_ctrl3_25_wd = reg_wdata[10:0];
+  assign tx_phy_clk_end_25_we = addr_hit[103] & reg_we & !reg_error;
+  assign tx_phy_clk_end_25_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl3_26_we = addr_hit[104] & reg_we & !reg_error;
-  assign tx_phy_ctrl3_26_wd = reg_wdata[10:0];
+  assign tx_phy_clk_end_26_we = addr_hit[104] & reg_we & !reg_error;
+  assign tx_phy_clk_end_26_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl3_27_we = addr_hit[105] & reg_we & !reg_error;
-  assign tx_phy_ctrl3_27_wd = reg_wdata[10:0];
+  assign tx_phy_clk_end_27_we = addr_hit[105] & reg_we & !reg_error;
+  assign tx_phy_clk_end_27_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl3_28_we = addr_hit[106] & reg_we & !reg_error;
-  assign tx_phy_ctrl3_28_wd = reg_wdata[10:0];
+  assign tx_phy_clk_end_28_we = addr_hit[106] & reg_we & !reg_error;
+  assign tx_phy_clk_end_28_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl3_29_we = addr_hit[107] & reg_we & !reg_error;
-  assign tx_phy_ctrl3_29_wd = reg_wdata[10:0];
+  assign tx_phy_clk_end_29_we = addr_hit[107] & reg_we & !reg_error;
+  assign tx_phy_clk_end_29_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl3_30_we = addr_hit[108] & reg_we & !reg_error;
-  assign tx_phy_ctrl3_30_wd = reg_wdata[10:0];
+  assign tx_phy_clk_end_30_we = addr_hit[108] & reg_we & !reg_error;
+  assign tx_phy_clk_end_30_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl3_31_we = addr_hit[109] & reg_we & !reg_error;
-  assign tx_phy_ctrl3_31_wd = reg_wdata[10:0];
+  assign tx_phy_clk_end_31_we = addr_hit[109] & reg_we & !reg_error;
+  assign tx_phy_clk_end_31_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl3_32_we = addr_hit[110] & reg_we & !reg_error;
-  assign tx_phy_ctrl3_32_wd = reg_wdata[10:0];
+  assign tx_phy_clk_end_32_we = addr_hit[110] & reg_we & !reg_error;
+  assign tx_phy_clk_end_32_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl3_33_we = addr_hit[111] & reg_we & !reg_error;
-  assign tx_phy_ctrl3_33_wd = reg_wdata[10:0];
+  assign tx_phy_clk_end_33_we = addr_hit[111] & reg_we & !reg_error;
+  assign tx_phy_clk_end_33_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl3_34_we = addr_hit[112] & reg_we & !reg_error;
-  assign tx_phy_ctrl3_34_wd = reg_wdata[10:0];
+  assign tx_phy_clk_end_34_we = addr_hit[112] & reg_we & !reg_error;
+  assign tx_phy_clk_end_34_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl3_35_we = addr_hit[113] & reg_we & !reg_error;
-  assign tx_phy_ctrl3_35_wd = reg_wdata[10:0];
+  assign tx_phy_clk_end_35_we = addr_hit[113] & reg_we & !reg_error;
+  assign tx_phy_clk_end_35_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl3_36_we = addr_hit[114] & reg_we & !reg_error;
-  assign tx_phy_ctrl3_36_wd = reg_wdata[10:0];
+  assign tx_phy_clk_end_36_we = addr_hit[114] & reg_we & !reg_error;
+  assign tx_phy_clk_end_36_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl3_37_we = addr_hit[115] & reg_we & !reg_error;
-  assign tx_phy_ctrl3_37_wd = reg_wdata[10:0];
+  assign tx_phy_clk_end_37_we = addr_hit[115] & reg_we & !reg_error;
+  assign tx_phy_clk_end_37_wd = reg_wdata[10:0];
 
   assign raw_mode_en_we = addr_hit[116] & reg_we & !reg_error;
   assign raw_mode_en_wd = reg_wdata[0];
@@ -9153,459 +9153,459 @@ module serial_link_reg_top #(
       end
 
       addr_hit[2]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl1_0_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_div_0_qs;
       end
 
       addr_hit[3]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl1_1_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_div_1_qs;
       end
 
       addr_hit[4]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl1_2_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_div_2_qs;
       end
 
       addr_hit[5]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl1_3_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_div_3_qs;
       end
 
       addr_hit[6]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl1_4_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_div_4_qs;
       end
 
       addr_hit[7]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl1_5_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_div_5_qs;
       end
 
       addr_hit[8]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl1_6_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_div_6_qs;
       end
 
       addr_hit[9]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl1_7_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_div_7_qs;
       end
 
       addr_hit[10]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl1_8_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_div_8_qs;
       end
 
       addr_hit[11]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl1_9_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_div_9_qs;
       end
 
       addr_hit[12]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl1_10_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_div_10_qs;
       end
 
       addr_hit[13]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl1_11_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_div_11_qs;
       end
 
       addr_hit[14]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl1_12_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_div_12_qs;
       end
 
       addr_hit[15]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl1_13_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_div_13_qs;
       end
 
       addr_hit[16]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl1_14_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_div_14_qs;
       end
 
       addr_hit[17]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl1_15_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_div_15_qs;
       end
 
       addr_hit[18]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl1_16_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_div_16_qs;
       end
 
       addr_hit[19]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl1_17_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_div_17_qs;
       end
 
       addr_hit[20]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl1_18_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_div_18_qs;
       end
 
       addr_hit[21]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl1_19_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_div_19_qs;
       end
 
       addr_hit[22]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl1_20_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_div_20_qs;
       end
 
       addr_hit[23]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl1_21_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_div_21_qs;
       end
 
       addr_hit[24]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl1_22_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_div_22_qs;
       end
 
       addr_hit[25]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl1_23_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_div_23_qs;
       end
 
       addr_hit[26]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl1_24_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_div_24_qs;
       end
 
       addr_hit[27]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl1_25_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_div_25_qs;
       end
 
       addr_hit[28]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl1_26_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_div_26_qs;
       end
 
       addr_hit[29]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl1_27_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_div_27_qs;
       end
 
       addr_hit[30]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl1_28_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_div_28_qs;
       end
 
       addr_hit[31]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl1_29_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_div_29_qs;
       end
 
       addr_hit[32]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl1_30_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_div_30_qs;
       end
 
       addr_hit[33]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl1_31_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_div_31_qs;
       end
 
       addr_hit[34]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl1_32_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_div_32_qs;
       end
 
       addr_hit[35]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl1_33_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_div_33_qs;
       end
 
       addr_hit[36]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl1_34_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_div_34_qs;
       end
 
       addr_hit[37]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl1_35_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_div_35_qs;
       end
 
       addr_hit[38]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl1_36_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_div_36_qs;
       end
 
       addr_hit[39]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl1_37_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_div_37_qs;
       end
 
       addr_hit[40]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_0_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_start_0_qs;
       end
 
       addr_hit[41]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_1_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_start_1_qs;
       end
 
       addr_hit[42]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_2_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_start_2_qs;
       end
 
       addr_hit[43]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_3_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_start_3_qs;
       end
 
       addr_hit[44]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_4_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_start_4_qs;
       end
 
       addr_hit[45]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_5_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_start_5_qs;
       end
 
       addr_hit[46]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_6_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_start_6_qs;
       end
 
       addr_hit[47]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_7_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_start_7_qs;
       end
 
       addr_hit[48]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_8_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_start_8_qs;
       end
 
       addr_hit[49]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_9_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_start_9_qs;
       end
 
       addr_hit[50]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_10_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_start_10_qs;
       end
 
       addr_hit[51]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_11_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_start_11_qs;
       end
 
       addr_hit[52]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_12_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_start_12_qs;
       end
 
       addr_hit[53]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_13_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_start_13_qs;
       end
 
       addr_hit[54]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_14_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_start_14_qs;
       end
 
       addr_hit[55]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_15_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_start_15_qs;
       end
 
       addr_hit[56]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_16_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_start_16_qs;
       end
 
       addr_hit[57]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_17_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_start_17_qs;
       end
 
       addr_hit[58]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_18_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_start_18_qs;
       end
 
       addr_hit[59]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_19_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_start_19_qs;
       end
 
       addr_hit[60]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_20_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_start_20_qs;
       end
 
       addr_hit[61]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_21_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_start_21_qs;
       end
 
       addr_hit[62]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_22_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_start_22_qs;
       end
 
       addr_hit[63]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_23_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_start_23_qs;
       end
 
       addr_hit[64]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_24_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_start_24_qs;
       end
 
       addr_hit[65]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_25_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_start_25_qs;
       end
 
       addr_hit[66]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_26_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_start_26_qs;
       end
 
       addr_hit[67]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_27_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_start_27_qs;
       end
 
       addr_hit[68]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_28_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_start_28_qs;
       end
 
       addr_hit[69]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_29_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_start_29_qs;
       end
 
       addr_hit[70]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_30_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_start_30_qs;
       end
 
       addr_hit[71]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_31_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_start_31_qs;
       end
 
       addr_hit[72]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_32_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_start_32_qs;
       end
 
       addr_hit[73]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_33_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_start_33_qs;
       end
 
       addr_hit[74]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_34_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_start_34_qs;
       end
 
       addr_hit[75]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_35_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_start_35_qs;
       end
 
       addr_hit[76]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_36_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_start_36_qs;
       end
 
       addr_hit[77]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_37_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_start_37_qs;
       end
 
       addr_hit[78]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl3_0_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_end_0_qs;
       end
 
       addr_hit[79]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl3_1_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_end_1_qs;
       end
 
       addr_hit[80]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl3_2_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_end_2_qs;
       end
 
       addr_hit[81]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl3_3_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_end_3_qs;
       end
 
       addr_hit[82]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl3_4_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_end_4_qs;
       end
 
       addr_hit[83]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl3_5_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_end_5_qs;
       end
 
       addr_hit[84]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl3_6_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_end_6_qs;
       end
 
       addr_hit[85]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl3_7_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_end_7_qs;
       end
 
       addr_hit[86]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl3_8_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_end_8_qs;
       end
 
       addr_hit[87]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl3_9_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_end_9_qs;
       end
 
       addr_hit[88]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl3_10_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_end_10_qs;
       end
 
       addr_hit[89]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl3_11_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_end_11_qs;
       end
 
       addr_hit[90]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl3_12_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_end_12_qs;
       end
 
       addr_hit[91]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl3_13_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_end_13_qs;
       end
 
       addr_hit[92]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl3_14_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_end_14_qs;
       end
 
       addr_hit[93]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl3_15_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_end_15_qs;
       end
 
       addr_hit[94]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl3_16_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_end_16_qs;
       end
 
       addr_hit[95]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl3_17_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_end_17_qs;
       end
 
       addr_hit[96]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl3_18_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_end_18_qs;
       end
 
       addr_hit[97]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl3_19_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_end_19_qs;
       end
 
       addr_hit[98]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl3_20_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_end_20_qs;
       end
 
       addr_hit[99]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl3_21_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_end_21_qs;
       end
 
       addr_hit[100]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl3_22_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_end_22_qs;
       end
 
       addr_hit[101]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl3_23_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_end_23_qs;
       end
 
       addr_hit[102]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl3_24_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_end_24_qs;
       end
 
       addr_hit[103]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl3_25_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_end_25_qs;
       end
 
       addr_hit[104]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl3_26_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_end_26_qs;
       end
 
       addr_hit[105]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl3_27_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_end_27_qs;
       end
 
       addr_hit[106]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl3_28_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_end_28_qs;
       end
 
       addr_hit[107]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl3_29_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_end_29_qs;
       end
 
       addr_hit[108]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl3_30_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_end_30_qs;
       end
 
       addr_hit[109]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl3_31_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_end_31_qs;
       end
 
       addr_hit[110]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl3_32_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_end_32_qs;
       end
 
       addr_hit[111]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl3_33_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_end_33_qs;
       end
 
       addr_hit[112]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl3_34_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_end_34_qs;
       end
 
       addr_hit[113]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl3_35_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_end_35_qs;
       end
 
       addr_hit[114]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl3_36_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_end_36_qs;
       end
 
       addr_hit[115]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl3_37_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_end_37_qs;
       end
 
       addr_hit[116]: begin

--- a/src/regs/serial_link_reg_top.sv
+++ b/src/regs/serial_link_reg_top.sv
@@ -10,7 +10,7 @@
 module serial_link_reg_top #(
   parameter type reg_req_t = logic,
   parameter type reg_rsp_t = logic,
-  parameter int AW = 9
+  parameter int AW = 10
 ) (
   input logic clk_i,
   input logic rst_ni,
@@ -198,234 +198,234 @@ module serial_link_reg_top #(
   logic [10:0] tx_phy_ctrl1_37_qs;
   logic [10:0] tx_phy_ctrl1_37_wd;
   logic tx_phy_ctrl1_37_we;
-  logic [10:0] tx_phy_ctrl2_0_clk_shift_start_0_qs;
-  logic [10:0] tx_phy_ctrl2_0_clk_shift_start_0_wd;
-  logic tx_phy_ctrl2_0_clk_shift_start_0_we;
-  logic [10:0] tx_phy_ctrl2_0_clk_shift_end_0_qs;
-  logic [10:0] tx_phy_ctrl2_0_clk_shift_end_0_wd;
-  logic tx_phy_ctrl2_0_clk_shift_end_0_we;
-  logic [10:0] tx_phy_ctrl2_1_clk_shift_start_1_qs;
-  logic [10:0] tx_phy_ctrl2_1_clk_shift_start_1_wd;
-  logic tx_phy_ctrl2_1_clk_shift_start_1_we;
-  logic [10:0] tx_phy_ctrl2_1_clk_shift_end_1_qs;
-  logic [10:0] tx_phy_ctrl2_1_clk_shift_end_1_wd;
-  logic tx_phy_ctrl2_1_clk_shift_end_1_we;
-  logic [10:0] tx_phy_ctrl2_2_clk_shift_start_2_qs;
-  logic [10:0] tx_phy_ctrl2_2_clk_shift_start_2_wd;
-  logic tx_phy_ctrl2_2_clk_shift_start_2_we;
-  logic [10:0] tx_phy_ctrl2_2_clk_shift_end_2_qs;
-  logic [10:0] tx_phy_ctrl2_2_clk_shift_end_2_wd;
-  logic tx_phy_ctrl2_2_clk_shift_end_2_we;
-  logic [10:0] tx_phy_ctrl2_3_clk_shift_start_3_qs;
-  logic [10:0] tx_phy_ctrl2_3_clk_shift_start_3_wd;
-  logic tx_phy_ctrl2_3_clk_shift_start_3_we;
-  logic [10:0] tx_phy_ctrl2_3_clk_shift_end_3_qs;
-  logic [10:0] tx_phy_ctrl2_3_clk_shift_end_3_wd;
-  logic tx_phy_ctrl2_3_clk_shift_end_3_we;
-  logic [10:0] tx_phy_ctrl2_4_clk_shift_start_4_qs;
-  logic [10:0] tx_phy_ctrl2_4_clk_shift_start_4_wd;
-  logic tx_phy_ctrl2_4_clk_shift_start_4_we;
-  logic [10:0] tx_phy_ctrl2_4_clk_shift_end_4_qs;
-  logic [10:0] tx_phy_ctrl2_4_clk_shift_end_4_wd;
-  logic tx_phy_ctrl2_4_clk_shift_end_4_we;
-  logic [10:0] tx_phy_ctrl2_5_clk_shift_start_5_qs;
-  logic [10:0] tx_phy_ctrl2_5_clk_shift_start_5_wd;
-  logic tx_phy_ctrl2_5_clk_shift_start_5_we;
-  logic [10:0] tx_phy_ctrl2_5_clk_shift_end_5_qs;
-  logic [10:0] tx_phy_ctrl2_5_clk_shift_end_5_wd;
-  logic tx_phy_ctrl2_5_clk_shift_end_5_we;
-  logic [10:0] tx_phy_ctrl2_6_clk_shift_start_6_qs;
-  logic [10:0] tx_phy_ctrl2_6_clk_shift_start_6_wd;
-  logic tx_phy_ctrl2_6_clk_shift_start_6_we;
-  logic [10:0] tx_phy_ctrl2_6_clk_shift_end_6_qs;
-  logic [10:0] tx_phy_ctrl2_6_clk_shift_end_6_wd;
-  logic tx_phy_ctrl2_6_clk_shift_end_6_we;
-  logic [10:0] tx_phy_ctrl2_7_clk_shift_start_7_qs;
-  logic [10:0] tx_phy_ctrl2_7_clk_shift_start_7_wd;
-  logic tx_phy_ctrl2_7_clk_shift_start_7_we;
-  logic [10:0] tx_phy_ctrl2_7_clk_shift_end_7_qs;
-  logic [10:0] tx_phy_ctrl2_7_clk_shift_end_7_wd;
-  logic tx_phy_ctrl2_7_clk_shift_end_7_we;
-  logic [10:0] tx_phy_ctrl2_8_clk_shift_start_8_qs;
-  logic [10:0] tx_phy_ctrl2_8_clk_shift_start_8_wd;
-  logic tx_phy_ctrl2_8_clk_shift_start_8_we;
-  logic [10:0] tx_phy_ctrl2_8_clk_shift_end_8_qs;
-  logic [10:0] tx_phy_ctrl2_8_clk_shift_end_8_wd;
-  logic tx_phy_ctrl2_8_clk_shift_end_8_we;
-  logic [10:0] tx_phy_ctrl2_9_clk_shift_start_9_qs;
-  logic [10:0] tx_phy_ctrl2_9_clk_shift_start_9_wd;
-  logic tx_phy_ctrl2_9_clk_shift_start_9_we;
-  logic [10:0] tx_phy_ctrl2_9_clk_shift_end_9_qs;
-  logic [10:0] tx_phy_ctrl2_9_clk_shift_end_9_wd;
-  logic tx_phy_ctrl2_9_clk_shift_end_9_we;
-  logic [10:0] tx_phy_ctrl2_10_clk_shift_start_10_qs;
-  logic [10:0] tx_phy_ctrl2_10_clk_shift_start_10_wd;
-  logic tx_phy_ctrl2_10_clk_shift_start_10_we;
-  logic [10:0] tx_phy_ctrl2_10_clk_shift_end_10_qs;
-  logic [10:0] tx_phy_ctrl2_10_clk_shift_end_10_wd;
-  logic tx_phy_ctrl2_10_clk_shift_end_10_we;
-  logic [10:0] tx_phy_ctrl2_11_clk_shift_start_11_qs;
-  logic [10:0] tx_phy_ctrl2_11_clk_shift_start_11_wd;
-  logic tx_phy_ctrl2_11_clk_shift_start_11_we;
-  logic [10:0] tx_phy_ctrl2_11_clk_shift_end_11_qs;
-  logic [10:0] tx_phy_ctrl2_11_clk_shift_end_11_wd;
-  logic tx_phy_ctrl2_11_clk_shift_end_11_we;
-  logic [10:0] tx_phy_ctrl2_12_clk_shift_start_12_qs;
-  logic [10:0] tx_phy_ctrl2_12_clk_shift_start_12_wd;
-  logic tx_phy_ctrl2_12_clk_shift_start_12_we;
-  logic [10:0] tx_phy_ctrl2_12_clk_shift_end_12_qs;
-  logic [10:0] tx_phy_ctrl2_12_clk_shift_end_12_wd;
-  logic tx_phy_ctrl2_12_clk_shift_end_12_we;
-  logic [10:0] tx_phy_ctrl2_13_clk_shift_start_13_qs;
-  logic [10:0] tx_phy_ctrl2_13_clk_shift_start_13_wd;
-  logic tx_phy_ctrl2_13_clk_shift_start_13_we;
-  logic [10:0] tx_phy_ctrl2_13_clk_shift_end_13_qs;
-  logic [10:0] tx_phy_ctrl2_13_clk_shift_end_13_wd;
-  logic tx_phy_ctrl2_13_clk_shift_end_13_we;
-  logic [10:0] tx_phy_ctrl2_14_clk_shift_start_14_qs;
-  logic [10:0] tx_phy_ctrl2_14_clk_shift_start_14_wd;
-  logic tx_phy_ctrl2_14_clk_shift_start_14_we;
-  logic [10:0] tx_phy_ctrl2_14_clk_shift_end_14_qs;
-  logic [10:0] tx_phy_ctrl2_14_clk_shift_end_14_wd;
-  logic tx_phy_ctrl2_14_clk_shift_end_14_we;
-  logic [10:0] tx_phy_ctrl2_15_clk_shift_start_15_qs;
-  logic [10:0] tx_phy_ctrl2_15_clk_shift_start_15_wd;
-  logic tx_phy_ctrl2_15_clk_shift_start_15_we;
-  logic [10:0] tx_phy_ctrl2_15_clk_shift_end_15_qs;
-  logic [10:0] tx_phy_ctrl2_15_clk_shift_end_15_wd;
-  logic tx_phy_ctrl2_15_clk_shift_end_15_we;
-  logic [10:0] tx_phy_ctrl2_16_clk_shift_start_16_qs;
-  logic [10:0] tx_phy_ctrl2_16_clk_shift_start_16_wd;
-  logic tx_phy_ctrl2_16_clk_shift_start_16_we;
-  logic [10:0] tx_phy_ctrl2_16_clk_shift_end_16_qs;
-  logic [10:0] tx_phy_ctrl2_16_clk_shift_end_16_wd;
-  logic tx_phy_ctrl2_16_clk_shift_end_16_we;
-  logic [10:0] tx_phy_ctrl2_17_clk_shift_start_17_qs;
-  logic [10:0] tx_phy_ctrl2_17_clk_shift_start_17_wd;
-  logic tx_phy_ctrl2_17_clk_shift_start_17_we;
-  logic [10:0] tx_phy_ctrl2_17_clk_shift_end_17_qs;
-  logic [10:0] tx_phy_ctrl2_17_clk_shift_end_17_wd;
-  logic tx_phy_ctrl2_17_clk_shift_end_17_we;
-  logic [10:0] tx_phy_ctrl2_18_clk_shift_start_18_qs;
-  logic [10:0] tx_phy_ctrl2_18_clk_shift_start_18_wd;
-  logic tx_phy_ctrl2_18_clk_shift_start_18_we;
-  logic [10:0] tx_phy_ctrl2_18_clk_shift_end_18_qs;
-  logic [10:0] tx_phy_ctrl2_18_clk_shift_end_18_wd;
-  logic tx_phy_ctrl2_18_clk_shift_end_18_we;
-  logic [10:0] tx_phy_ctrl2_19_clk_shift_start_19_qs;
-  logic [10:0] tx_phy_ctrl2_19_clk_shift_start_19_wd;
-  logic tx_phy_ctrl2_19_clk_shift_start_19_we;
-  logic [10:0] tx_phy_ctrl2_19_clk_shift_end_19_qs;
-  logic [10:0] tx_phy_ctrl2_19_clk_shift_end_19_wd;
-  logic tx_phy_ctrl2_19_clk_shift_end_19_we;
-  logic [10:0] tx_phy_ctrl2_20_clk_shift_start_20_qs;
-  logic [10:0] tx_phy_ctrl2_20_clk_shift_start_20_wd;
-  logic tx_phy_ctrl2_20_clk_shift_start_20_we;
-  logic [10:0] tx_phy_ctrl2_20_clk_shift_end_20_qs;
-  logic [10:0] tx_phy_ctrl2_20_clk_shift_end_20_wd;
-  logic tx_phy_ctrl2_20_clk_shift_end_20_we;
-  logic [10:0] tx_phy_ctrl2_21_clk_shift_start_21_qs;
-  logic [10:0] tx_phy_ctrl2_21_clk_shift_start_21_wd;
-  logic tx_phy_ctrl2_21_clk_shift_start_21_we;
-  logic [10:0] tx_phy_ctrl2_21_clk_shift_end_21_qs;
-  logic [10:0] tx_phy_ctrl2_21_clk_shift_end_21_wd;
-  logic tx_phy_ctrl2_21_clk_shift_end_21_we;
-  logic [10:0] tx_phy_ctrl2_22_clk_shift_start_22_qs;
-  logic [10:0] tx_phy_ctrl2_22_clk_shift_start_22_wd;
-  logic tx_phy_ctrl2_22_clk_shift_start_22_we;
-  logic [10:0] tx_phy_ctrl2_22_clk_shift_end_22_qs;
-  logic [10:0] tx_phy_ctrl2_22_clk_shift_end_22_wd;
-  logic tx_phy_ctrl2_22_clk_shift_end_22_we;
-  logic [10:0] tx_phy_ctrl2_23_clk_shift_start_23_qs;
-  logic [10:0] tx_phy_ctrl2_23_clk_shift_start_23_wd;
-  logic tx_phy_ctrl2_23_clk_shift_start_23_we;
-  logic [10:0] tx_phy_ctrl2_23_clk_shift_end_23_qs;
-  logic [10:0] tx_phy_ctrl2_23_clk_shift_end_23_wd;
-  logic tx_phy_ctrl2_23_clk_shift_end_23_we;
-  logic [10:0] tx_phy_ctrl2_24_clk_shift_start_24_qs;
-  logic [10:0] tx_phy_ctrl2_24_clk_shift_start_24_wd;
-  logic tx_phy_ctrl2_24_clk_shift_start_24_we;
-  logic [10:0] tx_phy_ctrl2_24_clk_shift_end_24_qs;
-  logic [10:0] tx_phy_ctrl2_24_clk_shift_end_24_wd;
-  logic tx_phy_ctrl2_24_clk_shift_end_24_we;
-  logic [10:0] tx_phy_ctrl2_25_clk_shift_start_25_qs;
-  logic [10:0] tx_phy_ctrl2_25_clk_shift_start_25_wd;
-  logic tx_phy_ctrl2_25_clk_shift_start_25_we;
-  logic [10:0] tx_phy_ctrl2_25_clk_shift_end_25_qs;
-  logic [10:0] tx_phy_ctrl2_25_clk_shift_end_25_wd;
-  logic tx_phy_ctrl2_25_clk_shift_end_25_we;
-  logic [10:0] tx_phy_ctrl2_26_clk_shift_start_26_qs;
-  logic [10:0] tx_phy_ctrl2_26_clk_shift_start_26_wd;
-  logic tx_phy_ctrl2_26_clk_shift_start_26_we;
-  logic [10:0] tx_phy_ctrl2_26_clk_shift_end_26_qs;
-  logic [10:0] tx_phy_ctrl2_26_clk_shift_end_26_wd;
-  logic tx_phy_ctrl2_26_clk_shift_end_26_we;
-  logic [10:0] tx_phy_ctrl2_27_clk_shift_start_27_qs;
-  logic [10:0] tx_phy_ctrl2_27_clk_shift_start_27_wd;
-  logic tx_phy_ctrl2_27_clk_shift_start_27_we;
-  logic [10:0] tx_phy_ctrl2_27_clk_shift_end_27_qs;
-  logic [10:0] tx_phy_ctrl2_27_clk_shift_end_27_wd;
-  logic tx_phy_ctrl2_27_clk_shift_end_27_we;
-  logic [10:0] tx_phy_ctrl2_28_clk_shift_start_28_qs;
-  logic [10:0] tx_phy_ctrl2_28_clk_shift_start_28_wd;
-  logic tx_phy_ctrl2_28_clk_shift_start_28_we;
-  logic [10:0] tx_phy_ctrl2_28_clk_shift_end_28_qs;
-  logic [10:0] tx_phy_ctrl2_28_clk_shift_end_28_wd;
-  logic tx_phy_ctrl2_28_clk_shift_end_28_we;
-  logic [10:0] tx_phy_ctrl2_29_clk_shift_start_29_qs;
-  logic [10:0] tx_phy_ctrl2_29_clk_shift_start_29_wd;
-  logic tx_phy_ctrl2_29_clk_shift_start_29_we;
-  logic [10:0] tx_phy_ctrl2_29_clk_shift_end_29_qs;
-  logic [10:0] tx_phy_ctrl2_29_clk_shift_end_29_wd;
-  logic tx_phy_ctrl2_29_clk_shift_end_29_we;
-  logic [10:0] tx_phy_ctrl2_30_clk_shift_start_30_qs;
-  logic [10:0] tx_phy_ctrl2_30_clk_shift_start_30_wd;
-  logic tx_phy_ctrl2_30_clk_shift_start_30_we;
-  logic [10:0] tx_phy_ctrl2_30_clk_shift_end_30_qs;
-  logic [10:0] tx_phy_ctrl2_30_clk_shift_end_30_wd;
-  logic tx_phy_ctrl2_30_clk_shift_end_30_we;
-  logic [10:0] tx_phy_ctrl2_31_clk_shift_start_31_qs;
-  logic [10:0] tx_phy_ctrl2_31_clk_shift_start_31_wd;
-  logic tx_phy_ctrl2_31_clk_shift_start_31_we;
-  logic [10:0] tx_phy_ctrl2_31_clk_shift_end_31_qs;
-  logic [10:0] tx_phy_ctrl2_31_clk_shift_end_31_wd;
-  logic tx_phy_ctrl2_31_clk_shift_end_31_we;
-  logic [10:0] tx_phy_ctrl2_32_clk_shift_start_32_qs;
-  logic [10:0] tx_phy_ctrl2_32_clk_shift_start_32_wd;
-  logic tx_phy_ctrl2_32_clk_shift_start_32_we;
-  logic [10:0] tx_phy_ctrl2_32_clk_shift_end_32_qs;
-  logic [10:0] tx_phy_ctrl2_32_clk_shift_end_32_wd;
-  logic tx_phy_ctrl2_32_clk_shift_end_32_we;
-  logic [10:0] tx_phy_ctrl2_33_clk_shift_start_33_qs;
-  logic [10:0] tx_phy_ctrl2_33_clk_shift_start_33_wd;
-  logic tx_phy_ctrl2_33_clk_shift_start_33_we;
-  logic [10:0] tx_phy_ctrl2_33_clk_shift_end_33_qs;
-  logic [10:0] tx_phy_ctrl2_33_clk_shift_end_33_wd;
-  logic tx_phy_ctrl2_33_clk_shift_end_33_we;
-  logic [10:0] tx_phy_ctrl2_34_clk_shift_start_34_qs;
-  logic [10:0] tx_phy_ctrl2_34_clk_shift_start_34_wd;
-  logic tx_phy_ctrl2_34_clk_shift_start_34_we;
-  logic [10:0] tx_phy_ctrl2_34_clk_shift_end_34_qs;
-  logic [10:0] tx_phy_ctrl2_34_clk_shift_end_34_wd;
-  logic tx_phy_ctrl2_34_clk_shift_end_34_we;
-  logic [10:0] tx_phy_ctrl2_35_clk_shift_start_35_qs;
-  logic [10:0] tx_phy_ctrl2_35_clk_shift_start_35_wd;
-  logic tx_phy_ctrl2_35_clk_shift_start_35_we;
-  logic [10:0] tx_phy_ctrl2_35_clk_shift_end_35_qs;
-  logic [10:0] tx_phy_ctrl2_35_clk_shift_end_35_wd;
-  logic tx_phy_ctrl2_35_clk_shift_end_35_we;
-  logic [10:0] tx_phy_ctrl2_36_clk_shift_start_36_qs;
-  logic [10:0] tx_phy_ctrl2_36_clk_shift_start_36_wd;
-  logic tx_phy_ctrl2_36_clk_shift_start_36_we;
-  logic [10:0] tx_phy_ctrl2_36_clk_shift_end_36_qs;
-  logic [10:0] tx_phy_ctrl2_36_clk_shift_end_36_wd;
-  logic tx_phy_ctrl2_36_clk_shift_end_36_we;
-  logic [10:0] tx_phy_ctrl2_37_clk_shift_start_37_qs;
-  logic [10:0] tx_phy_ctrl2_37_clk_shift_start_37_wd;
-  logic tx_phy_ctrl2_37_clk_shift_start_37_we;
-  logic [10:0] tx_phy_ctrl2_37_clk_shift_end_37_qs;
-  logic [10:0] tx_phy_ctrl2_37_clk_shift_end_37_wd;
-  logic tx_phy_ctrl2_37_clk_shift_end_37_we;
+  logic [10:0] tx_phy_ctrl2_0_qs;
+  logic [10:0] tx_phy_ctrl2_0_wd;
+  logic tx_phy_ctrl2_0_we;
+  logic [10:0] tx_phy_ctrl2_1_qs;
+  logic [10:0] tx_phy_ctrl2_1_wd;
+  logic tx_phy_ctrl2_1_we;
+  logic [10:0] tx_phy_ctrl2_2_qs;
+  logic [10:0] tx_phy_ctrl2_2_wd;
+  logic tx_phy_ctrl2_2_we;
+  logic [10:0] tx_phy_ctrl2_3_qs;
+  logic [10:0] tx_phy_ctrl2_3_wd;
+  logic tx_phy_ctrl2_3_we;
+  logic [10:0] tx_phy_ctrl2_4_qs;
+  logic [10:0] tx_phy_ctrl2_4_wd;
+  logic tx_phy_ctrl2_4_we;
+  logic [10:0] tx_phy_ctrl2_5_qs;
+  logic [10:0] tx_phy_ctrl2_5_wd;
+  logic tx_phy_ctrl2_5_we;
+  logic [10:0] tx_phy_ctrl2_6_qs;
+  logic [10:0] tx_phy_ctrl2_6_wd;
+  logic tx_phy_ctrl2_6_we;
+  logic [10:0] tx_phy_ctrl2_7_qs;
+  logic [10:0] tx_phy_ctrl2_7_wd;
+  logic tx_phy_ctrl2_7_we;
+  logic [10:0] tx_phy_ctrl2_8_qs;
+  logic [10:0] tx_phy_ctrl2_8_wd;
+  logic tx_phy_ctrl2_8_we;
+  logic [10:0] tx_phy_ctrl2_9_qs;
+  logic [10:0] tx_phy_ctrl2_9_wd;
+  logic tx_phy_ctrl2_9_we;
+  logic [10:0] tx_phy_ctrl2_10_qs;
+  logic [10:0] tx_phy_ctrl2_10_wd;
+  logic tx_phy_ctrl2_10_we;
+  logic [10:0] tx_phy_ctrl2_11_qs;
+  logic [10:0] tx_phy_ctrl2_11_wd;
+  logic tx_phy_ctrl2_11_we;
+  logic [10:0] tx_phy_ctrl2_12_qs;
+  logic [10:0] tx_phy_ctrl2_12_wd;
+  logic tx_phy_ctrl2_12_we;
+  logic [10:0] tx_phy_ctrl2_13_qs;
+  logic [10:0] tx_phy_ctrl2_13_wd;
+  logic tx_phy_ctrl2_13_we;
+  logic [10:0] tx_phy_ctrl2_14_qs;
+  logic [10:0] tx_phy_ctrl2_14_wd;
+  logic tx_phy_ctrl2_14_we;
+  logic [10:0] tx_phy_ctrl2_15_qs;
+  logic [10:0] tx_phy_ctrl2_15_wd;
+  logic tx_phy_ctrl2_15_we;
+  logic [10:0] tx_phy_ctrl2_16_qs;
+  logic [10:0] tx_phy_ctrl2_16_wd;
+  logic tx_phy_ctrl2_16_we;
+  logic [10:0] tx_phy_ctrl2_17_qs;
+  logic [10:0] tx_phy_ctrl2_17_wd;
+  logic tx_phy_ctrl2_17_we;
+  logic [10:0] tx_phy_ctrl2_18_qs;
+  logic [10:0] tx_phy_ctrl2_18_wd;
+  logic tx_phy_ctrl2_18_we;
+  logic [10:0] tx_phy_ctrl2_19_qs;
+  logic [10:0] tx_phy_ctrl2_19_wd;
+  logic tx_phy_ctrl2_19_we;
+  logic [10:0] tx_phy_ctrl2_20_qs;
+  logic [10:0] tx_phy_ctrl2_20_wd;
+  logic tx_phy_ctrl2_20_we;
+  logic [10:0] tx_phy_ctrl2_21_qs;
+  logic [10:0] tx_phy_ctrl2_21_wd;
+  logic tx_phy_ctrl2_21_we;
+  logic [10:0] tx_phy_ctrl2_22_qs;
+  logic [10:0] tx_phy_ctrl2_22_wd;
+  logic tx_phy_ctrl2_22_we;
+  logic [10:0] tx_phy_ctrl2_23_qs;
+  logic [10:0] tx_phy_ctrl2_23_wd;
+  logic tx_phy_ctrl2_23_we;
+  logic [10:0] tx_phy_ctrl2_24_qs;
+  logic [10:0] tx_phy_ctrl2_24_wd;
+  logic tx_phy_ctrl2_24_we;
+  logic [10:0] tx_phy_ctrl2_25_qs;
+  logic [10:0] tx_phy_ctrl2_25_wd;
+  logic tx_phy_ctrl2_25_we;
+  logic [10:0] tx_phy_ctrl2_26_qs;
+  logic [10:0] tx_phy_ctrl2_26_wd;
+  logic tx_phy_ctrl2_26_we;
+  logic [10:0] tx_phy_ctrl2_27_qs;
+  logic [10:0] tx_phy_ctrl2_27_wd;
+  logic tx_phy_ctrl2_27_we;
+  logic [10:0] tx_phy_ctrl2_28_qs;
+  logic [10:0] tx_phy_ctrl2_28_wd;
+  logic tx_phy_ctrl2_28_we;
+  logic [10:0] tx_phy_ctrl2_29_qs;
+  logic [10:0] tx_phy_ctrl2_29_wd;
+  logic tx_phy_ctrl2_29_we;
+  logic [10:0] tx_phy_ctrl2_30_qs;
+  logic [10:0] tx_phy_ctrl2_30_wd;
+  logic tx_phy_ctrl2_30_we;
+  logic [10:0] tx_phy_ctrl2_31_qs;
+  logic [10:0] tx_phy_ctrl2_31_wd;
+  logic tx_phy_ctrl2_31_we;
+  logic [10:0] tx_phy_ctrl2_32_qs;
+  logic [10:0] tx_phy_ctrl2_32_wd;
+  logic tx_phy_ctrl2_32_we;
+  logic [10:0] tx_phy_ctrl2_33_qs;
+  logic [10:0] tx_phy_ctrl2_33_wd;
+  logic tx_phy_ctrl2_33_we;
+  logic [10:0] tx_phy_ctrl2_34_qs;
+  logic [10:0] tx_phy_ctrl2_34_wd;
+  logic tx_phy_ctrl2_34_we;
+  logic [10:0] tx_phy_ctrl2_35_qs;
+  logic [10:0] tx_phy_ctrl2_35_wd;
+  logic tx_phy_ctrl2_35_we;
+  logic [10:0] tx_phy_ctrl2_36_qs;
+  logic [10:0] tx_phy_ctrl2_36_wd;
+  logic tx_phy_ctrl2_36_we;
+  logic [10:0] tx_phy_ctrl2_37_qs;
+  logic [10:0] tx_phy_ctrl2_37_wd;
+  logic tx_phy_ctrl2_37_we;
+  logic [10:0] tx_phy_ctrl3_0_qs;
+  logic [10:0] tx_phy_ctrl3_0_wd;
+  logic tx_phy_ctrl3_0_we;
+  logic [10:0] tx_phy_ctrl3_1_qs;
+  logic [10:0] tx_phy_ctrl3_1_wd;
+  logic tx_phy_ctrl3_1_we;
+  logic [10:0] tx_phy_ctrl3_2_qs;
+  logic [10:0] tx_phy_ctrl3_2_wd;
+  logic tx_phy_ctrl3_2_we;
+  logic [10:0] tx_phy_ctrl3_3_qs;
+  logic [10:0] tx_phy_ctrl3_3_wd;
+  logic tx_phy_ctrl3_3_we;
+  logic [10:0] tx_phy_ctrl3_4_qs;
+  logic [10:0] tx_phy_ctrl3_4_wd;
+  logic tx_phy_ctrl3_4_we;
+  logic [10:0] tx_phy_ctrl3_5_qs;
+  logic [10:0] tx_phy_ctrl3_5_wd;
+  logic tx_phy_ctrl3_5_we;
+  logic [10:0] tx_phy_ctrl3_6_qs;
+  logic [10:0] tx_phy_ctrl3_6_wd;
+  logic tx_phy_ctrl3_6_we;
+  logic [10:0] tx_phy_ctrl3_7_qs;
+  logic [10:0] tx_phy_ctrl3_7_wd;
+  logic tx_phy_ctrl3_7_we;
+  logic [10:0] tx_phy_ctrl3_8_qs;
+  logic [10:0] tx_phy_ctrl3_8_wd;
+  logic tx_phy_ctrl3_8_we;
+  logic [10:0] tx_phy_ctrl3_9_qs;
+  logic [10:0] tx_phy_ctrl3_9_wd;
+  logic tx_phy_ctrl3_9_we;
+  logic [10:0] tx_phy_ctrl3_10_qs;
+  logic [10:0] tx_phy_ctrl3_10_wd;
+  logic tx_phy_ctrl3_10_we;
+  logic [10:0] tx_phy_ctrl3_11_qs;
+  logic [10:0] tx_phy_ctrl3_11_wd;
+  logic tx_phy_ctrl3_11_we;
+  logic [10:0] tx_phy_ctrl3_12_qs;
+  logic [10:0] tx_phy_ctrl3_12_wd;
+  logic tx_phy_ctrl3_12_we;
+  logic [10:0] tx_phy_ctrl3_13_qs;
+  logic [10:0] tx_phy_ctrl3_13_wd;
+  logic tx_phy_ctrl3_13_we;
+  logic [10:0] tx_phy_ctrl3_14_qs;
+  logic [10:0] tx_phy_ctrl3_14_wd;
+  logic tx_phy_ctrl3_14_we;
+  logic [10:0] tx_phy_ctrl3_15_qs;
+  logic [10:0] tx_phy_ctrl3_15_wd;
+  logic tx_phy_ctrl3_15_we;
+  logic [10:0] tx_phy_ctrl3_16_qs;
+  logic [10:0] tx_phy_ctrl3_16_wd;
+  logic tx_phy_ctrl3_16_we;
+  logic [10:0] tx_phy_ctrl3_17_qs;
+  logic [10:0] tx_phy_ctrl3_17_wd;
+  logic tx_phy_ctrl3_17_we;
+  logic [10:0] tx_phy_ctrl3_18_qs;
+  logic [10:0] tx_phy_ctrl3_18_wd;
+  logic tx_phy_ctrl3_18_we;
+  logic [10:0] tx_phy_ctrl3_19_qs;
+  logic [10:0] tx_phy_ctrl3_19_wd;
+  logic tx_phy_ctrl3_19_we;
+  logic [10:0] tx_phy_ctrl3_20_qs;
+  logic [10:0] tx_phy_ctrl3_20_wd;
+  logic tx_phy_ctrl3_20_we;
+  logic [10:0] tx_phy_ctrl3_21_qs;
+  logic [10:0] tx_phy_ctrl3_21_wd;
+  logic tx_phy_ctrl3_21_we;
+  logic [10:0] tx_phy_ctrl3_22_qs;
+  logic [10:0] tx_phy_ctrl3_22_wd;
+  logic tx_phy_ctrl3_22_we;
+  logic [10:0] tx_phy_ctrl3_23_qs;
+  logic [10:0] tx_phy_ctrl3_23_wd;
+  logic tx_phy_ctrl3_23_we;
+  logic [10:0] tx_phy_ctrl3_24_qs;
+  logic [10:0] tx_phy_ctrl3_24_wd;
+  logic tx_phy_ctrl3_24_we;
+  logic [10:0] tx_phy_ctrl3_25_qs;
+  logic [10:0] tx_phy_ctrl3_25_wd;
+  logic tx_phy_ctrl3_25_we;
+  logic [10:0] tx_phy_ctrl3_26_qs;
+  logic [10:0] tx_phy_ctrl3_26_wd;
+  logic tx_phy_ctrl3_26_we;
+  logic [10:0] tx_phy_ctrl3_27_qs;
+  logic [10:0] tx_phy_ctrl3_27_wd;
+  logic tx_phy_ctrl3_27_we;
+  logic [10:0] tx_phy_ctrl3_28_qs;
+  logic [10:0] tx_phy_ctrl3_28_wd;
+  logic tx_phy_ctrl3_28_we;
+  logic [10:0] tx_phy_ctrl3_29_qs;
+  logic [10:0] tx_phy_ctrl3_29_wd;
+  logic tx_phy_ctrl3_29_we;
+  logic [10:0] tx_phy_ctrl3_30_qs;
+  logic [10:0] tx_phy_ctrl3_30_wd;
+  logic tx_phy_ctrl3_30_we;
+  logic [10:0] tx_phy_ctrl3_31_qs;
+  logic [10:0] tx_phy_ctrl3_31_wd;
+  logic tx_phy_ctrl3_31_we;
+  logic [10:0] tx_phy_ctrl3_32_qs;
+  logic [10:0] tx_phy_ctrl3_32_wd;
+  logic tx_phy_ctrl3_32_we;
+  logic [10:0] tx_phy_ctrl3_33_qs;
+  logic [10:0] tx_phy_ctrl3_33_wd;
+  logic tx_phy_ctrl3_33_we;
+  logic [10:0] tx_phy_ctrl3_34_qs;
+  logic [10:0] tx_phy_ctrl3_34_wd;
+  logic tx_phy_ctrl3_34_we;
+  logic [10:0] tx_phy_ctrl3_35_qs;
+  logic [10:0] tx_phy_ctrl3_35_wd;
+  logic tx_phy_ctrl3_35_we;
+  logic [10:0] tx_phy_ctrl3_36_qs;
+  logic [10:0] tx_phy_ctrl3_36_wd;
+  logic tx_phy_ctrl3_36_we;
+  logic [10:0] tx_phy_ctrl3_37_qs;
+  logic [10:0] tx_phy_ctrl3_37_wd;
+  logic tx_phy_ctrl3_37_we;
   logic raw_mode_en_wd;
   logic raw_mode_en_we;
   logic [5:0] raw_mode_in_ch_sel_wd;
@@ -2024,18 +2024,17 @@ module serial_link_reg_top #(
   // Subregister 0 of Multireg tx_phy_ctrl2
   // R[tx_phy_ctrl2_0]: V(False)
 
-  // F[clk_shift_start_0]: 10:0
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_0_clk_shift_start_0 (
+  ) u_tx_phy_ctrl2_0 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_0_clk_shift_start_0_we),
-    .wd     (tx_phy_ctrl2_0_clk_shift_start_0_wd),
+    .we     (tx_phy_ctrl2_0_we),
+    .wd     (tx_phy_ctrl2_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2043,54 +2042,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[0].clk_shift_start.q ),
+    .q      (reg2hw.tx_phy_ctrl2[0].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_0_clk_shift_start_0_qs)
+    .qs     (tx_phy_ctrl2_0_qs)
   );
-
-
-  // F[clk_shift_end_0]: 10:0
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl2_0_clk_shift_end_0 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl2_0_clk_shift_end_0_we),
-    .wd     (tx_phy_ctrl2_0_clk_shift_end_0_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[0].clk_shift_end.q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl2_0_clk_shift_end_0_qs)
-  );
-
 
   // Subregister 1 of Multireg tx_phy_ctrl2
   // R[tx_phy_ctrl2_1]: V(False)
 
-  // F[clk_shift_start_1]: 10:0
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_1_clk_shift_start_1 (
+  ) u_tx_phy_ctrl2_1 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_1_clk_shift_start_1_we),
-    .wd     (tx_phy_ctrl2_1_clk_shift_start_1_wd),
+    .we     (tx_phy_ctrl2_1_we),
+    .wd     (tx_phy_ctrl2_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2098,54 +2069,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[1].clk_shift_start.q ),
+    .q      (reg2hw.tx_phy_ctrl2[1].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_1_clk_shift_start_1_qs)
+    .qs     (tx_phy_ctrl2_1_qs)
   );
-
-
-  // F[clk_shift_end_1]: 10:0
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl2_1_clk_shift_end_1 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl2_1_clk_shift_end_1_we),
-    .wd     (tx_phy_ctrl2_1_clk_shift_end_1_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[1].clk_shift_end.q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl2_1_clk_shift_end_1_qs)
-  );
-
 
   // Subregister 2 of Multireg tx_phy_ctrl2
   // R[tx_phy_ctrl2_2]: V(False)
 
-  // F[clk_shift_start_2]: 10:0
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_2_clk_shift_start_2 (
+  ) u_tx_phy_ctrl2_2 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_2_clk_shift_start_2_we),
-    .wd     (tx_phy_ctrl2_2_clk_shift_start_2_wd),
+    .we     (tx_phy_ctrl2_2_we),
+    .wd     (tx_phy_ctrl2_2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2153,54 +2096,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[2].clk_shift_start.q ),
+    .q      (reg2hw.tx_phy_ctrl2[2].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_2_clk_shift_start_2_qs)
+    .qs     (tx_phy_ctrl2_2_qs)
   );
-
-
-  // F[clk_shift_end_2]: 10:0
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl2_2_clk_shift_end_2 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl2_2_clk_shift_end_2_we),
-    .wd     (tx_phy_ctrl2_2_clk_shift_end_2_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[2].clk_shift_end.q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl2_2_clk_shift_end_2_qs)
-  );
-
 
   // Subregister 3 of Multireg tx_phy_ctrl2
   // R[tx_phy_ctrl2_3]: V(False)
 
-  // F[clk_shift_start_3]: 10:0
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_3_clk_shift_start_3 (
+  ) u_tx_phy_ctrl2_3 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_3_clk_shift_start_3_we),
-    .wd     (tx_phy_ctrl2_3_clk_shift_start_3_wd),
+    .we     (tx_phy_ctrl2_3_we),
+    .wd     (tx_phy_ctrl2_3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2208,54 +2123,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[3].clk_shift_start.q ),
+    .q      (reg2hw.tx_phy_ctrl2[3].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_3_clk_shift_start_3_qs)
+    .qs     (tx_phy_ctrl2_3_qs)
   );
-
-
-  // F[clk_shift_end_3]: 10:0
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl2_3_clk_shift_end_3 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl2_3_clk_shift_end_3_we),
-    .wd     (tx_phy_ctrl2_3_clk_shift_end_3_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[3].clk_shift_end.q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl2_3_clk_shift_end_3_qs)
-  );
-
 
   // Subregister 4 of Multireg tx_phy_ctrl2
   // R[tx_phy_ctrl2_4]: V(False)
 
-  // F[clk_shift_start_4]: 10:0
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_4_clk_shift_start_4 (
+  ) u_tx_phy_ctrl2_4 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_4_clk_shift_start_4_we),
-    .wd     (tx_phy_ctrl2_4_clk_shift_start_4_wd),
+    .we     (tx_phy_ctrl2_4_we),
+    .wd     (tx_phy_ctrl2_4_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2263,54 +2150,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[4].clk_shift_start.q ),
+    .q      (reg2hw.tx_phy_ctrl2[4].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_4_clk_shift_start_4_qs)
+    .qs     (tx_phy_ctrl2_4_qs)
   );
-
-
-  // F[clk_shift_end_4]: 10:0
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl2_4_clk_shift_end_4 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl2_4_clk_shift_end_4_we),
-    .wd     (tx_phy_ctrl2_4_clk_shift_end_4_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[4].clk_shift_end.q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl2_4_clk_shift_end_4_qs)
-  );
-
 
   // Subregister 5 of Multireg tx_phy_ctrl2
   // R[tx_phy_ctrl2_5]: V(False)
 
-  // F[clk_shift_start_5]: 10:0
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_5_clk_shift_start_5 (
+  ) u_tx_phy_ctrl2_5 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_5_clk_shift_start_5_we),
-    .wd     (tx_phy_ctrl2_5_clk_shift_start_5_wd),
+    .we     (tx_phy_ctrl2_5_we),
+    .wd     (tx_phy_ctrl2_5_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2318,54 +2177,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[5].clk_shift_start.q ),
+    .q      (reg2hw.tx_phy_ctrl2[5].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_5_clk_shift_start_5_qs)
+    .qs     (tx_phy_ctrl2_5_qs)
   );
-
-
-  // F[clk_shift_end_5]: 10:0
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl2_5_clk_shift_end_5 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl2_5_clk_shift_end_5_we),
-    .wd     (tx_phy_ctrl2_5_clk_shift_end_5_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[5].clk_shift_end.q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl2_5_clk_shift_end_5_qs)
-  );
-
 
   // Subregister 6 of Multireg tx_phy_ctrl2
   // R[tx_phy_ctrl2_6]: V(False)
 
-  // F[clk_shift_start_6]: 10:0
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_6_clk_shift_start_6 (
+  ) u_tx_phy_ctrl2_6 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_6_clk_shift_start_6_we),
-    .wd     (tx_phy_ctrl2_6_clk_shift_start_6_wd),
+    .we     (tx_phy_ctrl2_6_we),
+    .wd     (tx_phy_ctrl2_6_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2373,54 +2204,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[6].clk_shift_start.q ),
+    .q      (reg2hw.tx_phy_ctrl2[6].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_6_clk_shift_start_6_qs)
+    .qs     (tx_phy_ctrl2_6_qs)
   );
-
-
-  // F[clk_shift_end_6]: 10:0
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl2_6_clk_shift_end_6 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl2_6_clk_shift_end_6_we),
-    .wd     (tx_phy_ctrl2_6_clk_shift_end_6_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[6].clk_shift_end.q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl2_6_clk_shift_end_6_qs)
-  );
-
 
   // Subregister 7 of Multireg tx_phy_ctrl2
   // R[tx_phy_ctrl2_7]: V(False)
 
-  // F[clk_shift_start_7]: 10:0
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_7_clk_shift_start_7 (
+  ) u_tx_phy_ctrl2_7 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_7_clk_shift_start_7_we),
-    .wd     (tx_phy_ctrl2_7_clk_shift_start_7_wd),
+    .we     (tx_phy_ctrl2_7_we),
+    .wd     (tx_phy_ctrl2_7_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2428,54 +2231,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[7].clk_shift_start.q ),
+    .q      (reg2hw.tx_phy_ctrl2[7].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_7_clk_shift_start_7_qs)
+    .qs     (tx_phy_ctrl2_7_qs)
   );
-
-
-  // F[clk_shift_end_7]: 10:0
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl2_7_clk_shift_end_7 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl2_7_clk_shift_end_7_we),
-    .wd     (tx_phy_ctrl2_7_clk_shift_end_7_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[7].clk_shift_end.q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl2_7_clk_shift_end_7_qs)
-  );
-
 
   // Subregister 8 of Multireg tx_phy_ctrl2
   // R[tx_phy_ctrl2_8]: V(False)
 
-  // F[clk_shift_start_8]: 10:0
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_8_clk_shift_start_8 (
+  ) u_tx_phy_ctrl2_8 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_8_clk_shift_start_8_we),
-    .wd     (tx_phy_ctrl2_8_clk_shift_start_8_wd),
+    .we     (tx_phy_ctrl2_8_we),
+    .wd     (tx_phy_ctrl2_8_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2483,54 +2258,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[8].clk_shift_start.q ),
+    .q      (reg2hw.tx_phy_ctrl2[8].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_8_clk_shift_start_8_qs)
+    .qs     (tx_phy_ctrl2_8_qs)
   );
-
-
-  // F[clk_shift_end_8]: 10:0
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl2_8_clk_shift_end_8 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl2_8_clk_shift_end_8_we),
-    .wd     (tx_phy_ctrl2_8_clk_shift_end_8_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[8].clk_shift_end.q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl2_8_clk_shift_end_8_qs)
-  );
-
 
   // Subregister 9 of Multireg tx_phy_ctrl2
   // R[tx_phy_ctrl2_9]: V(False)
 
-  // F[clk_shift_start_9]: 10:0
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_9_clk_shift_start_9 (
+  ) u_tx_phy_ctrl2_9 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_9_clk_shift_start_9_we),
-    .wd     (tx_phy_ctrl2_9_clk_shift_start_9_wd),
+    .we     (tx_phy_ctrl2_9_we),
+    .wd     (tx_phy_ctrl2_9_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2538,54 +2285,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[9].clk_shift_start.q ),
+    .q      (reg2hw.tx_phy_ctrl2[9].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_9_clk_shift_start_9_qs)
+    .qs     (tx_phy_ctrl2_9_qs)
   );
-
-
-  // F[clk_shift_end_9]: 10:0
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl2_9_clk_shift_end_9 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl2_9_clk_shift_end_9_we),
-    .wd     (tx_phy_ctrl2_9_clk_shift_end_9_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[9].clk_shift_end.q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl2_9_clk_shift_end_9_qs)
-  );
-
 
   // Subregister 10 of Multireg tx_phy_ctrl2
   // R[tx_phy_ctrl2_10]: V(False)
 
-  // F[clk_shift_start_10]: 10:0
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_10_clk_shift_start_10 (
+  ) u_tx_phy_ctrl2_10 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_10_clk_shift_start_10_we),
-    .wd     (tx_phy_ctrl2_10_clk_shift_start_10_wd),
+    .we     (tx_phy_ctrl2_10_we),
+    .wd     (tx_phy_ctrl2_10_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2593,54 +2312,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[10].clk_shift_start.q ),
+    .q      (reg2hw.tx_phy_ctrl2[10].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_10_clk_shift_start_10_qs)
+    .qs     (tx_phy_ctrl2_10_qs)
   );
-
-
-  // F[clk_shift_end_10]: 10:0
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl2_10_clk_shift_end_10 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl2_10_clk_shift_end_10_we),
-    .wd     (tx_phy_ctrl2_10_clk_shift_end_10_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[10].clk_shift_end.q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl2_10_clk_shift_end_10_qs)
-  );
-
 
   // Subregister 11 of Multireg tx_phy_ctrl2
   // R[tx_phy_ctrl2_11]: V(False)
 
-  // F[clk_shift_start_11]: 10:0
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_11_clk_shift_start_11 (
+  ) u_tx_phy_ctrl2_11 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_11_clk_shift_start_11_we),
-    .wd     (tx_phy_ctrl2_11_clk_shift_start_11_wd),
+    .we     (tx_phy_ctrl2_11_we),
+    .wd     (tx_phy_ctrl2_11_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2648,54 +2339,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[11].clk_shift_start.q ),
+    .q      (reg2hw.tx_phy_ctrl2[11].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_11_clk_shift_start_11_qs)
+    .qs     (tx_phy_ctrl2_11_qs)
   );
-
-
-  // F[clk_shift_end_11]: 10:0
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl2_11_clk_shift_end_11 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl2_11_clk_shift_end_11_we),
-    .wd     (tx_phy_ctrl2_11_clk_shift_end_11_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[11].clk_shift_end.q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl2_11_clk_shift_end_11_qs)
-  );
-
 
   // Subregister 12 of Multireg tx_phy_ctrl2
   // R[tx_phy_ctrl2_12]: V(False)
 
-  // F[clk_shift_start_12]: 10:0
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_12_clk_shift_start_12 (
+  ) u_tx_phy_ctrl2_12 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_12_clk_shift_start_12_we),
-    .wd     (tx_phy_ctrl2_12_clk_shift_start_12_wd),
+    .we     (tx_phy_ctrl2_12_we),
+    .wd     (tx_phy_ctrl2_12_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2703,54 +2366,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[12].clk_shift_start.q ),
+    .q      (reg2hw.tx_phy_ctrl2[12].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_12_clk_shift_start_12_qs)
+    .qs     (tx_phy_ctrl2_12_qs)
   );
-
-
-  // F[clk_shift_end_12]: 10:0
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl2_12_clk_shift_end_12 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl2_12_clk_shift_end_12_we),
-    .wd     (tx_phy_ctrl2_12_clk_shift_end_12_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[12].clk_shift_end.q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl2_12_clk_shift_end_12_qs)
-  );
-
 
   // Subregister 13 of Multireg tx_phy_ctrl2
   // R[tx_phy_ctrl2_13]: V(False)
 
-  // F[clk_shift_start_13]: 10:0
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_13_clk_shift_start_13 (
+  ) u_tx_phy_ctrl2_13 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_13_clk_shift_start_13_we),
-    .wd     (tx_phy_ctrl2_13_clk_shift_start_13_wd),
+    .we     (tx_phy_ctrl2_13_we),
+    .wd     (tx_phy_ctrl2_13_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2758,54 +2393,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[13].clk_shift_start.q ),
+    .q      (reg2hw.tx_phy_ctrl2[13].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_13_clk_shift_start_13_qs)
+    .qs     (tx_phy_ctrl2_13_qs)
   );
-
-
-  // F[clk_shift_end_13]: 10:0
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl2_13_clk_shift_end_13 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl2_13_clk_shift_end_13_we),
-    .wd     (tx_phy_ctrl2_13_clk_shift_end_13_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[13].clk_shift_end.q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl2_13_clk_shift_end_13_qs)
-  );
-
 
   // Subregister 14 of Multireg tx_phy_ctrl2
   // R[tx_phy_ctrl2_14]: V(False)
 
-  // F[clk_shift_start_14]: 10:0
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_14_clk_shift_start_14 (
+  ) u_tx_phy_ctrl2_14 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_14_clk_shift_start_14_we),
-    .wd     (tx_phy_ctrl2_14_clk_shift_start_14_wd),
+    .we     (tx_phy_ctrl2_14_we),
+    .wd     (tx_phy_ctrl2_14_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2813,54 +2420,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[14].clk_shift_start.q ),
+    .q      (reg2hw.tx_phy_ctrl2[14].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_14_clk_shift_start_14_qs)
+    .qs     (tx_phy_ctrl2_14_qs)
   );
-
-
-  // F[clk_shift_end_14]: 10:0
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl2_14_clk_shift_end_14 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl2_14_clk_shift_end_14_we),
-    .wd     (tx_phy_ctrl2_14_clk_shift_end_14_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[14].clk_shift_end.q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl2_14_clk_shift_end_14_qs)
-  );
-
 
   // Subregister 15 of Multireg tx_phy_ctrl2
   // R[tx_phy_ctrl2_15]: V(False)
 
-  // F[clk_shift_start_15]: 10:0
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_15_clk_shift_start_15 (
+  ) u_tx_phy_ctrl2_15 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_15_clk_shift_start_15_we),
-    .wd     (tx_phy_ctrl2_15_clk_shift_start_15_wd),
+    .we     (tx_phy_ctrl2_15_we),
+    .wd     (tx_phy_ctrl2_15_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2868,54 +2447,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[15].clk_shift_start.q ),
+    .q      (reg2hw.tx_phy_ctrl2[15].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_15_clk_shift_start_15_qs)
+    .qs     (tx_phy_ctrl2_15_qs)
   );
-
-
-  // F[clk_shift_end_15]: 10:0
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl2_15_clk_shift_end_15 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl2_15_clk_shift_end_15_we),
-    .wd     (tx_phy_ctrl2_15_clk_shift_end_15_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[15].clk_shift_end.q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl2_15_clk_shift_end_15_qs)
-  );
-
 
   // Subregister 16 of Multireg tx_phy_ctrl2
   // R[tx_phy_ctrl2_16]: V(False)
 
-  // F[clk_shift_start_16]: 10:0
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_16_clk_shift_start_16 (
+  ) u_tx_phy_ctrl2_16 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_16_clk_shift_start_16_we),
-    .wd     (tx_phy_ctrl2_16_clk_shift_start_16_wd),
+    .we     (tx_phy_ctrl2_16_we),
+    .wd     (tx_phy_ctrl2_16_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2923,54 +2474,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[16].clk_shift_start.q ),
+    .q      (reg2hw.tx_phy_ctrl2[16].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_16_clk_shift_start_16_qs)
+    .qs     (tx_phy_ctrl2_16_qs)
   );
-
-
-  // F[clk_shift_end_16]: 10:0
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl2_16_clk_shift_end_16 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl2_16_clk_shift_end_16_we),
-    .wd     (tx_phy_ctrl2_16_clk_shift_end_16_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[16].clk_shift_end.q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl2_16_clk_shift_end_16_qs)
-  );
-
 
   // Subregister 17 of Multireg tx_phy_ctrl2
   // R[tx_phy_ctrl2_17]: V(False)
 
-  // F[clk_shift_start_17]: 10:0
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_17_clk_shift_start_17 (
+  ) u_tx_phy_ctrl2_17 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_17_clk_shift_start_17_we),
-    .wd     (tx_phy_ctrl2_17_clk_shift_start_17_wd),
+    .we     (tx_phy_ctrl2_17_we),
+    .wd     (tx_phy_ctrl2_17_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2978,54 +2501,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[17].clk_shift_start.q ),
+    .q      (reg2hw.tx_phy_ctrl2[17].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_17_clk_shift_start_17_qs)
+    .qs     (tx_phy_ctrl2_17_qs)
   );
-
-
-  // F[clk_shift_end_17]: 10:0
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl2_17_clk_shift_end_17 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl2_17_clk_shift_end_17_we),
-    .wd     (tx_phy_ctrl2_17_clk_shift_end_17_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[17].clk_shift_end.q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl2_17_clk_shift_end_17_qs)
-  );
-
 
   // Subregister 18 of Multireg tx_phy_ctrl2
   // R[tx_phy_ctrl2_18]: V(False)
 
-  // F[clk_shift_start_18]: 10:0
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_18_clk_shift_start_18 (
+  ) u_tx_phy_ctrl2_18 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_18_clk_shift_start_18_we),
-    .wd     (tx_phy_ctrl2_18_clk_shift_start_18_wd),
+    .we     (tx_phy_ctrl2_18_we),
+    .wd     (tx_phy_ctrl2_18_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3033,54 +2528,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[18].clk_shift_start.q ),
+    .q      (reg2hw.tx_phy_ctrl2[18].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_18_clk_shift_start_18_qs)
+    .qs     (tx_phy_ctrl2_18_qs)
   );
-
-
-  // F[clk_shift_end_18]: 10:0
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl2_18_clk_shift_end_18 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl2_18_clk_shift_end_18_we),
-    .wd     (tx_phy_ctrl2_18_clk_shift_end_18_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[18].clk_shift_end.q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl2_18_clk_shift_end_18_qs)
-  );
-
 
   // Subregister 19 of Multireg tx_phy_ctrl2
   // R[tx_phy_ctrl2_19]: V(False)
 
-  // F[clk_shift_start_19]: 10:0
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_19_clk_shift_start_19 (
+  ) u_tx_phy_ctrl2_19 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_19_clk_shift_start_19_we),
-    .wd     (tx_phy_ctrl2_19_clk_shift_start_19_wd),
+    .we     (tx_phy_ctrl2_19_we),
+    .wd     (tx_phy_ctrl2_19_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3088,54 +2555,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[19].clk_shift_start.q ),
+    .q      (reg2hw.tx_phy_ctrl2[19].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_19_clk_shift_start_19_qs)
+    .qs     (tx_phy_ctrl2_19_qs)
   );
-
-
-  // F[clk_shift_end_19]: 10:0
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl2_19_clk_shift_end_19 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl2_19_clk_shift_end_19_we),
-    .wd     (tx_phy_ctrl2_19_clk_shift_end_19_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[19].clk_shift_end.q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl2_19_clk_shift_end_19_qs)
-  );
-
 
   // Subregister 20 of Multireg tx_phy_ctrl2
   // R[tx_phy_ctrl2_20]: V(False)
 
-  // F[clk_shift_start_20]: 10:0
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_20_clk_shift_start_20 (
+  ) u_tx_phy_ctrl2_20 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_20_clk_shift_start_20_we),
-    .wd     (tx_phy_ctrl2_20_clk_shift_start_20_wd),
+    .we     (tx_phy_ctrl2_20_we),
+    .wd     (tx_phy_ctrl2_20_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3143,54 +2582,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[20].clk_shift_start.q ),
+    .q      (reg2hw.tx_phy_ctrl2[20].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_20_clk_shift_start_20_qs)
+    .qs     (tx_phy_ctrl2_20_qs)
   );
-
-
-  // F[clk_shift_end_20]: 10:0
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl2_20_clk_shift_end_20 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl2_20_clk_shift_end_20_we),
-    .wd     (tx_phy_ctrl2_20_clk_shift_end_20_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[20].clk_shift_end.q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl2_20_clk_shift_end_20_qs)
-  );
-
 
   // Subregister 21 of Multireg tx_phy_ctrl2
   // R[tx_phy_ctrl2_21]: V(False)
 
-  // F[clk_shift_start_21]: 10:0
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_21_clk_shift_start_21 (
+  ) u_tx_phy_ctrl2_21 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_21_clk_shift_start_21_we),
-    .wd     (tx_phy_ctrl2_21_clk_shift_start_21_wd),
+    .we     (tx_phy_ctrl2_21_we),
+    .wd     (tx_phy_ctrl2_21_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3198,54 +2609,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[21].clk_shift_start.q ),
+    .q      (reg2hw.tx_phy_ctrl2[21].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_21_clk_shift_start_21_qs)
+    .qs     (tx_phy_ctrl2_21_qs)
   );
-
-
-  // F[clk_shift_end_21]: 10:0
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl2_21_clk_shift_end_21 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl2_21_clk_shift_end_21_we),
-    .wd     (tx_phy_ctrl2_21_clk_shift_end_21_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[21].clk_shift_end.q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl2_21_clk_shift_end_21_qs)
-  );
-
 
   // Subregister 22 of Multireg tx_phy_ctrl2
   // R[tx_phy_ctrl2_22]: V(False)
 
-  // F[clk_shift_start_22]: 10:0
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_22_clk_shift_start_22 (
+  ) u_tx_phy_ctrl2_22 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_22_clk_shift_start_22_we),
-    .wd     (tx_phy_ctrl2_22_clk_shift_start_22_wd),
+    .we     (tx_phy_ctrl2_22_we),
+    .wd     (tx_phy_ctrl2_22_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3253,54 +2636,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[22].clk_shift_start.q ),
+    .q      (reg2hw.tx_phy_ctrl2[22].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_22_clk_shift_start_22_qs)
+    .qs     (tx_phy_ctrl2_22_qs)
   );
-
-
-  // F[clk_shift_end_22]: 10:0
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl2_22_clk_shift_end_22 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl2_22_clk_shift_end_22_we),
-    .wd     (tx_phy_ctrl2_22_clk_shift_end_22_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[22].clk_shift_end.q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl2_22_clk_shift_end_22_qs)
-  );
-
 
   // Subregister 23 of Multireg tx_phy_ctrl2
   // R[tx_phy_ctrl2_23]: V(False)
 
-  // F[clk_shift_start_23]: 10:0
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_23_clk_shift_start_23 (
+  ) u_tx_phy_ctrl2_23 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_23_clk_shift_start_23_we),
-    .wd     (tx_phy_ctrl2_23_clk_shift_start_23_wd),
+    .we     (tx_phy_ctrl2_23_we),
+    .wd     (tx_phy_ctrl2_23_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3308,54 +2663,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[23].clk_shift_start.q ),
+    .q      (reg2hw.tx_phy_ctrl2[23].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_23_clk_shift_start_23_qs)
+    .qs     (tx_phy_ctrl2_23_qs)
   );
-
-
-  // F[clk_shift_end_23]: 10:0
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl2_23_clk_shift_end_23 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl2_23_clk_shift_end_23_we),
-    .wd     (tx_phy_ctrl2_23_clk_shift_end_23_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[23].clk_shift_end.q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl2_23_clk_shift_end_23_qs)
-  );
-
 
   // Subregister 24 of Multireg tx_phy_ctrl2
   // R[tx_phy_ctrl2_24]: V(False)
 
-  // F[clk_shift_start_24]: 10:0
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_24_clk_shift_start_24 (
+  ) u_tx_phy_ctrl2_24 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_24_clk_shift_start_24_we),
-    .wd     (tx_phy_ctrl2_24_clk_shift_start_24_wd),
+    .we     (tx_phy_ctrl2_24_we),
+    .wd     (tx_phy_ctrl2_24_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3363,54 +2690,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[24].clk_shift_start.q ),
+    .q      (reg2hw.tx_phy_ctrl2[24].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_24_clk_shift_start_24_qs)
+    .qs     (tx_phy_ctrl2_24_qs)
   );
-
-
-  // F[clk_shift_end_24]: 10:0
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl2_24_clk_shift_end_24 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl2_24_clk_shift_end_24_we),
-    .wd     (tx_phy_ctrl2_24_clk_shift_end_24_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[24].clk_shift_end.q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl2_24_clk_shift_end_24_qs)
-  );
-
 
   // Subregister 25 of Multireg tx_phy_ctrl2
   // R[tx_phy_ctrl2_25]: V(False)
 
-  // F[clk_shift_start_25]: 10:0
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_25_clk_shift_start_25 (
+  ) u_tx_phy_ctrl2_25 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_25_clk_shift_start_25_we),
-    .wd     (tx_phy_ctrl2_25_clk_shift_start_25_wd),
+    .we     (tx_phy_ctrl2_25_we),
+    .wd     (tx_phy_ctrl2_25_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3418,54 +2717,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[25].clk_shift_start.q ),
+    .q      (reg2hw.tx_phy_ctrl2[25].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_25_clk_shift_start_25_qs)
+    .qs     (tx_phy_ctrl2_25_qs)
   );
-
-
-  // F[clk_shift_end_25]: 10:0
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl2_25_clk_shift_end_25 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl2_25_clk_shift_end_25_we),
-    .wd     (tx_phy_ctrl2_25_clk_shift_end_25_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[25].clk_shift_end.q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl2_25_clk_shift_end_25_qs)
-  );
-
 
   // Subregister 26 of Multireg tx_phy_ctrl2
   // R[tx_phy_ctrl2_26]: V(False)
 
-  // F[clk_shift_start_26]: 10:0
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_26_clk_shift_start_26 (
+  ) u_tx_phy_ctrl2_26 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_26_clk_shift_start_26_we),
-    .wd     (tx_phy_ctrl2_26_clk_shift_start_26_wd),
+    .we     (tx_phy_ctrl2_26_we),
+    .wd     (tx_phy_ctrl2_26_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3473,54 +2744,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[26].clk_shift_start.q ),
+    .q      (reg2hw.tx_phy_ctrl2[26].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_26_clk_shift_start_26_qs)
+    .qs     (tx_phy_ctrl2_26_qs)
   );
-
-
-  // F[clk_shift_end_26]: 10:0
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl2_26_clk_shift_end_26 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl2_26_clk_shift_end_26_we),
-    .wd     (tx_phy_ctrl2_26_clk_shift_end_26_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[26].clk_shift_end.q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl2_26_clk_shift_end_26_qs)
-  );
-
 
   // Subregister 27 of Multireg tx_phy_ctrl2
   // R[tx_phy_ctrl2_27]: V(False)
 
-  // F[clk_shift_start_27]: 10:0
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_27_clk_shift_start_27 (
+  ) u_tx_phy_ctrl2_27 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_27_clk_shift_start_27_we),
-    .wd     (tx_phy_ctrl2_27_clk_shift_start_27_wd),
+    .we     (tx_phy_ctrl2_27_we),
+    .wd     (tx_phy_ctrl2_27_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3528,54 +2771,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[27].clk_shift_start.q ),
+    .q      (reg2hw.tx_phy_ctrl2[27].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_27_clk_shift_start_27_qs)
+    .qs     (tx_phy_ctrl2_27_qs)
   );
-
-
-  // F[clk_shift_end_27]: 10:0
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl2_27_clk_shift_end_27 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl2_27_clk_shift_end_27_we),
-    .wd     (tx_phy_ctrl2_27_clk_shift_end_27_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[27].clk_shift_end.q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl2_27_clk_shift_end_27_qs)
-  );
-
 
   // Subregister 28 of Multireg tx_phy_ctrl2
   // R[tx_phy_ctrl2_28]: V(False)
 
-  // F[clk_shift_start_28]: 10:0
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_28_clk_shift_start_28 (
+  ) u_tx_phy_ctrl2_28 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_28_clk_shift_start_28_we),
-    .wd     (tx_phy_ctrl2_28_clk_shift_start_28_wd),
+    .we     (tx_phy_ctrl2_28_we),
+    .wd     (tx_phy_ctrl2_28_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3583,54 +2798,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[28].clk_shift_start.q ),
+    .q      (reg2hw.tx_phy_ctrl2[28].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_28_clk_shift_start_28_qs)
+    .qs     (tx_phy_ctrl2_28_qs)
   );
-
-
-  // F[clk_shift_end_28]: 10:0
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl2_28_clk_shift_end_28 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl2_28_clk_shift_end_28_we),
-    .wd     (tx_phy_ctrl2_28_clk_shift_end_28_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[28].clk_shift_end.q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl2_28_clk_shift_end_28_qs)
-  );
-
 
   // Subregister 29 of Multireg tx_phy_ctrl2
   // R[tx_phy_ctrl2_29]: V(False)
 
-  // F[clk_shift_start_29]: 10:0
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_29_clk_shift_start_29 (
+  ) u_tx_phy_ctrl2_29 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_29_clk_shift_start_29_we),
-    .wd     (tx_phy_ctrl2_29_clk_shift_start_29_wd),
+    .we     (tx_phy_ctrl2_29_we),
+    .wd     (tx_phy_ctrl2_29_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3638,54 +2825,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[29].clk_shift_start.q ),
+    .q      (reg2hw.tx_phy_ctrl2[29].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_29_clk_shift_start_29_qs)
+    .qs     (tx_phy_ctrl2_29_qs)
   );
-
-
-  // F[clk_shift_end_29]: 10:0
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl2_29_clk_shift_end_29 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl2_29_clk_shift_end_29_we),
-    .wd     (tx_phy_ctrl2_29_clk_shift_end_29_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[29].clk_shift_end.q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl2_29_clk_shift_end_29_qs)
-  );
-
 
   // Subregister 30 of Multireg tx_phy_ctrl2
   // R[tx_phy_ctrl2_30]: V(False)
 
-  // F[clk_shift_start_30]: 10:0
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_30_clk_shift_start_30 (
+  ) u_tx_phy_ctrl2_30 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_30_clk_shift_start_30_we),
-    .wd     (tx_phy_ctrl2_30_clk_shift_start_30_wd),
+    .we     (tx_phy_ctrl2_30_we),
+    .wd     (tx_phy_ctrl2_30_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3693,54 +2852,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[30].clk_shift_start.q ),
+    .q      (reg2hw.tx_phy_ctrl2[30].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_30_clk_shift_start_30_qs)
+    .qs     (tx_phy_ctrl2_30_qs)
   );
-
-
-  // F[clk_shift_end_30]: 10:0
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl2_30_clk_shift_end_30 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl2_30_clk_shift_end_30_we),
-    .wd     (tx_phy_ctrl2_30_clk_shift_end_30_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[30].clk_shift_end.q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl2_30_clk_shift_end_30_qs)
-  );
-
 
   // Subregister 31 of Multireg tx_phy_ctrl2
   // R[tx_phy_ctrl2_31]: V(False)
 
-  // F[clk_shift_start_31]: 10:0
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_31_clk_shift_start_31 (
+  ) u_tx_phy_ctrl2_31 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_31_clk_shift_start_31_we),
-    .wd     (tx_phy_ctrl2_31_clk_shift_start_31_wd),
+    .we     (tx_phy_ctrl2_31_we),
+    .wd     (tx_phy_ctrl2_31_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3748,54 +2879,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[31].clk_shift_start.q ),
+    .q      (reg2hw.tx_phy_ctrl2[31].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_31_clk_shift_start_31_qs)
+    .qs     (tx_phy_ctrl2_31_qs)
   );
-
-
-  // F[clk_shift_end_31]: 10:0
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl2_31_clk_shift_end_31 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl2_31_clk_shift_end_31_we),
-    .wd     (tx_phy_ctrl2_31_clk_shift_end_31_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[31].clk_shift_end.q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl2_31_clk_shift_end_31_qs)
-  );
-
 
   // Subregister 32 of Multireg tx_phy_ctrl2
   // R[tx_phy_ctrl2_32]: V(False)
 
-  // F[clk_shift_start_32]: 10:0
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_32_clk_shift_start_32 (
+  ) u_tx_phy_ctrl2_32 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_32_clk_shift_start_32_we),
-    .wd     (tx_phy_ctrl2_32_clk_shift_start_32_wd),
+    .we     (tx_phy_ctrl2_32_we),
+    .wd     (tx_phy_ctrl2_32_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3803,54 +2906,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[32].clk_shift_start.q ),
+    .q      (reg2hw.tx_phy_ctrl2[32].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_32_clk_shift_start_32_qs)
+    .qs     (tx_phy_ctrl2_32_qs)
   );
-
-
-  // F[clk_shift_end_32]: 10:0
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl2_32_clk_shift_end_32 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl2_32_clk_shift_end_32_we),
-    .wd     (tx_phy_ctrl2_32_clk_shift_end_32_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[32].clk_shift_end.q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl2_32_clk_shift_end_32_qs)
-  );
-
 
   // Subregister 33 of Multireg tx_phy_ctrl2
   // R[tx_phy_ctrl2_33]: V(False)
 
-  // F[clk_shift_start_33]: 10:0
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_33_clk_shift_start_33 (
+  ) u_tx_phy_ctrl2_33 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_33_clk_shift_start_33_we),
-    .wd     (tx_phy_ctrl2_33_clk_shift_start_33_wd),
+    .we     (tx_phy_ctrl2_33_we),
+    .wd     (tx_phy_ctrl2_33_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3858,54 +2933,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[33].clk_shift_start.q ),
+    .q      (reg2hw.tx_phy_ctrl2[33].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_33_clk_shift_start_33_qs)
+    .qs     (tx_phy_ctrl2_33_qs)
   );
-
-
-  // F[clk_shift_end_33]: 10:0
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl2_33_clk_shift_end_33 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl2_33_clk_shift_end_33_we),
-    .wd     (tx_phy_ctrl2_33_clk_shift_end_33_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[33].clk_shift_end.q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl2_33_clk_shift_end_33_qs)
-  );
-
 
   // Subregister 34 of Multireg tx_phy_ctrl2
   // R[tx_phy_ctrl2_34]: V(False)
 
-  // F[clk_shift_start_34]: 10:0
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_34_clk_shift_start_34 (
+  ) u_tx_phy_ctrl2_34 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_34_clk_shift_start_34_we),
-    .wd     (tx_phy_ctrl2_34_clk_shift_start_34_wd),
+    .we     (tx_phy_ctrl2_34_we),
+    .wd     (tx_phy_ctrl2_34_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3913,54 +2960,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[34].clk_shift_start.q ),
+    .q      (reg2hw.tx_phy_ctrl2[34].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_34_clk_shift_start_34_qs)
+    .qs     (tx_phy_ctrl2_34_qs)
   );
-
-
-  // F[clk_shift_end_34]: 10:0
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl2_34_clk_shift_end_34 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl2_34_clk_shift_end_34_we),
-    .wd     (tx_phy_ctrl2_34_clk_shift_end_34_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[34].clk_shift_end.q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl2_34_clk_shift_end_34_qs)
-  );
-
 
   // Subregister 35 of Multireg tx_phy_ctrl2
   // R[tx_phy_ctrl2_35]: V(False)
 
-  // F[clk_shift_start_35]: 10:0
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_35_clk_shift_start_35 (
+  ) u_tx_phy_ctrl2_35 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_35_clk_shift_start_35_we),
-    .wd     (tx_phy_ctrl2_35_clk_shift_start_35_wd),
+    .we     (tx_phy_ctrl2_35_we),
+    .wd     (tx_phy_ctrl2_35_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3968,54 +2987,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[35].clk_shift_start.q ),
+    .q      (reg2hw.tx_phy_ctrl2[35].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_35_clk_shift_start_35_qs)
+    .qs     (tx_phy_ctrl2_35_qs)
   );
-
-
-  // F[clk_shift_end_35]: 10:0
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl2_35_clk_shift_end_35 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl2_35_clk_shift_end_35_we),
-    .wd     (tx_phy_ctrl2_35_clk_shift_end_35_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[35].clk_shift_end.q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl2_35_clk_shift_end_35_qs)
-  );
-
 
   // Subregister 36 of Multireg tx_phy_ctrl2
   // R[tx_phy_ctrl2_36]: V(False)
 
-  // F[clk_shift_start_36]: 10:0
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_36_clk_shift_start_36 (
+  ) u_tx_phy_ctrl2_36 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_36_clk_shift_start_36_we),
-    .wd     (tx_phy_ctrl2_36_clk_shift_start_36_wd),
+    .we     (tx_phy_ctrl2_36_we),
+    .wd     (tx_phy_ctrl2_36_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4023,54 +3014,26 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[36].clk_shift_start.q ),
+    .q      (reg2hw.tx_phy_ctrl2[36].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_36_clk_shift_start_36_qs)
+    .qs     (tx_phy_ctrl2_36_qs)
   );
-
-
-  // F[clk_shift_end_36]: 10:0
-  prim_subreg #(
-    .DW      (11),
-    .SWACCESS("RW"),
-    .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl2_36_clk_shift_end_36 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (tx_phy_ctrl2_36_clk_shift_end_36_we),
-    .wd     (tx_phy_ctrl2_36_clk_shift_end_36_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[36].clk_shift_end.q ),
-
-    // to register interface (read)
-    .qs     (tx_phy_ctrl2_36_clk_shift_end_36_qs)
-  );
-
 
   // Subregister 37 of Multireg tx_phy_ctrl2
   // R[tx_phy_ctrl2_37]: V(False)
 
-  // F[clk_shift_start_37]: 10:0
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_37_clk_shift_start_37 (
+  ) u_tx_phy_ctrl2_37 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_37_clk_shift_start_37_we),
-    .wd     (tx_phy_ctrl2_37_clk_shift_start_37_wd),
+    .we     (tx_phy_ctrl2_37_we),
+    .wd     (tx_phy_ctrl2_37_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4078,25 +3041,28 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[37].clk_shift_start.q ),
+    .q      (reg2hw.tx_phy_ctrl2[37].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_37_clk_shift_start_37_qs)
+    .qs     (tx_phy_ctrl2_37_qs)
   );
 
 
-  // F[clk_shift_end_37]: 10:0
+
+  // Subregister 0 of Multireg tx_phy_ctrl3
+  // R[tx_phy_ctrl3_0]: V(False)
+
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl2_37_clk_shift_end_37 (
+  ) u_tx_phy_ctrl3_0 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_37_clk_shift_end_37_we),
-    .wd     (tx_phy_ctrl2_37_clk_shift_end_37_wd),
+    .we     (tx_phy_ctrl3_0_we),
+    .wd     (tx_phy_ctrl3_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4104,12 +3070,1010 @@ module serial_link_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[37].clk_shift_end.q ),
+    .q      (reg2hw.tx_phy_ctrl3[0].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_37_clk_shift_end_37_qs)
+    .qs     (tx_phy_ctrl3_0_qs)
   );
 
+  // Subregister 1 of Multireg tx_phy_ctrl3
+  // R[tx_phy_ctrl3_1]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h6)
+  ) u_tx_phy_ctrl3_1 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_ctrl3_1_we),
+    .wd     (tx_phy_ctrl3_1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_ctrl3[1].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_ctrl3_1_qs)
+  );
+
+  // Subregister 2 of Multireg tx_phy_ctrl3
+  // R[tx_phy_ctrl3_2]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h6)
+  ) u_tx_phy_ctrl3_2 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_ctrl3_2_we),
+    .wd     (tx_phy_ctrl3_2_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_ctrl3[2].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_ctrl3_2_qs)
+  );
+
+  // Subregister 3 of Multireg tx_phy_ctrl3
+  // R[tx_phy_ctrl3_3]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h6)
+  ) u_tx_phy_ctrl3_3 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_ctrl3_3_we),
+    .wd     (tx_phy_ctrl3_3_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_ctrl3[3].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_ctrl3_3_qs)
+  );
+
+  // Subregister 4 of Multireg tx_phy_ctrl3
+  // R[tx_phy_ctrl3_4]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h6)
+  ) u_tx_phy_ctrl3_4 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_ctrl3_4_we),
+    .wd     (tx_phy_ctrl3_4_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_ctrl3[4].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_ctrl3_4_qs)
+  );
+
+  // Subregister 5 of Multireg tx_phy_ctrl3
+  // R[tx_phy_ctrl3_5]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h6)
+  ) u_tx_phy_ctrl3_5 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_ctrl3_5_we),
+    .wd     (tx_phy_ctrl3_5_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_ctrl3[5].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_ctrl3_5_qs)
+  );
+
+  // Subregister 6 of Multireg tx_phy_ctrl3
+  // R[tx_phy_ctrl3_6]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h6)
+  ) u_tx_phy_ctrl3_6 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_ctrl3_6_we),
+    .wd     (tx_phy_ctrl3_6_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_ctrl3[6].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_ctrl3_6_qs)
+  );
+
+  // Subregister 7 of Multireg tx_phy_ctrl3
+  // R[tx_phy_ctrl3_7]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h6)
+  ) u_tx_phy_ctrl3_7 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_ctrl3_7_we),
+    .wd     (tx_phy_ctrl3_7_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_ctrl3[7].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_ctrl3_7_qs)
+  );
+
+  // Subregister 8 of Multireg tx_phy_ctrl3
+  // R[tx_phy_ctrl3_8]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h6)
+  ) u_tx_phy_ctrl3_8 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_ctrl3_8_we),
+    .wd     (tx_phy_ctrl3_8_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_ctrl3[8].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_ctrl3_8_qs)
+  );
+
+  // Subregister 9 of Multireg tx_phy_ctrl3
+  // R[tx_phy_ctrl3_9]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h6)
+  ) u_tx_phy_ctrl3_9 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_ctrl3_9_we),
+    .wd     (tx_phy_ctrl3_9_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_ctrl3[9].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_ctrl3_9_qs)
+  );
+
+  // Subregister 10 of Multireg tx_phy_ctrl3
+  // R[tx_phy_ctrl3_10]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h6)
+  ) u_tx_phy_ctrl3_10 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_ctrl3_10_we),
+    .wd     (tx_phy_ctrl3_10_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_ctrl3[10].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_ctrl3_10_qs)
+  );
+
+  // Subregister 11 of Multireg tx_phy_ctrl3
+  // R[tx_phy_ctrl3_11]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h6)
+  ) u_tx_phy_ctrl3_11 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_ctrl3_11_we),
+    .wd     (tx_phy_ctrl3_11_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_ctrl3[11].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_ctrl3_11_qs)
+  );
+
+  // Subregister 12 of Multireg tx_phy_ctrl3
+  // R[tx_phy_ctrl3_12]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h6)
+  ) u_tx_phy_ctrl3_12 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_ctrl3_12_we),
+    .wd     (tx_phy_ctrl3_12_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_ctrl3[12].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_ctrl3_12_qs)
+  );
+
+  // Subregister 13 of Multireg tx_phy_ctrl3
+  // R[tx_phy_ctrl3_13]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h6)
+  ) u_tx_phy_ctrl3_13 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_ctrl3_13_we),
+    .wd     (tx_phy_ctrl3_13_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_ctrl3[13].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_ctrl3_13_qs)
+  );
+
+  // Subregister 14 of Multireg tx_phy_ctrl3
+  // R[tx_phy_ctrl3_14]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h6)
+  ) u_tx_phy_ctrl3_14 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_ctrl3_14_we),
+    .wd     (tx_phy_ctrl3_14_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_ctrl3[14].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_ctrl3_14_qs)
+  );
+
+  // Subregister 15 of Multireg tx_phy_ctrl3
+  // R[tx_phy_ctrl3_15]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h6)
+  ) u_tx_phy_ctrl3_15 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_ctrl3_15_we),
+    .wd     (tx_phy_ctrl3_15_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_ctrl3[15].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_ctrl3_15_qs)
+  );
+
+  // Subregister 16 of Multireg tx_phy_ctrl3
+  // R[tx_phy_ctrl3_16]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h6)
+  ) u_tx_phy_ctrl3_16 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_ctrl3_16_we),
+    .wd     (tx_phy_ctrl3_16_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_ctrl3[16].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_ctrl3_16_qs)
+  );
+
+  // Subregister 17 of Multireg tx_phy_ctrl3
+  // R[tx_phy_ctrl3_17]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h6)
+  ) u_tx_phy_ctrl3_17 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_ctrl3_17_we),
+    .wd     (tx_phy_ctrl3_17_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_ctrl3[17].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_ctrl3_17_qs)
+  );
+
+  // Subregister 18 of Multireg tx_phy_ctrl3
+  // R[tx_phy_ctrl3_18]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h6)
+  ) u_tx_phy_ctrl3_18 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_ctrl3_18_we),
+    .wd     (tx_phy_ctrl3_18_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_ctrl3[18].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_ctrl3_18_qs)
+  );
+
+  // Subregister 19 of Multireg tx_phy_ctrl3
+  // R[tx_phy_ctrl3_19]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h6)
+  ) u_tx_phy_ctrl3_19 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_ctrl3_19_we),
+    .wd     (tx_phy_ctrl3_19_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_ctrl3[19].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_ctrl3_19_qs)
+  );
+
+  // Subregister 20 of Multireg tx_phy_ctrl3
+  // R[tx_phy_ctrl3_20]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h6)
+  ) u_tx_phy_ctrl3_20 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_ctrl3_20_we),
+    .wd     (tx_phy_ctrl3_20_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_ctrl3[20].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_ctrl3_20_qs)
+  );
+
+  // Subregister 21 of Multireg tx_phy_ctrl3
+  // R[tx_phy_ctrl3_21]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h6)
+  ) u_tx_phy_ctrl3_21 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_ctrl3_21_we),
+    .wd     (tx_phy_ctrl3_21_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_ctrl3[21].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_ctrl3_21_qs)
+  );
+
+  // Subregister 22 of Multireg tx_phy_ctrl3
+  // R[tx_phy_ctrl3_22]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h6)
+  ) u_tx_phy_ctrl3_22 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_ctrl3_22_we),
+    .wd     (tx_phy_ctrl3_22_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_ctrl3[22].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_ctrl3_22_qs)
+  );
+
+  // Subregister 23 of Multireg tx_phy_ctrl3
+  // R[tx_phy_ctrl3_23]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h6)
+  ) u_tx_phy_ctrl3_23 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_ctrl3_23_we),
+    .wd     (tx_phy_ctrl3_23_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_ctrl3[23].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_ctrl3_23_qs)
+  );
+
+  // Subregister 24 of Multireg tx_phy_ctrl3
+  // R[tx_phy_ctrl3_24]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h6)
+  ) u_tx_phy_ctrl3_24 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_ctrl3_24_we),
+    .wd     (tx_phy_ctrl3_24_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_ctrl3[24].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_ctrl3_24_qs)
+  );
+
+  // Subregister 25 of Multireg tx_phy_ctrl3
+  // R[tx_phy_ctrl3_25]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h6)
+  ) u_tx_phy_ctrl3_25 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_ctrl3_25_we),
+    .wd     (tx_phy_ctrl3_25_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_ctrl3[25].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_ctrl3_25_qs)
+  );
+
+  // Subregister 26 of Multireg tx_phy_ctrl3
+  // R[tx_phy_ctrl3_26]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h6)
+  ) u_tx_phy_ctrl3_26 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_ctrl3_26_we),
+    .wd     (tx_phy_ctrl3_26_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_ctrl3[26].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_ctrl3_26_qs)
+  );
+
+  // Subregister 27 of Multireg tx_phy_ctrl3
+  // R[tx_phy_ctrl3_27]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h6)
+  ) u_tx_phy_ctrl3_27 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_ctrl3_27_we),
+    .wd     (tx_phy_ctrl3_27_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_ctrl3[27].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_ctrl3_27_qs)
+  );
+
+  // Subregister 28 of Multireg tx_phy_ctrl3
+  // R[tx_phy_ctrl3_28]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h6)
+  ) u_tx_phy_ctrl3_28 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_ctrl3_28_we),
+    .wd     (tx_phy_ctrl3_28_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_ctrl3[28].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_ctrl3_28_qs)
+  );
+
+  // Subregister 29 of Multireg tx_phy_ctrl3
+  // R[tx_phy_ctrl3_29]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h6)
+  ) u_tx_phy_ctrl3_29 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_ctrl3_29_we),
+    .wd     (tx_phy_ctrl3_29_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_ctrl3[29].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_ctrl3_29_qs)
+  );
+
+  // Subregister 30 of Multireg tx_phy_ctrl3
+  // R[tx_phy_ctrl3_30]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h6)
+  ) u_tx_phy_ctrl3_30 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_ctrl3_30_we),
+    .wd     (tx_phy_ctrl3_30_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_ctrl3[30].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_ctrl3_30_qs)
+  );
+
+  // Subregister 31 of Multireg tx_phy_ctrl3
+  // R[tx_phy_ctrl3_31]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h6)
+  ) u_tx_phy_ctrl3_31 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_ctrl3_31_we),
+    .wd     (tx_phy_ctrl3_31_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_ctrl3[31].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_ctrl3_31_qs)
+  );
+
+  // Subregister 32 of Multireg tx_phy_ctrl3
+  // R[tx_phy_ctrl3_32]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h6)
+  ) u_tx_phy_ctrl3_32 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_ctrl3_32_we),
+    .wd     (tx_phy_ctrl3_32_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_ctrl3[32].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_ctrl3_32_qs)
+  );
+
+  // Subregister 33 of Multireg tx_phy_ctrl3
+  // R[tx_phy_ctrl3_33]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h6)
+  ) u_tx_phy_ctrl3_33 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_ctrl3_33_we),
+    .wd     (tx_phy_ctrl3_33_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_ctrl3[33].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_ctrl3_33_qs)
+  );
+
+  // Subregister 34 of Multireg tx_phy_ctrl3
+  // R[tx_phy_ctrl3_34]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h6)
+  ) u_tx_phy_ctrl3_34 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_ctrl3_34_we),
+    .wd     (tx_phy_ctrl3_34_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_ctrl3[34].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_ctrl3_34_qs)
+  );
+
+  // Subregister 35 of Multireg tx_phy_ctrl3
+  // R[tx_phy_ctrl3_35]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h6)
+  ) u_tx_phy_ctrl3_35 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_ctrl3_35_we),
+    .wd     (tx_phy_ctrl3_35_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_ctrl3[35].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_ctrl3_35_qs)
+  );
+
+  // Subregister 36 of Multireg tx_phy_ctrl3
+  // R[tx_phy_ctrl3_36]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h6)
+  ) u_tx_phy_ctrl3_36 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_ctrl3_36_we),
+    .wd     (tx_phy_ctrl3_36_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_ctrl3[36].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_ctrl3_36_qs)
+  );
+
+  // Subregister 37 of Multireg tx_phy_ctrl3
+  // R[tx_phy_ctrl3_37]: V(False)
+
+  prim_subreg #(
+    .DW      (11),
+    .SWACCESS("RW"),
+    .RESVAL  (11'h6)
+  ) u_tx_phy_ctrl3_37 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (tx_phy_ctrl3_37_we),
+    .wd     (tx_phy_ctrl3_37_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tx_phy_ctrl3[37].q ),
+
+    // to register interface (read)
+    .qs     (tx_phy_ctrl3_37_qs)
+  );
 
 
   // R[raw_mode_en]: V(False)
@@ -8060,106 +8024,144 @@ module serial_link_reg_top #(
 
 
 
-  logic [96:0] addr_hit;
+  logic [134:0] addr_hit;
   always_comb begin
     addr_hit = '0;
-    addr_hit[ 0] = (reg_addr == SERIAL_LINK_CTRL_OFFSET);
-    addr_hit[ 1] = (reg_addr == SERIAL_LINK_ISOLATED_OFFSET);
-    addr_hit[ 2] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_0_OFFSET);
-    addr_hit[ 3] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_1_OFFSET);
-    addr_hit[ 4] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_2_OFFSET);
-    addr_hit[ 5] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_3_OFFSET);
-    addr_hit[ 6] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_4_OFFSET);
-    addr_hit[ 7] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_5_OFFSET);
-    addr_hit[ 8] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_6_OFFSET);
-    addr_hit[ 9] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_7_OFFSET);
-    addr_hit[10] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_8_OFFSET);
-    addr_hit[11] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_9_OFFSET);
-    addr_hit[12] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_10_OFFSET);
-    addr_hit[13] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_11_OFFSET);
-    addr_hit[14] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_12_OFFSET);
-    addr_hit[15] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_13_OFFSET);
-    addr_hit[16] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_14_OFFSET);
-    addr_hit[17] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_15_OFFSET);
-    addr_hit[18] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_16_OFFSET);
-    addr_hit[19] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_17_OFFSET);
-    addr_hit[20] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_18_OFFSET);
-    addr_hit[21] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_19_OFFSET);
-    addr_hit[22] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_20_OFFSET);
-    addr_hit[23] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_21_OFFSET);
-    addr_hit[24] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_22_OFFSET);
-    addr_hit[25] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_23_OFFSET);
-    addr_hit[26] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_24_OFFSET);
-    addr_hit[27] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_25_OFFSET);
-    addr_hit[28] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_26_OFFSET);
-    addr_hit[29] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_27_OFFSET);
-    addr_hit[30] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_28_OFFSET);
-    addr_hit[31] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_29_OFFSET);
-    addr_hit[32] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_30_OFFSET);
-    addr_hit[33] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_31_OFFSET);
-    addr_hit[34] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_32_OFFSET);
-    addr_hit[35] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_33_OFFSET);
-    addr_hit[36] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_34_OFFSET);
-    addr_hit[37] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_35_OFFSET);
-    addr_hit[38] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_36_OFFSET);
-    addr_hit[39] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_37_OFFSET);
-    addr_hit[40] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_0_OFFSET);
-    addr_hit[41] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_1_OFFSET);
-    addr_hit[42] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_2_OFFSET);
-    addr_hit[43] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_3_OFFSET);
-    addr_hit[44] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_4_OFFSET);
-    addr_hit[45] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_5_OFFSET);
-    addr_hit[46] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_6_OFFSET);
-    addr_hit[47] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_7_OFFSET);
-    addr_hit[48] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_8_OFFSET);
-    addr_hit[49] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_9_OFFSET);
-    addr_hit[50] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_10_OFFSET);
-    addr_hit[51] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_11_OFFSET);
-    addr_hit[52] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_12_OFFSET);
-    addr_hit[53] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_13_OFFSET);
-    addr_hit[54] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_14_OFFSET);
-    addr_hit[55] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_15_OFFSET);
-    addr_hit[56] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_16_OFFSET);
-    addr_hit[57] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_17_OFFSET);
-    addr_hit[58] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_18_OFFSET);
-    addr_hit[59] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_19_OFFSET);
-    addr_hit[60] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_20_OFFSET);
-    addr_hit[61] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_21_OFFSET);
-    addr_hit[62] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_22_OFFSET);
-    addr_hit[63] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_23_OFFSET);
-    addr_hit[64] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_24_OFFSET);
-    addr_hit[65] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_25_OFFSET);
-    addr_hit[66] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_26_OFFSET);
-    addr_hit[67] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_27_OFFSET);
-    addr_hit[68] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_28_OFFSET);
-    addr_hit[69] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_29_OFFSET);
-    addr_hit[70] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_30_OFFSET);
-    addr_hit[71] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_31_OFFSET);
-    addr_hit[72] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_32_OFFSET);
-    addr_hit[73] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_33_OFFSET);
-    addr_hit[74] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_34_OFFSET);
-    addr_hit[75] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_35_OFFSET);
-    addr_hit[76] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_36_OFFSET);
-    addr_hit[77] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_37_OFFSET);
-    addr_hit[78] = (reg_addr == SERIAL_LINK_RAW_MODE_EN_OFFSET);
-    addr_hit[79] = (reg_addr == SERIAL_LINK_RAW_MODE_IN_CH_SEL_OFFSET);
-    addr_hit[80] = (reg_addr == SERIAL_LINK_RAW_MODE_IN_DATA_VALID_0_OFFSET);
-    addr_hit[81] = (reg_addr == SERIAL_LINK_RAW_MODE_IN_DATA_VALID_1_OFFSET);
-    addr_hit[82] = (reg_addr == SERIAL_LINK_RAW_MODE_IN_DATA_OFFSET);
-    addr_hit[83] = (reg_addr == SERIAL_LINK_RAW_MODE_OUT_CH_MASK_0_OFFSET);
-    addr_hit[84] = (reg_addr == SERIAL_LINK_RAW_MODE_OUT_CH_MASK_1_OFFSET);
-    addr_hit[85] = (reg_addr == SERIAL_LINK_RAW_MODE_OUT_DATA_FIFO_OFFSET);
-    addr_hit[86] = (reg_addr == SERIAL_LINK_RAW_MODE_OUT_DATA_FIFO_CTRL_OFFSET);
-    addr_hit[87] = (reg_addr == SERIAL_LINK_RAW_MODE_OUT_EN_OFFSET);
-    addr_hit[88] = (reg_addr == SERIAL_LINK_FLOW_CONTROL_FIFO_CLEAR_OFFSET);
-    addr_hit[89] = (reg_addr == SERIAL_LINK_CHANNEL_ALLOC_TX_CFG_OFFSET);
-    addr_hit[90] = (reg_addr == SERIAL_LINK_CHANNEL_ALLOC_TX_CH_EN_0_OFFSET);
-    addr_hit[91] = (reg_addr == SERIAL_LINK_CHANNEL_ALLOC_TX_CH_EN_1_OFFSET);
-    addr_hit[92] = (reg_addr == SERIAL_LINK_CHANNEL_ALLOC_TX_CTRL_OFFSET);
-    addr_hit[93] = (reg_addr == SERIAL_LINK_CHANNEL_ALLOC_RX_CFG_OFFSET);
-    addr_hit[94] = (reg_addr == SERIAL_LINK_CHANNEL_ALLOC_RX_CTRL_OFFSET);
-    addr_hit[95] = (reg_addr == SERIAL_LINK_CHANNEL_ALLOC_RX_CH_EN_0_OFFSET);
-    addr_hit[96] = (reg_addr == SERIAL_LINK_CHANNEL_ALLOC_RX_CH_EN_1_OFFSET);
+    addr_hit[  0] = (reg_addr == SERIAL_LINK_CTRL_OFFSET);
+    addr_hit[  1] = (reg_addr == SERIAL_LINK_ISOLATED_OFFSET);
+    addr_hit[  2] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_0_OFFSET);
+    addr_hit[  3] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_1_OFFSET);
+    addr_hit[  4] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_2_OFFSET);
+    addr_hit[  5] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_3_OFFSET);
+    addr_hit[  6] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_4_OFFSET);
+    addr_hit[  7] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_5_OFFSET);
+    addr_hit[  8] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_6_OFFSET);
+    addr_hit[  9] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_7_OFFSET);
+    addr_hit[ 10] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_8_OFFSET);
+    addr_hit[ 11] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_9_OFFSET);
+    addr_hit[ 12] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_10_OFFSET);
+    addr_hit[ 13] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_11_OFFSET);
+    addr_hit[ 14] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_12_OFFSET);
+    addr_hit[ 15] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_13_OFFSET);
+    addr_hit[ 16] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_14_OFFSET);
+    addr_hit[ 17] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_15_OFFSET);
+    addr_hit[ 18] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_16_OFFSET);
+    addr_hit[ 19] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_17_OFFSET);
+    addr_hit[ 20] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_18_OFFSET);
+    addr_hit[ 21] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_19_OFFSET);
+    addr_hit[ 22] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_20_OFFSET);
+    addr_hit[ 23] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_21_OFFSET);
+    addr_hit[ 24] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_22_OFFSET);
+    addr_hit[ 25] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_23_OFFSET);
+    addr_hit[ 26] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_24_OFFSET);
+    addr_hit[ 27] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_25_OFFSET);
+    addr_hit[ 28] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_26_OFFSET);
+    addr_hit[ 29] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_27_OFFSET);
+    addr_hit[ 30] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_28_OFFSET);
+    addr_hit[ 31] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_29_OFFSET);
+    addr_hit[ 32] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_30_OFFSET);
+    addr_hit[ 33] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_31_OFFSET);
+    addr_hit[ 34] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_32_OFFSET);
+    addr_hit[ 35] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_33_OFFSET);
+    addr_hit[ 36] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_34_OFFSET);
+    addr_hit[ 37] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_35_OFFSET);
+    addr_hit[ 38] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_36_OFFSET);
+    addr_hit[ 39] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL1_37_OFFSET);
+    addr_hit[ 40] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_0_OFFSET);
+    addr_hit[ 41] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_1_OFFSET);
+    addr_hit[ 42] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_2_OFFSET);
+    addr_hit[ 43] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_3_OFFSET);
+    addr_hit[ 44] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_4_OFFSET);
+    addr_hit[ 45] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_5_OFFSET);
+    addr_hit[ 46] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_6_OFFSET);
+    addr_hit[ 47] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_7_OFFSET);
+    addr_hit[ 48] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_8_OFFSET);
+    addr_hit[ 49] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_9_OFFSET);
+    addr_hit[ 50] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_10_OFFSET);
+    addr_hit[ 51] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_11_OFFSET);
+    addr_hit[ 52] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_12_OFFSET);
+    addr_hit[ 53] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_13_OFFSET);
+    addr_hit[ 54] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_14_OFFSET);
+    addr_hit[ 55] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_15_OFFSET);
+    addr_hit[ 56] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_16_OFFSET);
+    addr_hit[ 57] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_17_OFFSET);
+    addr_hit[ 58] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_18_OFFSET);
+    addr_hit[ 59] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_19_OFFSET);
+    addr_hit[ 60] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_20_OFFSET);
+    addr_hit[ 61] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_21_OFFSET);
+    addr_hit[ 62] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_22_OFFSET);
+    addr_hit[ 63] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_23_OFFSET);
+    addr_hit[ 64] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_24_OFFSET);
+    addr_hit[ 65] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_25_OFFSET);
+    addr_hit[ 66] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_26_OFFSET);
+    addr_hit[ 67] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_27_OFFSET);
+    addr_hit[ 68] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_28_OFFSET);
+    addr_hit[ 69] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_29_OFFSET);
+    addr_hit[ 70] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_30_OFFSET);
+    addr_hit[ 71] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_31_OFFSET);
+    addr_hit[ 72] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_32_OFFSET);
+    addr_hit[ 73] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_33_OFFSET);
+    addr_hit[ 74] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_34_OFFSET);
+    addr_hit[ 75] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_35_OFFSET);
+    addr_hit[ 76] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_36_OFFSET);
+    addr_hit[ 77] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL2_37_OFFSET);
+    addr_hit[ 78] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_0_OFFSET);
+    addr_hit[ 79] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_1_OFFSET);
+    addr_hit[ 80] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_2_OFFSET);
+    addr_hit[ 81] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_3_OFFSET);
+    addr_hit[ 82] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_4_OFFSET);
+    addr_hit[ 83] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_5_OFFSET);
+    addr_hit[ 84] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_6_OFFSET);
+    addr_hit[ 85] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_7_OFFSET);
+    addr_hit[ 86] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_8_OFFSET);
+    addr_hit[ 87] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_9_OFFSET);
+    addr_hit[ 88] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_10_OFFSET);
+    addr_hit[ 89] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_11_OFFSET);
+    addr_hit[ 90] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_12_OFFSET);
+    addr_hit[ 91] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_13_OFFSET);
+    addr_hit[ 92] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_14_OFFSET);
+    addr_hit[ 93] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_15_OFFSET);
+    addr_hit[ 94] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_16_OFFSET);
+    addr_hit[ 95] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_17_OFFSET);
+    addr_hit[ 96] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_18_OFFSET);
+    addr_hit[ 97] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_19_OFFSET);
+    addr_hit[ 98] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_20_OFFSET);
+    addr_hit[ 99] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_21_OFFSET);
+    addr_hit[100] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_22_OFFSET);
+    addr_hit[101] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_23_OFFSET);
+    addr_hit[102] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_24_OFFSET);
+    addr_hit[103] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_25_OFFSET);
+    addr_hit[104] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_26_OFFSET);
+    addr_hit[105] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_27_OFFSET);
+    addr_hit[106] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_28_OFFSET);
+    addr_hit[107] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_29_OFFSET);
+    addr_hit[108] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_30_OFFSET);
+    addr_hit[109] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_31_OFFSET);
+    addr_hit[110] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_32_OFFSET);
+    addr_hit[111] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_33_OFFSET);
+    addr_hit[112] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_34_OFFSET);
+    addr_hit[113] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_35_OFFSET);
+    addr_hit[114] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_36_OFFSET);
+    addr_hit[115] = (reg_addr == SERIAL_LINK_TX_PHY_CTRL3_37_OFFSET);
+    addr_hit[116] = (reg_addr == SERIAL_LINK_RAW_MODE_EN_OFFSET);
+    addr_hit[117] = (reg_addr == SERIAL_LINK_RAW_MODE_IN_CH_SEL_OFFSET);
+    addr_hit[118] = (reg_addr == SERIAL_LINK_RAW_MODE_IN_DATA_VALID_0_OFFSET);
+    addr_hit[119] = (reg_addr == SERIAL_LINK_RAW_MODE_IN_DATA_VALID_1_OFFSET);
+    addr_hit[120] = (reg_addr == SERIAL_LINK_RAW_MODE_IN_DATA_OFFSET);
+    addr_hit[121] = (reg_addr == SERIAL_LINK_RAW_MODE_OUT_CH_MASK_0_OFFSET);
+    addr_hit[122] = (reg_addr == SERIAL_LINK_RAW_MODE_OUT_CH_MASK_1_OFFSET);
+    addr_hit[123] = (reg_addr == SERIAL_LINK_RAW_MODE_OUT_DATA_FIFO_OFFSET);
+    addr_hit[124] = (reg_addr == SERIAL_LINK_RAW_MODE_OUT_DATA_FIFO_CTRL_OFFSET);
+    addr_hit[125] = (reg_addr == SERIAL_LINK_RAW_MODE_OUT_EN_OFFSET);
+    addr_hit[126] = (reg_addr == SERIAL_LINK_FLOW_CONTROL_FIFO_CLEAR_OFFSET);
+    addr_hit[127] = (reg_addr == SERIAL_LINK_CHANNEL_ALLOC_TX_CFG_OFFSET);
+    addr_hit[128] = (reg_addr == SERIAL_LINK_CHANNEL_ALLOC_TX_CH_EN_0_OFFSET);
+    addr_hit[129] = (reg_addr == SERIAL_LINK_CHANNEL_ALLOC_TX_CH_EN_1_OFFSET);
+    addr_hit[130] = (reg_addr == SERIAL_LINK_CHANNEL_ALLOC_TX_CTRL_OFFSET);
+    addr_hit[131] = (reg_addr == SERIAL_LINK_CHANNEL_ALLOC_RX_CFG_OFFSET);
+    addr_hit[132] = (reg_addr == SERIAL_LINK_CHANNEL_ALLOC_RX_CTRL_OFFSET);
+    addr_hit[133] = (reg_addr == SERIAL_LINK_CHANNEL_ALLOC_RX_CH_EN_0_OFFSET);
+    addr_hit[134] = (reg_addr == SERIAL_LINK_CHANNEL_ALLOC_RX_CH_EN_1_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -8167,103 +8169,141 @@ module serial_link_reg_top #(
   // Check sub-word write is permitted
   always_comb begin
     wr_err = (reg_we &
-              ((addr_hit[ 0] & (|(SERIAL_LINK_PERMIT[ 0] & ~reg_be))) |
-               (addr_hit[ 1] & (|(SERIAL_LINK_PERMIT[ 1] & ~reg_be))) |
-               (addr_hit[ 2] & (|(SERIAL_LINK_PERMIT[ 2] & ~reg_be))) |
-               (addr_hit[ 3] & (|(SERIAL_LINK_PERMIT[ 3] & ~reg_be))) |
-               (addr_hit[ 4] & (|(SERIAL_LINK_PERMIT[ 4] & ~reg_be))) |
-               (addr_hit[ 5] & (|(SERIAL_LINK_PERMIT[ 5] & ~reg_be))) |
-               (addr_hit[ 6] & (|(SERIAL_LINK_PERMIT[ 6] & ~reg_be))) |
-               (addr_hit[ 7] & (|(SERIAL_LINK_PERMIT[ 7] & ~reg_be))) |
-               (addr_hit[ 8] & (|(SERIAL_LINK_PERMIT[ 8] & ~reg_be))) |
-               (addr_hit[ 9] & (|(SERIAL_LINK_PERMIT[ 9] & ~reg_be))) |
-               (addr_hit[10] & (|(SERIAL_LINK_PERMIT[10] & ~reg_be))) |
-               (addr_hit[11] & (|(SERIAL_LINK_PERMIT[11] & ~reg_be))) |
-               (addr_hit[12] & (|(SERIAL_LINK_PERMIT[12] & ~reg_be))) |
-               (addr_hit[13] & (|(SERIAL_LINK_PERMIT[13] & ~reg_be))) |
-               (addr_hit[14] & (|(SERIAL_LINK_PERMIT[14] & ~reg_be))) |
-               (addr_hit[15] & (|(SERIAL_LINK_PERMIT[15] & ~reg_be))) |
-               (addr_hit[16] & (|(SERIAL_LINK_PERMIT[16] & ~reg_be))) |
-               (addr_hit[17] & (|(SERIAL_LINK_PERMIT[17] & ~reg_be))) |
-               (addr_hit[18] & (|(SERIAL_LINK_PERMIT[18] & ~reg_be))) |
-               (addr_hit[19] & (|(SERIAL_LINK_PERMIT[19] & ~reg_be))) |
-               (addr_hit[20] & (|(SERIAL_LINK_PERMIT[20] & ~reg_be))) |
-               (addr_hit[21] & (|(SERIAL_LINK_PERMIT[21] & ~reg_be))) |
-               (addr_hit[22] & (|(SERIAL_LINK_PERMIT[22] & ~reg_be))) |
-               (addr_hit[23] & (|(SERIAL_LINK_PERMIT[23] & ~reg_be))) |
-               (addr_hit[24] & (|(SERIAL_LINK_PERMIT[24] & ~reg_be))) |
-               (addr_hit[25] & (|(SERIAL_LINK_PERMIT[25] & ~reg_be))) |
-               (addr_hit[26] & (|(SERIAL_LINK_PERMIT[26] & ~reg_be))) |
-               (addr_hit[27] & (|(SERIAL_LINK_PERMIT[27] & ~reg_be))) |
-               (addr_hit[28] & (|(SERIAL_LINK_PERMIT[28] & ~reg_be))) |
-               (addr_hit[29] & (|(SERIAL_LINK_PERMIT[29] & ~reg_be))) |
-               (addr_hit[30] & (|(SERIAL_LINK_PERMIT[30] & ~reg_be))) |
-               (addr_hit[31] & (|(SERIAL_LINK_PERMIT[31] & ~reg_be))) |
-               (addr_hit[32] & (|(SERIAL_LINK_PERMIT[32] & ~reg_be))) |
-               (addr_hit[33] & (|(SERIAL_LINK_PERMIT[33] & ~reg_be))) |
-               (addr_hit[34] & (|(SERIAL_LINK_PERMIT[34] & ~reg_be))) |
-               (addr_hit[35] & (|(SERIAL_LINK_PERMIT[35] & ~reg_be))) |
-               (addr_hit[36] & (|(SERIAL_LINK_PERMIT[36] & ~reg_be))) |
-               (addr_hit[37] & (|(SERIAL_LINK_PERMIT[37] & ~reg_be))) |
-               (addr_hit[38] & (|(SERIAL_LINK_PERMIT[38] & ~reg_be))) |
-               (addr_hit[39] & (|(SERIAL_LINK_PERMIT[39] & ~reg_be))) |
-               (addr_hit[40] & (|(SERIAL_LINK_PERMIT[40] & ~reg_be))) |
-               (addr_hit[41] & (|(SERIAL_LINK_PERMIT[41] & ~reg_be))) |
-               (addr_hit[42] & (|(SERIAL_LINK_PERMIT[42] & ~reg_be))) |
-               (addr_hit[43] & (|(SERIAL_LINK_PERMIT[43] & ~reg_be))) |
-               (addr_hit[44] & (|(SERIAL_LINK_PERMIT[44] & ~reg_be))) |
-               (addr_hit[45] & (|(SERIAL_LINK_PERMIT[45] & ~reg_be))) |
-               (addr_hit[46] & (|(SERIAL_LINK_PERMIT[46] & ~reg_be))) |
-               (addr_hit[47] & (|(SERIAL_LINK_PERMIT[47] & ~reg_be))) |
-               (addr_hit[48] & (|(SERIAL_LINK_PERMIT[48] & ~reg_be))) |
-               (addr_hit[49] & (|(SERIAL_LINK_PERMIT[49] & ~reg_be))) |
-               (addr_hit[50] & (|(SERIAL_LINK_PERMIT[50] & ~reg_be))) |
-               (addr_hit[51] & (|(SERIAL_LINK_PERMIT[51] & ~reg_be))) |
-               (addr_hit[52] & (|(SERIAL_LINK_PERMIT[52] & ~reg_be))) |
-               (addr_hit[53] & (|(SERIAL_LINK_PERMIT[53] & ~reg_be))) |
-               (addr_hit[54] & (|(SERIAL_LINK_PERMIT[54] & ~reg_be))) |
-               (addr_hit[55] & (|(SERIAL_LINK_PERMIT[55] & ~reg_be))) |
-               (addr_hit[56] & (|(SERIAL_LINK_PERMIT[56] & ~reg_be))) |
-               (addr_hit[57] & (|(SERIAL_LINK_PERMIT[57] & ~reg_be))) |
-               (addr_hit[58] & (|(SERIAL_LINK_PERMIT[58] & ~reg_be))) |
-               (addr_hit[59] & (|(SERIAL_LINK_PERMIT[59] & ~reg_be))) |
-               (addr_hit[60] & (|(SERIAL_LINK_PERMIT[60] & ~reg_be))) |
-               (addr_hit[61] & (|(SERIAL_LINK_PERMIT[61] & ~reg_be))) |
-               (addr_hit[62] & (|(SERIAL_LINK_PERMIT[62] & ~reg_be))) |
-               (addr_hit[63] & (|(SERIAL_LINK_PERMIT[63] & ~reg_be))) |
-               (addr_hit[64] & (|(SERIAL_LINK_PERMIT[64] & ~reg_be))) |
-               (addr_hit[65] & (|(SERIAL_LINK_PERMIT[65] & ~reg_be))) |
-               (addr_hit[66] & (|(SERIAL_LINK_PERMIT[66] & ~reg_be))) |
-               (addr_hit[67] & (|(SERIAL_LINK_PERMIT[67] & ~reg_be))) |
-               (addr_hit[68] & (|(SERIAL_LINK_PERMIT[68] & ~reg_be))) |
-               (addr_hit[69] & (|(SERIAL_LINK_PERMIT[69] & ~reg_be))) |
-               (addr_hit[70] & (|(SERIAL_LINK_PERMIT[70] & ~reg_be))) |
-               (addr_hit[71] & (|(SERIAL_LINK_PERMIT[71] & ~reg_be))) |
-               (addr_hit[72] & (|(SERIAL_LINK_PERMIT[72] & ~reg_be))) |
-               (addr_hit[73] & (|(SERIAL_LINK_PERMIT[73] & ~reg_be))) |
-               (addr_hit[74] & (|(SERIAL_LINK_PERMIT[74] & ~reg_be))) |
-               (addr_hit[75] & (|(SERIAL_LINK_PERMIT[75] & ~reg_be))) |
-               (addr_hit[76] & (|(SERIAL_LINK_PERMIT[76] & ~reg_be))) |
-               (addr_hit[77] & (|(SERIAL_LINK_PERMIT[77] & ~reg_be))) |
-               (addr_hit[78] & (|(SERIAL_LINK_PERMIT[78] & ~reg_be))) |
-               (addr_hit[79] & (|(SERIAL_LINK_PERMIT[79] & ~reg_be))) |
-               (addr_hit[80] & (|(SERIAL_LINK_PERMIT[80] & ~reg_be))) |
-               (addr_hit[81] & (|(SERIAL_LINK_PERMIT[81] & ~reg_be))) |
-               (addr_hit[82] & (|(SERIAL_LINK_PERMIT[82] & ~reg_be))) |
-               (addr_hit[83] & (|(SERIAL_LINK_PERMIT[83] & ~reg_be))) |
-               (addr_hit[84] & (|(SERIAL_LINK_PERMIT[84] & ~reg_be))) |
-               (addr_hit[85] & (|(SERIAL_LINK_PERMIT[85] & ~reg_be))) |
-               (addr_hit[86] & (|(SERIAL_LINK_PERMIT[86] & ~reg_be))) |
-               (addr_hit[87] & (|(SERIAL_LINK_PERMIT[87] & ~reg_be))) |
-               (addr_hit[88] & (|(SERIAL_LINK_PERMIT[88] & ~reg_be))) |
-               (addr_hit[89] & (|(SERIAL_LINK_PERMIT[89] & ~reg_be))) |
-               (addr_hit[90] & (|(SERIAL_LINK_PERMIT[90] & ~reg_be))) |
-               (addr_hit[91] & (|(SERIAL_LINK_PERMIT[91] & ~reg_be))) |
-               (addr_hit[92] & (|(SERIAL_LINK_PERMIT[92] & ~reg_be))) |
-               (addr_hit[93] & (|(SERIAL_LINK_PERMIT[93] & ~reg_be))) |
-               (addr_hit[94] & (|(SERIAL_LINK_PERMIT[94] & ~reg_be))) |
-               (addr_hit[95] & (|(SERIAL_LINK_PERMIT[95] & ~reg_be))) |
-               (addr_hit[96] & (|(SERIAL_LINK_PERMIT[96] & ~reg_be)))));
+              ((addr_hit[  0] & (|(SERIAL_LINK_PERMIT[  0] & ~reg_be))) |
+               (addr_hit[  1] & (|(SERIAL_LINK_PERMIT[  1] & ~reg_be))) |
+               (addr_hit[  2] & (|(SERIAL_LINK_PERMIT[  2] & ~reg_be))) |
+               (addr_hit[  3] & (|(SERIAL_LINK_PERMIT[  3] & ~reg_be))) |
+               (addr_hit[  4] & (|(SERIAL_LINK_PERMIT[  4] & ~reg_be))) |
+               (addr_hit[  5] & (|(SERIAL_LINK_PERMIT[  5] & ~reg_be))) |
+               (addr_hit[  6] & (|(SERIAL_LINK_PERMIT[  6] & ~reg_be))) |
+               (addr_hit[  7] & (|(SERIAL_LINK_PERMIT[  7] & ~reg_be))) |
+               (addr_hit[  8] & (|(SERIAL_LINK_PERMIT[  8] & ~reg_be))) |
+               (addr_hit[  9] & (|(SERIAL_LINK_PERMIT[  9] & ~reg_be))) |
+               (addr_hit[ 10] & (|(SERIAL_LINK_PERMIT[ 10] & ~reg_be))) |
+               (addr_hit[ 11] & (|(SERIAL_LINK_PERMIT[ 11] & ~reg_be))) |
+               (addr_hit[ 12] & (|(SERIAL_LINK_PERMIT[ 12] & ~reg_be))) |
+               (addr_hit[ 13] & (|(SERIAL_LINK_PERMIT[ 13] & ~reg_be))) |
+               (addr_hit[ 14] & (|(SERIAL_LINK_PERMIT[ 14] & ~reg_be))) |
+               (addr_hit[ 15] & (|(SERIAL_LINK_PERMIT[ 15] & ~reg_be))) |
+               (addr_hit[ 16] & (|(SERIAL_LINK_PERMIT[ 16] & ~reg_be))) |
+               (addr_hit[ 17] & (|(SERIAL_LINK_PERMIT[ 17] & ~reg_be))) |
+               (addr_hit[ 18] & (|(SERIAL_LINK_PERMIT[ 18] & ~reg_be))) |
+               (addr_hit[ 19] & (|(SERIAL_LINK_PERMIT[ 19] & ~reg_be))) |
+               (addr_hit[ 20] & (|(SERIAL_LINK_PERMIT[ 20] & ~reg_be))) |
+               (addr_hit[ 21] & (|(SERIAL_LINK_PERMIT[ 21] & ~reg_be))) |
+               (addr_hit[ 22] & (|(SERIAL_LINK_PERMIT[ 22] & ~reg_be))) |
+               (addr_hit[ 23] & (|(SERIAL_LINK_PERMIT[ 23] & ~reg_be))) |
+               (addr_hit[ 24] & (|(SERIAL_LINK_PERMIT[ 24] & ~reg_be))) |
+               (addr_hit[ 25] & (|(SERIAL_LINK_PERMIT[ 25] & ~reg_be))) |
+               (addr_hit[ 26] & (|(SERIAL_LINK_PERMIT[ 26] & ~reg_be))) |
+               (addr_hit[ 27] & (|(SERIAL_LINK_PERMIT[ 27] & ~reg_be))) |
+               (addr_hit[ 28] & (|(SERIAL_LINK_PERMIT[ 28] & ~reg_be))) |
+               (addr_hit[ 29] & (|(SERIAL_LINK_PERMIT[ 29] & ~reg_be))) |
+               (addr_hit[ 30] & (|(SERIAL_LINK_PERMIT[ 30] & ~reg_be))) |
+               (addr_hit[ 31] & (|(SERIAL_LINK_PERMIT[ 31] & ~reg_be))) |
+               (addr_hit[ 32] & (|(SERIAL_LINK_PERMIT[ 32] & ~reg_be))) |
+               (addr_hit[ 33] & (|(SERIAL_LINK_PERMIT[ 33] & ~reg_be))) |
+               (addr_hit[ 34] & (|(SERIAL_LINK_PERMIT[ 34] & ~reg_be))) |
+               (addr_hit[ 35] & (|(SERIAL_LINK_PERMIT[ 35] & ~reg_be))) |
+               (addr_hit[ 36] & (|(SERIAL_LINK_PERMIT[ 36] & ~reg_be))) |
+               (addr_hit[ 37] & (|(SERIAL_LINK_PERMIT[ 37] & ~reg_be))) |
+               (addr_hit[ 38] & (|(SERIAL_LINK_PERMIT[ 38] & ~reg_be))) |
+               (addr_hit[ 39] & (|(SERIAL_LINK_PERMIT[ 39] & ~reg_be))) |
+               (addr_hit[ 40] & (|(SERIAL_LINK_PERMIT[ 40] & ~reg_be))) |
+               (addr_hit[ 41] & (|(SERIAL_LINK_PERMIT[ 41] & ~reg_be))) |
+               (addr_hit[ 42] & (|(SERIAL_LINK_PERMIT[ 42] & ~reg_be))) |
+               (addr_hit[ 43] & (|(SERIAL_LINK_PERMIT[ 43] & ~reg_be))) |
+               (addr_hit[ 44] & (|(SERIAL_LINK_PERMIT[ 44] & ~reg_be))) |
+               (addr_hit[ 45] & (|(SERIAL_LINK_PERMIT[ 45] & ~reg_be))) |
+               (addr_hit[ 46] & (|(SERIAL_LINK_PERMIT[ 46] & ~reg_be))) |
+               (addr_hit[ 47] & (|(SERIAL_LINK_PERMIT[ 47] & ~reg_be))) |
+               (addr_hit[ 48] & (|(SERIAL_LINK_PERMIT[ 48] & ~reg_be))) |
+               (addr_hit[ 49] & (|(SERIAL_LINK_PERMIT[ 49] & ~reg_be))) |
+               (addr_hit[ 50] & (|(SERIAL_LINK_PERMIT[ 50] & ~reg_be))) |
+               (addr_hit[ 51] & (|(SERIAL_LINK_PERMIT[ 51] & ~reg_be))) |
+               (addr_hit[ 52] & (|(SERIAL_LINK_PERMIT[ 52] & ~reg_be))) |
+               (addr_hit[ 53] & (|(SERIAL_LINK_PERMIT[ 53] & ~reg_be))) |
+               (addr_hit[ 54] & (|(SERIAL_LINK_PERMIT[ 54] & ~reg_be))) |
+               (addr_hit[ 55] & (|(SERIAL_LINK_PERMIT[ 55] & ~reg_be))) |
+               (addr_hit[ 56] & (|(SERIAL_LINK_PERMIT[ 56] & ~reg_be))) |
+               (addr_hit[ 57] & (|(SERIAL_LINK_PERMIT[ 57] & ~reg_be))) |
+               (addr_hit[ 58] & (|(SERIAL_LINK_PERMIT[ 58] & ~reg_be))) |
+               (addr_hit[ 59] & (|(SERIAL_LINK_PERMIT[ 59] & ~reg_be))) |
+               (addr_hit[ 60] & (|(SERIAL_LINK_PERMIT[ 60] & ~reg_be))) |
+               (addr_hit[ 61] & (|(SERIAL_LINK_PERMIT[ 61] & ~reg_be))) |
+               (addr_hit[ 62] & (|(SERIAL_LINK_PERMIT[ 62] & ~reg_be))) |
+               (addr_hit[ 63] & (|(SERIAL_LINK_PERMIT[ 63] & ~reg_be))) |
+               (addr_hit[ 64] & (|(SERIAL_LINK_PERMIT[ 64] & ~reg_be))) |
+               (addr_hit[ 65] & (|(SERIAL_LINK_PERMIT[ 65] & ~reg_be))) |
+               (addr_hit[ 66] & (|(SERIAL_LINK_PERMIT[ 66] & ~reg_be))) |
+               (addr_hit[ 67] & (|(SERIAL_LINK_PERMIT[ 67] & ~reg_be))) |
+               (addr_hit[ 68] & (|(SERIAL_LINK_PERMIT[ 68] & ~reg_be))) |
+               (addr_hit[ 69] & (|(SERIAL_LINK_PERMIT[ 69] & ~reg_be))) |
+               (addr_hit[ 70] & (|(SERIAL_LINK_PERMIT[ 70] & ~reg_be))) |
+               (addr_hit[ 71] & (|(SERIAL_LINK_PERMIT[ 71] & ~reg_be))) |
+               (addr_hit[ 72] & (|(SERIAL_LINK_PERMIT[ 72] & ~reg_be))) |
+               (addr_hit[ 73] & (|(SERIAL_LINK_PERMIT[ 73] & ~reg_be))) |
+               (addr_hit[ 74] & (|(SERIAL_LINK_PERMIT[ 74] & ~reg_be))) |
+               (addr_hit[ 75] & (|(SERIAL_LINK_PERMIT[ 75] & ~reg_be))) |
+               (addr_hit[ 76] & (|(SERIAL_LINK_PERMIT[ 76] & ~reg_be))) |
+               (addr_hit[ 77] & (|(SERIAL_LINK_PERMIT[ 77] & ~reg_be))) |
+               (addr_hit[ 78] & (|(SERIAL_LINK_PERMIT[ 78] & ~reg_be))) |
+               (addr_hit[ 79] & (|(SERIAL_LINK_PERMIT[ 79] & ~reg_be))) |
+               (addr_hit[ 80] & (|(SERIAL_LINK_PERMIT[ 80] & ~reg_be))) |
+               (addr_hit[ 81] & (|(SERIAL_LINK_PERMIT[ 81] & ~reg_be))) |
+               (addr_hit[ 82] & (|(SERIAL_LINK_PERMIT[ 82] & ~reg_be))) |
+               (addr_hit[ 83] & (|(SERIAL_LINK_PERMIT[ 83] & ~reg_be))) |
+               (addr_hit[ 84] & (|(SERIAL_LINK_PERMIT[ 84] & ~reg_be))) |
+               (addr_hit[ 85] & (|(SERIAL_LINK_PERMIT[ 85] & ~reg_be))) |
+               (addr_hit[ 86] & (|(SERIAL_LINK_PERMIT[ 86] & ~reg_be))) |
+               (addr_hit[ 87] & (|(SERIAL_LINK_PERMIT[ 87] & ~reg_be))) |
+               (addr_hit[ 88] & (|(SERIAL_LINK_PERMIT[ 88] & ~reg_be))) |
+               (addr_hit[ 89] & (|(SERIAL_LINK_PERMIT[ 89] & ~reg_be))) |
+               (addr_hit[ 90] & (|(SERIAL_LINK_PERMIT[ 90] & ~reg_be))) |
+               (addr_hit[ 91] & (|(SERIAL_LINK_PERMIT[ 91] & ~reg_be))) |
+               (addr_hit[ 92] & (|(SERIAL_LINK_PERMIT[ 92] & ~reg_be))) |
+               (addr_hit[ 93] & (|(SERIAL_LINK_PERMIT[ 93] & ~reg_be))) |
+               (addr_hit[ 94] & (|(SERIAL_LINK_PERMIT[ 94] & ~reg_be))) |
+               (addr_hit[ 95] & (|(SERIAL_LINK_PERMIT[ 95] & ~reg_be))) |
+               (addr_hit[ 96] & (|(SERIAL_LINK_PERMIT[ 96] & ~reg_be))) |
+               (addr_hit[ 97] & (|(SERIAL_LINK_PERMIT[ 97] & ~reg_be))) |
+               (addr_hit[ 98] & (|(SERIAL_LINK_PERMIT[ 98] & ~reg_be))) |
+               (addr_hit[ 99] & (|(SERIAL_LINK_PERMIT[ 99] & ~reg_be))) |
+               (addr_hit[100] & (|(SERIAL_LINK_PERMIT[100] & ~reg_be))) |
+               (addr_hit[101] & (|(SERIAL_LINK_PERMIT[101] & ~reg_be))) |
+               (addr_hit[102] & (|(SERIAL_LINK_PERMIT[102] & ~reg_be))) |
+               (addr_hit[103] & (|(SERIAL_LINK_PERMIT[103] & ~reg_be))) |
+               (addr_hit[104] & (|(SERIAL_LINK_PERMIT[104] & ~reg_be))) |
+               (addr_hit[105] & (|(SERIAL_LINK_PERMIT[105] & ~reg_be))) |
+               (addr_hit[106] & (|(SERIAL_LINK_PERMIT[106] & ~reg_be))) |
+               (addr_hit[107] & (|(SERIAL_LINK_PERMIT[107] & ~reg_be))) |
+               (addr_hit[108] & (|(SERIAL_LINK_PERMIT[108] & ~reg_be))) |
+               (addr_hit[109] & (|(SERIAL_LINK_PERMIT[109] & ~reg_be))) |
+               (addr_hit[110] & (|(SERIAL_LINK_PERMIT[110] & ~reg_be))) |
+               (addr_hit[111] & (|(SERIAL_LINK_PERMIT[111] & ~reg_be))) |
+               (addr_hit[112] & (|(SERIAL_LINK_PERMIT[112] & ~reg_be))) |
+               (addr_hit[113] & (|(SERIAL_LINK_PERMIT[113] & ~reg_be))) |
+               (addr_hit[114] & (|(SERIAL_LINK_PERMIT[114] & ~reg_be))) |
+               (addr_hit[115] & (|(SERIAL_LINK_PERMIT[115] & ~reg_be))) |
+               (addr_hit[116] & (|(SERIAL_LINK_PERMIT[116] & ~reg_be))) |
+               (addr_hit[117] & (|(SERIAL_LINK_PERMIT[117] & ~reg_be))) |
+               (addr_hit[118] & (|(SERIAL_LINK_PERMIT[118] & ~reg_be))) |
+               (addr_hit[119] & (|(SERIAL_LINK_PERMIT[119] & ~reg_be))) |
+               (addr_hit[120] & (|(SERIAL_LINK_PERMIT[120] & ~reg_be))) |
+               (addr_hit[121] & (|(SERIAL_LINK_PERMIT[121] & ~reg_be))) |
+               (addr_hit[122] & (|(SERIAL_LINK_PERMIT[122] & ~reg_be))) |
+               (addr_hit[123] & (|(SERIAL_LINK_PERMIT[123] & ~reg_be))) |
+               (addr_hit[124] & (|(SERIAL_LINK_PERMIT[124] & ~reg_be))) |
+               (addr_hit[125] & (|(SERIAL_LINK_PERMIT[125] & ~reg_be))) |
+               (addr_hit[126] & (|(SERIAL_LINK_PERMIT[126] & ~reg_be))) |
+               (addr_hit[127] & (|(SERIAL_LINK_PERMIT[127] & ~reg_be))) |
+               (addr_hit[128] & (|(SERIAL_LINK_PERMIT[128] & ~reg_be))) |
+               (addr_hit[129] & (|(SERIAL_LINK_PERMIT[129] & ~reg_be))) |
+               (addr_hit[130] & (|(SERIAL_LINK_PERMIT[130] & ~reg_be))) |
+               (addr_hit[131] & (|(SERIAL_LINK_PERMIT[131] & ~reg_be))) |
+               (addr_hit[132] & (|(SERIAL_LINK_PERMIT[132] & ~reg_be))) |
+               (addr_hit[133] & (|(SERIAL_LINK_PERMIT[133] & ~reg_be))) |
+               (addr_hit[134] & (|(SERIAL_LINK_PERMIT[134] & ~reg_be)))));
   end
 
   assign ctrl_clk_ena_we = addr_hit[0] & reg_we & !reg_error;
@@ -8396,704 +8436,704 @@ module serial_link_reg_top #(
   assign tx_phy_ctrl1_37_we = addr_hit[39] & reg_we & !reg_error;
   assign tx_phy_ctrl1_37_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_0_clk_shift_start_0_we = addr_hit[40] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_0_clk_shift_start_0_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl2_0_we = addr_hit[40] & reg_we & !reg_error;
+  assign tx_phy_ctrl2_0_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_0_clk_shift_end_0_we = addr_hit[40] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_0_clk_shift_end_0_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl2_1_we = addr_hit[41] & reg_we & !reg_error;
+  assign tx_phy_ctrl2_1_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_1_clk_shift_start_1_we = addr_hit[41] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_1_clk_shift_start_1_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl2_2_we = addr_hit[42] & reg_we & !reg_error;
+  assign tx_phy_ctrl2_2_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_1_clk_shift_end_1_we = addr_hit[41] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_1_clk_shift_end_1_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl2_3_we = addr_hit[43] & reg_we & !reg_error;
+  assign tx_phy_ctrl2_3_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_2_clk_shift_start_2_we = addr_hit[42] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_2_clk_shift_start_2_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl2_4_we = addr_hit[44] & reg_we & !reg_error;
+  assign tx_phy_ctrl2_4_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_2_clk_shift_end_2_we = addr_hit[42] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_2_clk_shift_end_2_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl2_5_we = addr_hit[45] & reg_we & !reg_error;
+  assign tx_phy_ctrl2_5_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_3_clk_shift_start_3_we = addr_hit[43] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_3_clk_shift_start_3_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl2_6_we = addr_hit[46] & reg_we & !reg_error;
+  assign tx_phy_ctrl2_6_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_3_clk_shift_end_3_we = addr_hit[43] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_3_clk_shift_end_3_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl2_7_we = addr_hit[47] & reg_we & !reg_error;
+  assign tx_phy_ctrl2_7_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_4_clk_shift_start_4_we = addr_hit[44] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_4_clk_shift_start_4_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl2_8_we = addr_hit[48] & reg_we & !reg_error;
+  assign tx_phy_ctrl2_8_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_4_clk_shift_end_4_we = addr_hit[44] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_4_clk_shift_end_4_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl2_9_we = addr_hit[49] & reg_we & !reg_error;
+  assign tx_phy_ctrl2_9_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_5_clk_shift_start_5_we = addr_hit[45] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_5_clk_shift_start_5_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl2_10_we = addr_hit[50] & reg_we & !reg_error;
+  assign tx_phy_ctrl2_10_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_5_clk_shift_end_5_we = addr_hit[45] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_5_clk_shift_end_5_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl2_11_we = addr_hit[51] & reg_we & !reg_error;
+  assign tx_phy_ctrl2_11_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_6_clk_shift_start_6_we = addr_hit[46] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_6_clk_shift_start_6_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl2_12_we = addr_hit[52] & reg_we & !reg_error;
+  assign tx_phy_ctrl2_12_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_6_clk_shift_end_6_we = addr_hit[46] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_6_clk_shift_end_6_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl2_13_we = addr_hit[53] & reg_we & !reg_error;
+  assign tx_phy_ctrl2_13_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_7_clk_shift_start_7_we = addr_hit[47] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_7_clk_shift_start_7_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl2_14_we = addr_hit[54] & reg_we & !reg_error;
+  assign tx_phy_ctrl2_14_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_7_clk_shift_end_7_we = addr_hit[47] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_7_clk_shift_end_7_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl2_15_we = addr_hit[55] & reg_we & !reg_error;
+  assign tx_phy_ctrl2_15_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_8_clk_shift_start_8_we = addr_hit[48] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_8_clk_shift_start_8_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl2_16_we = addr_hit[56] & reg_we & !reg_error;
+  assign tx_phy_ctrl2_16_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_8_clk_shift_end_8_we = addr_hit[48] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_8_clk_shift_end_8_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl2_17_we = addr_hit[57] & reg_we & !reg_error;
+  assign tx_phy_ctrl2_17_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_9_clk_shift_start_9_we = addr_hit[49] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_9_clk_shift_start_9_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl2_18_we = addr_hit[58] & reg_we & !reg_error;
+  assign tx_phy_ctrl2_18_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_9_clk_shift_end_9_we = addr_hit[49] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_9_clk_shift_end_9_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl2_19_we = addr_hit[59] & reg_we & !reg_error;
+  assign tx_phy_ctrl2_19_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_10_clk_shift_start_10_we = addr_hit[50] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_10_clk_shift_start_10_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl2_20_we = addr_hit[60] & reg_we & !reg_error;
+  assign tx_phy_ctrl2_20_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_10_clk_shift_end_10_we = addr_hit[50] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_10_clk_shift_end_10_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl2_21_we = addr_hit[61] & reg_we & !reg_error;
+  assign tx_phy_ctrl2_21_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_11_clk_shift_start_11_we = addr_hit[51] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_11_clk_shift_start_11_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl2_22_we = addr_hit[62] & reg_we & !reg_error;
+  assign tx_phy_ctrl2_22_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_11_clk_shift_end_11_we = addr_hit[51] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_11_clk_shift_end_11_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl2_23_we = addr_hit[63] & reg_we & !reg_error;
+  assign tx_phy_ctrl2_23_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_12_clk_shift_start_12_we = addr_hit[52] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_12_clk_shift_start_12_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl2_24_we = addr_hit[64] & reg_we & !reg_error;
+  assign tx_phy_ctrl2_24_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_12_clk_shift_end_12_we = addr_hit[52] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_12_clk_shift_end_12_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl2_25_we = addr_hit[65] & reg_we & !reg_error;
+  assign tx_phy_ctrl2_25_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_13_clk_shift_start_13_we = addr_hit[53] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_13_clk_shift_start_13_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl2_26_we = addr_hit[66] & reg_we & !reg_error;
+  assign tx_phy_ctrl2_26_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_13_clk_shift_end_13_we = addr_hit[53] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_13_clk_shift_end_13_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl2_27_we = addr_hit[67] & reg_we & !reg_error;
+  assign tx_phy_ctrl2_27_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_14_clk_shift_start_14_we = addr_hit[54] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_14_clk_shift_start_14_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl2_28_we = addr_hit[68] & reg_we & !reg_error;
+  assign tx_phy_ctrl2_28_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_14_clk_shift_end_14_we = addr_hit[54] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_14_clk_shift_end_14_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl2_29_we = addr_hit[69] & reg_we & !reg_error;
+  assign tx_phy_ctrl2_29_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_15_clk_shift_start_15_we = addr_hit[55] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_15_clk_shift_start_15_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl2_30_we = addr_hit[70] & reg_we & !reg_error;
+  assign tx_phy_ctrl2_30_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_15_clk_shift_end_15_we = addr_hit[55] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_15_clk_shift_end_15_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl2_31_we = addr_hit[71] & reg_we & !reg_error;
+  assign tx_phy_ctrl2_31_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_16_clk_shift_start_16_we = addr_hit[56] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_16_clk_shift_start_16_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl2_32_we = addr_hit[72] & reg_we & !reg_error;
+  assign tx_phy_ctrl2_32_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_16_clk_shift_end_16_we = addr_hit[56] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_16_clk_shift_end_16_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl2_33_we = addr_hit[73] & reg_we & !reg_error;
+  assign tx_phy_ctrl2_33_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_17_clk_shift_start_17_we = addr_hit[57] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_17_clk_shift_start_17_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl2_34_we = addr_hit[74] & reg_we & !reg_error;
+  assign tx_phy_ctrl2_34_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_17_clk_shift_end_17_we = addr_hit[57] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_17_clk_shift_end_17_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl2_35_we = addr_hit[75] & reg_we & !reg_error;
+  assign tx_phy_ctrl2_35_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_18_clk_shift_start_18_we = addr_hit[58] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_18_clk_shift_start_18_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl2_36_we = addr_hit[76] & reg_we & !reg_error;
+  assign tx_phy_ctrl2_36_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_18_clk_shift_end_18_we = addr_hit[58] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_18_clk_shift_end_18_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl2_37_we = addr_hit[77] & reg_we & !reg_error;
+  assign tx_phy_ctrl2_37_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_19_clk_shift_start_19_we = addr_hit[59] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_19_clk_shift_start_19_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl3_0_we = addr_hit[78] & reg_we & !reg_error;
+  assign tx_phy_ctrl3_0_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_19_clk_shift_end_19_we = addr_hit[59] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_19_clk_shift_end_19_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl3_1_we = addr_hit[79] & reg_we & !reg_error;
+  assign tx_phy_ctrl3_1_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_20_clk_shift_start_20_we = addr_hit[60] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_20_clk_shift_start_20_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl3_2_we = addr_hit[80] & reg_we & !reg_error;
+  assign tx_phy_ctrl3_2_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_20_clk_shift_end_20_we = addr_hit[60] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_20_clk_shift_end_20_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl3_3_we = addr_hit[81] & reg_we & !reg_error;
+  assign tx_phy_ctrl3_3_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_21_clk_shift_start_21_we = addr_hit[61] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_21_clk_shift_start_21_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl3_4_we = addr_hit[82] & reg_we & !reg_error;
+  assign tx_phy_ctrl3_4_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_21_clk_shift_end_21_we = addr_hit[61] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_21_clk_shift_end_21_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl3_5_we = addr_hit[83] & reg_we & !reg_error;
+  assign tx_phy_ctrl3_5_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_22_clk_shift_start_22_we = addr_hit[62] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_22_clk_shift_start_22_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl3_6_we = addr_hit[84] & reg_we & !reg_error;
+  assign tx_phy_ctrl3_6_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_22_clk_shift_end_22_we = addr_hit[62] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_22_clk_shift_end_22_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl3_7_we = addr_hit[85] & reg_we & !reg_error;
+  assign tx_phy_ctrl3_7_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_23_clk_shift_start_23_we = addr_hit[63] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_23_clk_shift_start_23_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl3_8_we = addr_hit[86] & reg_we & !reg_error;
+  assign tx_phy_ctrl3_8_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_23_clk_shift_end_23_we = addr_hit[63] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_23_clk_shift_end_23_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl3_9_we = addr_hit[87] & reg_we & !reg_error;
+  assign tx_phy_ctrl3_9_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_24_clk_shift_start_24_we = addr_hit[64] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_24_clk_shift_start_24_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl3_10_we = addr_hit[88] & reg_we & !reg_error;
+  assign tx_phy_ctrl3_10_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_24_clk_shift_end_24_we = addr_hit[64] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_24_clk_shift_end_24_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl3_11_we = addr_hit[89] & reg_we & !reg_error;
+  assign tx_phy_ctrl3_11_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_25_clk_shift_start_25_we = addr_hit[65] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_25_clk_shift_start_25_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl3_12_we = addr_hit[90] & reg_we & !reg_error;
+  assign tx_phy_ctrl3_12_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_25_clk_shift_end_25_we = addr_hit[65] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_25_clk_shift_end_25_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl3_13_we = addr_hit[91] & reg_we & !reg_error;
+  assign tx_phy_ctrl3_13_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_26_clk_shift_start_26_we = addr_hit[66] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_26_clk_shift_start_26_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl3_14_we = addr_hit[92] & reg_we & !reg_error;
+  assign tx_phy_ctrl3_14_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_26_clk_shift_end_26_we = addr_hit[66] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_26_clk_shift_end_26_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl3_15_we = addr_hit[93] & reg_we & !reg_error;
+  assign tx_phy_ctrl3_15_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_27_clk_shift_start_27_we = addr_hit[67] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_27_clk_shift_start_27_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl3_16_we = addr_hit[94] & reg_we & !reg_error;
+  assign tx_phy_ctrl3_16_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_27_clk_shift_end_27_we = addr_hit[67] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_27_clk_shift_end_27_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl3_17_we = addr_hit[95] & reg_we & !reg_error;
+  assign tx_phy_ctrl3_17_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_28_clk_shift_start_28_we = addr_hit[68] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_28_clk_shift_start_28_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl3_18_we = addr_hit[96] & reg_we & !reg_error;
+  assign tx_phy_ctrl3_18_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_28_clk_shift_end_28_we = addr_hit[68] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_28_clk_shift_end_28_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl3_19_we = addr_hit[97] & reg_we & !reg_error;
+  assign tx_phy_ctrl3_19_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_29_clk_shift_start_29_we = addr_hit[69] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_29_clk_shift_start_29_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl3_20_we = addr_hit[98] & reg_we & !reg_error;
+  assign tx_phy_ctrl3_20_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_29_clk_shift_end_29_we = addr_hit[69] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_29_clk_shift_end_29_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl3_21_we = addr_hit[99] & reg_we & !reg_error;
+  assign tx_phy_ctrl3_21_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_30_clk_shift_start_30_we = addr_hit[70] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_30_clk_shift_start_30_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl3_22_we = addr_hit[100] & reg_we & !reg_error;
+  assign tx_phy_ctrl3_22_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_30_clk_shift_end_30_we = addr_hit[70] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_30_clk_shift_end_30_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl3_23_we = addr_hit[101] & reg_we & !reg_error;
+  assign tx_phy_ctrl3_23_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_31_clk_shift_start_31_we = addr_hit[71] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_31_clk_shift_start_31_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl3_24_we = addr_hit[102] & reg_we & !reg_error;
+  assign tx_phy_ctrl3_24_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_31_clk_shift_end_31_we = addr_hit[71] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_31_clk_shift_end_31_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl3_25_we = addr_hit[103] & reg_we & !reg_error;
+  assign tx_phy_ctrl3_25_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_32_clk_shift_start_32_we = addr_hit[72] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_32_clk_shift_start_32_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl3_26_we = addr_hit[104] & reg_we & !reg_error;
+  assign tx_phy_ctrl3_26_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_32_clk_shift_end_32_we = addr_hit[72] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_32_clk_shift_end_32_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl3_27_we = addr_hit[105] & reg_we & !reg_error;
+  assign tx_phy_ctrl3_27_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_33_clk_shift_start_33_we = addr_hit[73] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_33_clk_shift_start_33_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl3_28_we = addr_hit[106] & reg_we & !reg_error;
+  assign tx_phy_ctrl3_28_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_33_clk_shift_end_33_we = addr_hit[73] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_33_clk_shift_end_33_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl3_29_we = addr_hit[107] & reg_we & !reg_error;
+  assign tx_phy_ctrl3_29_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_34_clk_shift_start_34_we = addr_hit[74] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_34_clk_shift_start_34_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl3_30_we = addr_hit[108] & reg_we & !reg_error;
+  assign tx_phy_ctrl3_30_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_34_clk_shift_end_34_we = addr_hit[74] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_34_clk_shift_end_34_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl3_31_we = addr_hit[109] & reg_we & !reg_error;
+  assign tx_phy_ctrl3_31_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_35_clk_shift_start_35_we = addr_hit[75] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_35_clk_shift_start_35_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl3_32_we = addr_hit[110] & reg_we & !reg_error;
+  assign tx_phy_ctrl3_32_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_35_clk_shift_end_35_we = addr_hit[75] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_35_clk_shift_end_35_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl3_33_we = addr_hit[111] & reg_we & !reg_error;
+  assign tx_phy_ctrl3_33_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_36_clk_shift_start_36_we = addr_hit[76] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_36_clk_shift_start_36_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl3_34_we = addr_hit[112] & reg_we & !reg_error;
+  assign tx_phy_ctrl3_34_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_36_clk_shift_end_36_we = addr_hit[76] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_36_clk_shift_end_36_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl3_35_we = addr_hit[113] & reg_we & !reg_error;
+  assign tx_phy_ctrl3_35_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_37_clk_shift_start_37_we = addr_hit[77] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_37_clk_shift_start_37_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl3_36_we = addr_hit[114] & reg_we & !reg_error;
+  assign tx_phy_ctrl3_36_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_37_clk_shift_end_37_we = addr_hit[77] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_37_clk_shift_end_37_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl3_37_we = addr_hit[115] & reg_we & !reg_error;
+  assign tx_phy_ctrl3_37_wd = reg_wdata[10:0];
 
-  assign raw_mode_en_we = addr_hit[78] & reg_we & !reg_error;
+  assign raw_mode_en_we = addr_hit[116] & reg_we & !reg_error;
   assign raw_mode_en_wd = reg_wdata[0];
 
-  assign raw_mode_in_ch_sel_we = addr_hit[79] & reg_we & !reg_error;
+  assign raw_mode_in_ch_sel_we = addr_hit[117] & reg_we & !reg_error;
   assign raw_mode_in_ch_sel_wd = reg_wdata[5:0];
 
-  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_0_re = addr_hit[80] & reg_re & !reg_error;
+  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_0_re = addr_hit[118] & reg_re & !reg_error;
 
-  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_1_re = addr_hit[80] & reg_re & !reg_error;
+  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_1_re = addr_hit[118] & reg_re & !reg_error;
 
-  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_2_re = addr_hit[80] & reg_re & !reg_error;
+  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_2_re = addr_hit[118] & reg_re & !reg_error;
 
-  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_3_re = addr_hit[80] & reg_re & !reg_error;
+  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_3_re = addr_hit[118] & reg_re & !reg_error;
 
-  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_4_re = addr_hit[80] & reg_re & !reg_error;
+  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_4_re = addr_hit[118] & reg_re & !reg_error;
 
-  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_5_re = addr_hit[80] & reg_re & !reg_error;
+  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_5_re = addr_hit[118] & reg_re & !reg_error;
 
-  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_6_re = addr_hit[80] & reg_re & !reg_error;
+  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_6_re = addr_hit[118] & reg_re & !reg_error;
 
-  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_7_re = addr_hit[80] & reg_re & !reg_error;
+  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_7_re = addr_hit[118] & reg_re & !reg_error;
 
-  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_8_re = addr_hit[80] & reg_re & !reg_error;
+  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_8_re = addr_hit[118] & reg_re & !reg_error;
 
-  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_9_re = addr_hit[80] & reg_re & !reg_error;
+  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_9_re = addr_hit[118] & reg_re & !reg_error;
 
-  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_10_re = addr_hit[80] & reg_re & !reg_error;
+  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_10_re = addr_hit[118] & reg_re & !reg_error;
 
-  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_11_re = addr_hit[80] & reg_re & !reg_error;
+  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_11_re = addr_hit[118] & reg_re & !reg_error;
 
-  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_12_re = addr_hit[80] & reg_re & !reg_error;
+  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_12_re = addr_hit[118] & reg_re & !reg_error;
 
-  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_13_re = addr_hit[80] & reg_re & !reg_error;
+  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_13_re = addr_hit[118] & reg_re & !reg_error;
 
-  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_14_re = addr_hit[80] & reg_re & !reg_error;
+  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_14_re = addr_hit[118] & reg_re & !reg_error;
 
-  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_15_re = addr_hit[80] & reg_re & !reg_error;
+  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_15_re = addr_hit[118] & reg_re & !reg_error;
 
-  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_16_re = addr_hit[80] & reg_re & !reg_error;
+  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_16_re = addr_hit[118] & reg_re & !reg_error;
 
-  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_17_re = addr_hit[80] & reg_re & !reg_error;
+  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_17_re = addr_hit[118] & reg_re & !reg_error;
 
-  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_18_re = addr_hit[80] & reg_re & !reg_error;
+  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_18_re = addr_hit[118] & reg_re & !reg_error;
 
-  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_19_re = addr_hit[80] & reg_re & !reg_error;
+  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_19_re = addr_hit[118] & reg_re & !reg_error;
 
-  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_20_re = addr_hit[80] & reg_re & !reg_error;
+  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_20_re = addr_hit[118] & reg_re & !reg_error;
 
-  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_21_re = addr_hit[80] & reg_re & !reg_error;
+  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_21_re = addr_hit[118] & reg_re & !reg_error;
 
-  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_22_re = addr_hit[80] & reg_re & !reg_error;
+  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_22_re = addr_hit[118] & reg_re & !reg_error;
 
-  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_23_re = addr_hit[80] & reg_re & !reg_error;
+  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_23_re = addr_hit[118] & reg_re & !reg_error;
 
-  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_24_re = addr_hit[80] & reg_re & !reg_error;
+  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_24_re = addr_hit[118] & reg_re & !reg_error;
 
-  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_25_re = addr_hit[80] & reg_re & !reg_error;
+  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_25_re = addr_hit[118] & reg_re & !reg_error;
 
-  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_26_re = addr_hit[80] & reg_re & !reg_error;
+  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_26_re = addr_hit[118] & reg_re & !reg_error;
 
-  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_27_re = addr_hit[80] & reg_re & !reg_error;
+  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_27_re = addr_hit[118] & reg_re & !reg_error;
 
-  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_28_re = addr_hit[80] & reg_re & !reg_error;
+  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_28_re = addr_hit[118] & reg_re & !reg_error;
 
-  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_29_re = addr_hit[80] & reg_re & !reg_error;
+  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_29_re = addr_hit[118] & reg_re & !reg_error;
 
-  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_30_re = addr_hit[80] & reg_re & !reg_error;
+  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_30_re = addr_hit[118] & reg_re & !reg_error;
 
-  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_31_re = addr_hit[80] & reg_re & !reg_error;
+  assign raw_mode_in_data_valid_0_raw_mode_in_data_valid_31_re = addr_hit[118] & reg_re & !reg_error;
 
-  assign raw_mode_in_data_valid_1_raw_mode_in_data_valid_32_re = addr_hit[81] & reg_re & !reg_error;
+  assign raw_mode_in_data_valid_1_raw_mode_in_data_valid_32_re = addr_hit[119] & reg_re & !reg_error;
 
-  assign raw_mode_in_data_valid_1_raw_mode_in_data_valid_33_re = addr_hit[81] & reg_re & !reg_error;
+  assign raw_mode_in_data_valid_1_raw_mode_in_data_valid_33_re = addr_hit[119] & reg_re & !reg_error;
 
-  assign raw_mode_in_data_valid_1_raw_mode_in_data_valid_34_re = addr_hit[81] & reg_re & !reg_error;
+  assign raw_mode_in_data_valid_1_raw_mode_in_data_valid_34_re = addr_hit[119] & reg_re & !reg_error;
 
-  assign raw_mode_in_data_valid_1_raw_mode_in_data_valid_35_re = addr_hit[81] & reg_re & !reg_error;
+  assign raw_mode_in_data_valid_1_raw_mode_in_data_valid_35_re = addr_hit[119] & reg_re & !reg_error;
 
-  assign raw_mode_in_data_valid_1_raw_mode_in_data_valid_36_re = addr_hit[81] & reg_re & !reg_error;
+  assign raw_mode_in_data_valid_1_raw_mode_in_data_valid_36_re = addr_hit[119] & reg_re & !reg_error;
 
-  assign raw_mode_in_data_valid_1_raw_mode_in_data_valid_37_re = addr_hit[81] & reg_re & !reg_error;
+  assign raw_mode_in_data_valid_1_raw_mode_in_data_valid_37_re = addr_hit[119] & reg_re & !reg_error;
 
-  assign raw_mode_in_data_re = addr_hit[82] & reg_re & !reg_error;
+  assign raw_mode_in_data_re = addr_hit[120] & reg_re & !reg_error;
 
-  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_0_we = addr_hit[83] & reg_we & !reg_error;
+  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_0_we = addr_hit[121] & reg_we & !reg_error;
   assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_0_wd = reg_wdata[0];
 
-  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_1_we = addr_hit[83] & reg_we & !reg_error;
+  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_1_we = addr_hit[121] & reg_we & !reg_error;
   assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_1_wd = reg_wdata[1];
 
-  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_2_we = addr_hit[83] & reg_we & !reg_error;
+  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_2_we = addr_hit[121] & reg_we & !reg_error;
   assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_2_wd = reg_wdata[2];
 
-  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_3_we = addr_hit[83] & reg_we & !reg_error;
+  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_3_we = addr_hit[121] & reg_we & !reg_error;
   assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_3_wd = reg_wdata[3];
 
-  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_4_we = addr_hit[83] & reg_we & !reg_error;
+  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_4_we = addr_hit[121] & reg_we & !reg_error;
   assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_4_wd = reg_wdata[4];
 
-  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_5_we = addr_hit[83] & reg_we & !reg_error;
+  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_5_we = addr_hit[121] & reg_we & !reg_error;
   assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_5_wd = reg_wdata[5];
 
-  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_6_we = addr_hit[83] & reg_we & !reg_error;
+  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_6_we = addr_hit[121] & reg_we & !reg_error;
   assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_6_wd = reg_wdata[6];
 
-  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_7_we = addr_hit[83] & reg_we & !reg_error;
+  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_7_we = addr_hit[121] & reg_we & !reg_error;
   assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_7_wd = reg_wdata[7];
 
-  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_8_we = addr_hit[83] & reg_we & !reg_error;
+  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_8_we = addr_hit[121] & reg_we & !reg_error;
   assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_8_wd = reg_wdata[8];
 
-  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_9_we = addr_hit[83] & reg_we & !reg_error;
+  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_9_we = addr_hit[121] & reg_we & !reg_error;
   assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_9_wd = reg_wdata[9];
 
-  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_10_we = addr_hit[83] & reg_we & !reg_error;
+  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_10_we = addr_hit[121] & reg_we & !reg_error;
   assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_10_wd = reg_wdata[10];
 
-  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_11_we = addr_hit[83] & reg_we & !reg_error;
+  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_11_we = addr_hit[121] & reg_we & !reg_error;
   assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_11_wd = reg_wdata[11];
 
-  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_12_we = addr_hit[83] & reg_we & !reg_error;
+  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_12_we = addr_hit[121] & reg_we & !reg_error;
   assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_12_wd = reg_wdata[12];
 
-  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_13_we = addr_hit[83] & reg_we & !reg_error;
+  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_13_we = addr_hit[121] & reg_we & !reg_error;
   assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_13_wd = reg_wdata[13];
 
-  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_14_we = addr_hit[83] & reg_we & !reg_error;
+  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_14_we = addr_hit[121] & reg_we & !reg_error;
   assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_14_wd = reg_wdata[14];
 
-  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_15_we = addr_hit[83] & reg_we & !reg_error;
+  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_15_we = addr_hit[121] & reg_we & !reg_error;
   assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_15_wd = reg_wdata[15];
 
-  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_16_we = addr_hit[83] & reg_we & !reg_error;
+  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_16_we = addr_hit[121] & reg_we & !reg_error;
   assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_16_wd = reg_wdata[16];
 
-  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_17_we = addr_hit[83] & reg_we & !reg_error;
+  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_17_we = addr_hit[121] & reg_we & !reg_error;
   assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_17_wd = reg_wdata[17];
 
-  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_18_we = addr_hit[83] & reg_we & !reg_error;
+  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_18_we = addr_hit[121] & reg_we & !reg_error;
   assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_18_wd = reg_wdata[18];
 
-  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_19_we = addr_hit[83] & reg_we & !reg_error;
+  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_19_we = addr_hit[121] & reg_we & !reg_error;
   assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_19_wd = reg_wdata[19];
 
-  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_20_we = addr_hit[83] & reg_we & !reg_error;
+  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_20_we = addr_hit[121] & reg_we & !reg_error;
   assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_20_wd = reg_wdata[20];
 
-  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_21_we = addr_hit[83] & reg_we & !reg_error;
+  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_21_we = addr_hit[121] & reg_we & !reg_error;
   assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_21_wd = reg_wdata[21];
 
-  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_22_we = addr_hit[83] & reg_we & !reg_error;
+  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_22_we = addr_hit[121] & reg_we & !reg_error;
   assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_22_wd = reg_wdata[22];
 
-  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_23_we = addr_hit[83] & reg_we & !reg_error;
+  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_23_we = addr_hit[121] & reg_we & !reg_error;
   assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_23_wd = reg_wdata[23];
 
-  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_24_we = addr_hit[83] & reg_we & !reg_error;
+  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_24_we = addr_hit[121] & reg_we & !reg_error;
   assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_24_wd = reg_wdata[24];
 
-  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_25_we = addr_hit[83] & reg_we & !reg_error;
+  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_25_we = addr_hit[121] & reg_we & !reg_error;
   assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_25_wd = reg_wdata[25];
 
-  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_26_we = addr_hit[83] & reg_we & !reg_error;
+  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_26_we = addr_hit[121] & reg_we & !reg_error;
   assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_26_wd = reg_wdata[26];
 
-  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_27_we = addr_hit[83] & reg_we & !reg_error;
+  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_27_we = addr_hit[121] & reg_we & !reg_error;
   assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_27_wd = reg_wdata[27];
 
-  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_28_we = addr_hit[83] & reg_we & !reg_error;
+  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_28_we = addr_hit[121] & reg_we & !reg_error;
   assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_28_wd = reg_wdata[28];
 
-  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_29_we = addr_hit[83] & reg_we & !reg_error;
+  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_29_we = addr_hit[121] & reg_we & !reg_error;
   assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_29_wd = reg_wdata[29];
 
-  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_30_we = addr_hit[83] & reg_we & !reg_error;
+  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_30_we = addr_hit[121] & reg_we & !reg_error;
   assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_30_wd = reg_wdata[30];
 
-  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_31_we = addr_hit[83] & reg_we & !reg_error;
+  assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_31_we = addr_hit[121] & reg_we & !reg_error;
   assign raw_mode_out_ch_mask_0_raw_mode_out_ch_mask_31_wd = reg_wdata[31];
 
-  assign raw_mode_out_ch_mask_1_raw_mode_out_ch_mask_32_we = addr_hit[84] & reg_we & !reg_error;
+  assign raw_mode_out_ch_mask_1_raw_mode_out_ch_mask_32_we = addr_hit[122] & reg_we & !reg_error;
   assign raw_mode_out_ch_mask_1_raw_mode_out_ch_mask_32_wd = reg_wdata[0];
 
-  assign raw_mode_out_ch_mask_1_raw_mode_out_ch_mask_33_we = addr_hit[84] & reg_we & !reg_error;
+  assign raw_mode_out_ch_mask_1_raw_mode_out_ch_mask_33_we = addr_hit[122] & reg_we & !reg_error;
   assign raw_mode_out_ch_mask_1_raw_mode_out_ch_mask_33_wd = reg_wdata[1];
 
-  assign raw_mode_out_ch_mask_1_raw_mode_out_ch_mask_34_we = addr_hit[84] & reg_we & !reg_error;
+  assign raw_mode_out_ch_mask_1_raw_mode_out_ch_mask_34_we = addr_hit[122] & reg_we & !reg_error;
   assign raw_mode_out_ch_mask_1_raw_mode_out_ch_mask_34_wd = reg_wdata[2];
 
-  assign raw_mode_out_ch_mask_1_raw_mode_out_ch_mask_35_we = addr_hit[84] & reg_we & !reg_error;
+  assign raw_mode_out_ch_mask_1_raw_mode_out_ch_mask_35_we = addr_hit[122] & reg_we & !reg_error;
   assign raw_mode_out_ch_mask_1_raw_mode_out_ch_mask_35_wd = reg_wdata[3];
 
-  assign raw_mode_out_ch_mask_1_raw_mode_out_ch_mask_36_we = addr_hit[84] & reg_we & !reg_error;
+  assign raw_mode_out_ch_mask_1_raw_mode_out_ch_mask_36_we = addr_hit[122] & reg_we & !reg_error;
   assign raw_mode_out_ch_mask_1_raw_mode_out_ch_mask_36_wd = reg_wdata[4];
 
-  assign raw_mode_out_ch_mask_1_raw_mode_out_ch_mask_37_we = addr_hit[84] & reg_we & !reg_error;
+  assign raw_mode_out_ch_mask_1_raw_mode_out_ch_mask_37_we = addr_hit[122] & reg_we & !reg_error;
   assign raw_mode_out_ch_mask_1_raw_mode_out_ch_mask_37_wd = reg_wdata[5];
 
-  assign raw_mode_out_data_fifo_we = addr_hit[85] & reg_we & !reg_error;
+  assign raw_mode_out_data_fifo_we = addr_hit[123] & reg_we & !reg_error;
   assign raw_mode_out_data_fifo_wd = reg_wdata[15:0];
 
-  assign raw_mode_out_data_fifo_ctrl_clear_we = addr_hit[86] & reg_we & !reg_error;
+  assign raw_mode_out_data_fifo_ctrl_clear_we = addr_hit[124] & reg_we & !reg_error;
   assign raw_mode_out_data_fifo_ctrl_clear_wd = reg_wdata[0];
 
-  assign raw_mode_out_data_fifo_ctrl_fill_state_re = addr_hit[86] & reg_re & !reg_error;
+  assign raw_mode_out_data_fifo_ctrl_fill_state_re = addr_hit[124] & reg_re & !reg_error;
 
-  assign raw_mode_out_data_fifo_ctrl_is_full_re = addr_hit[86] & reg_re & !reg_error;
+  assign raw_mode_out_data_fifo_ctrl_is_full_re = addr_hit[124] & reg_re & !reg_error;
 
-  assign raw_mode_out_en_we = addr_hit[87] & reg_we & !reg_error;
+  assign raw_mode_out_en_we = addr_hit[125] & reg_we & !reg_error;
   assign raw_mode_out_en_wd = reg_wdata[0];
 
-  assign flow_control_fifo_clear_we = addr_hit[88] & reg_we & !reg_error;
+  assign flow_control_fifo_clear_we = addr_hit[126] & reg_we & !reg_error;
   assign flow_control_fifo_clear_wd = reg_wdata[0];
 
-  assign channel_alloc_tx_cfg_bypass_en_we = addr_hit[89] & reg_we & !reg_error;
+  assign channel_alloc_tx_cfg_bypass_en_we = addr_hit[127] & reg_we & !reg_error;
   assign channel_alloc_tx_cfg_bypass_en_wd = reg_wdata[0];
 
-  assign channel_alloc_tx_cfg_auto_flush_en_we = addr_hit[89] & reg_we & !reg_error;
+  assign channel_alloc_tx_cfg_auto_flush_en_we = addr_hit[127] & reg_we & !reg_error;
   assign channel_alloc_tx_cfg_auto_flush_en_wd = reg_wdata[1];
 
-  assign channel_alloc_tx_cfg_auto_flush_count_we = addr_hit[89] & reg_we & !reg_error;
+  assign channel_alloc_tx_cfg_auto_flush_count_we = addr_hit[127] & reg_we & !reg_error;
   assign channel_alloc_tx_cfg_auto_flush_count_wd = reg_wdata[15:8];
 
-  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_0_we = addr_hit[90] & reg_we & !reg_error;
+  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_0_we = addr_hit[128] & reg_we & !reg_error;
   assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_0_wd = reg_wdata[0];
 
-  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_1_we = addr_hit[90] & reg_we & !reg_error;
+  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_1_we = addr_hit[128] & reg_we & !reg_error;
   assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_1_wd = reg_wdata[1];
 
-  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_2_we = addr_hit[90] & reg_we & !reg_error;
+  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_2_we = addr_hit[128] & reg_we & !reg_error;
   assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_2_wd = reg_wdata[2];
 
-  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_3_we = addr_hit[90] & reg_we & !reg_error;
+  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_3_we = addr_hit[128] & reg_we & !reg_error;
   assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_3_wd = reg_wdata[3];
 
-  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_4_we = addr_hit[90] & reg_we & !reg_error;
+  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_4_we = addr_hit[128] & reg_we & !reg_error;
   assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_4_wd = reg_wdata[4];
 
-  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_5_we = addr_hit[90] & reg_we & !reg_error;
+  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_5_we = addr_hit[128] & reg_we & !reg_error;
   assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_5_wd = reg_wdata[5];
 
-  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_6_we = addr_hit[90] & reg_we & !reg_error;
+  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_6_we = addr_hit[128] & reg_we & !reg_error;
   assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_6_wd = reg_wdata[6];
 
-  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_7_we = addr_hit[90] & reg_we & !reg_error;
+  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_7_we = addr_hit[128] & reg_we & !reg_error;
   assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_7_wd = reg_wdata[7];
 
-  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_8_we = addr_hit[90] & reg_we & !reg_error;
+  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_8_we = addr_hit[128] & reg_we & !reg_error;
   assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_8_wd = reg_wdata[8];
 
-  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_9_we = addr_hit[90] & reg_we & !reg_error;
+  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_9_we = addr_hit[128] & reg_we & !reg_error;
   assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_9_wd = reg_wdata[9];
 
-  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_10_we = addr_hit[90] & reg_we & !reg_error;
+  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_10_we = addr_hit[128] & reg_we & !reg_error;
   assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_10_wd = reg_wdata[10];
 
-  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_11_we = addr_hit[90] & reg_we & !reg_error;
+  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_11_we = addr_hit[128] & reg_we & !reg_error;
   assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_11_wd = reg_wdata[11];
 
-  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_12_we = addr_hit[90] & reg_we & !reg_error;
+  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_12_we = addr_hit[128] & reg_we & !reg_error;
   assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_12_wd = reg_wdata[12];
 
-  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_13_we = addr_hit[90] & reg_we & !reg_error;
+  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_13_we = addr_hit[128] & reg_we & !reg_error;
   assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_13_wd = reg_wdata[13];
 
-  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_14_we = addr_hit[90] & reg_we & !reg_error;
+  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_14_we = addr_hit[128] & reg_we & !reg_error;
   assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_14_wd = reg_wdata[14];
 
-  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_15_we = addr_hit[90] & reg_we & !reg_error;
+  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_15_we = addr_hit[128] & reg_we & !reg_error;
   assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_15_wd = reg_wdata[15];
 
-  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_16_we = addr_hit[90] & reg_we & !reg_error;
+  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_16_we = addr_hit[128] & reg_we & !reg_error;
   assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_16_wd = reg_wdata[16];
 
-  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_17_we = addr_hit[90] & reg_we & !reg_error;
+  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_17_we = addr_hit[128] & reg_we & !reg_error;
   assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_17_wd = reg_wdata[17];
 
-  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_18_we = addr_hit[90] & reg_we & !reg_error;
+  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_18_we = addr_hit[128] & reg_we & !reg_error;
   assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_18_wd = reg_wdata[18];
 
-  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_19_we = addr_hit[90] & reg_we & !reg_error;
+  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_19_we = addr_hit[128] & reg_we & !reg_error;
   assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_19_wd = reg_wdata[19];
 
-  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_20_we = addr_hit[90] & reg_we & !reg_error;
+  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_20_we = addr_hit[128] & reg_we & !reg_error;
   assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_20_wd = reg_wdata[20];
 
-  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_21_we = addr_hit[90] & reg_we & !reg_error;
+  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_21_we = addr_hit[128] & reg_we & !reg_error;
   assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_21_wd = reg_wdata[21];
 
-  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_22_we = addr_hit[90] & reg_we & !reg_error;
+  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_22_we = addr_hit[128] & reg_we & !reg_error;
   assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_22_wd = reg_wdata[22];
 
-  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_23_we = addr_hit[90] & reg_we & !reg_error;
+  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_23_we = addr_hit[128] & reg_we & !reg_error;
   assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_23_wd = reg_wdata[23];
 
-  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_24_we = addr_hit[90] & reg_we & !reg_error;
+  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_24_we = addr_hit[128] & reg_we & !reg_error;
   assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_24_wd = reg_wdata[24];
 
-  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_25_we = addr_hit[90] & reg_we & !reg_error;
+  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_25_we = addr_hit[128] & reg_we & !reg_error;
   assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_25_wd = reg_wdata[25];
 
-  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_26_we = addr_hit[90] & reg_we & !reg_error;
+  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_26_we = addr_hit[128] & reg_we & !reg_error;
   assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_26_wd = reg_wdata[26];
 
-  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_27_we = addr_hit[90] & reg_we & !reg_error;
+  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_27_we = addr_hit[128] & reg_we & !reg_error;
   assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_27_wd = reg_wdata[27];
 
-  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_28_we = addr_hit[90] & reg_we & !reg_error;
+  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_28_we = addr_hit[128] & reg_we & !reg_error;
   assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_28_wd = reg_wdata[28];
 
-  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_29_we = addr_hit[90] & reg_we & !reg_error;
+  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_29_we = addr_hit[128] & reg_we & !reg_error;
   assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_29_wd = reg_wdata[29];
 
-  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_30_we = addr_hit[90] & reg_we & !reg_error;
+  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_30_we = addr_hit[128] & reg_we & !reg_error;
   assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_30_wd = reg_wdata[30];
 
-  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_31_we = addr_hit[90] & reg_we & !reg_error;
+  assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_31_we = addr_hit[128] & reg_we & !reg_error;
   assign channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_31_wd = reg_wdata[31];
 
-  assign channel_alloc_tx_ch_en_1_channel_alloc_tx_ch_en_32_we = addr_hit[91] & reg_we & !reg_error;
+  assign channel_alloc_tx_ch_en_1_channel_alloc_tx_ch_en_32_we = addr_hit[129] & reg_we & !reg_error;
   assign channel_alloc_tx_ch_en_1_channel_alloc_tx_ch_en_32_wd = reg_wdata[0];
 
-  assign channel_alloc_tx_ch_en_1_channel_alloc_tx_ch_en_33_we = addr_hit[91] & reg_we & !reg_error;
+  assign channel_alloc_tx_ch_en_1_channel_alloc_tx_ch_en_33_we = addr_hit[129] & reg_we & !reg_error;
   assign channel_alloc_tx_ch_en_1_channel_alloc_tx_ch_en_33_wd = reg_wdata[1];
 
-  assign channel_alloc_tx_ch_en_1_channel_alloc_tx_ch_en_34_we = addr_hit[91] & reg_we & !reg_error;
+  assign channel_alloc_tx_ch_en_1_channel_alloc_tx_ch_en_34_we = addr_hit[129] & reg_we & !reg_error;
   assign channel_alloc_tx_ch_en_1_channel_alloc_tx_ch_en_34_wd = reg_wdata[2];
 
-  assign channel_alloc_tx_ch_en_1_channel_alloc_tx_ch_en_35_we = addr_hit[91] & reg_we & !reg_error;
+  assign channel_alloc_tx_ch_en_1_channel_alloc_tx_ch_en_35_we = addr_hit[129] & reg_we & !reg_error;
   assign channel_alloc_tx_ch_en_1_channel_alloc_tx_ch_en_35_wd = reg_wdata[3];
 
-  assign channel_alloc_tx_ch_en_1_channel_alloc_tx_ch_en_36_we = addr_hit[91] & reg_we & !reg_error;
+  assign channel_alloc_tx_ch_en_1_channel_alloc_tx_ch_en_36_we = addr_hit[129] & reg_we & !reg_error;
   assign channel_alloc_tx_ch_en_1_channel_alloc_tx_ch_en_36_wd = reg_wdata[4];
 
-  assign channel_alloc_tx_ch_en_1_channel_alloc_tx_ch_en_37_we = addr_hit[91] & reg_we & !reg_error;
+  assign channel_alloc_tx_ch_en_1_channel_alloc_tx_ch_en_37_we = addr_hit[129] & reg_we & !reg_error;
   assign channel_alloc_tx_ch_en_1_channel_alloc_tx_ch_en_37_wd = reg_wdata[5];
 
-  assign channel_alloc_tx_ctrl_clear_we = addr_hit[92] & reg_we & !reg_error;
+  assign channel_alloc_tx_ctrl_clear_we = addr_hit[130] & reg_we & !reg_error;
   assign channel_alloc_tx_ctrl_clear_wd = reg_wdata[0];
 
-  assign channel_alloc_tx_ctrl_flush_we = addr_hit[92] & reg_we & !reg_error;
+  assign channel_alloc_tx_ctrl_flush_we = addr_hit[130] & reg_we & !reg_error;
   assign channel_alloc_tx_ctrl_flush_wd = reg_wdata[1];
 
-  assign channel_alloc_rx_cfg_bypass_en_we = addr_hit[93] & reg_we & !reg_error;
+  assign channel_alloc_rx_cfg_bypass_en_we = addr_hit[131] & reg_we & !reg_error;
   assign channel_alloc_rx_cfg_bypass_en_wd = reg_wdata[0];
 
-  assign channel_alloc_rx_cfg_auto_flush_en_we = addr_hit[93] & reg_we & !reg_error;
+  assign channel_alloc_rx_cfg_auto_flush_en_we = addr_hit[131] & reg_we & !reg_error;
   assign channel_alloc_rx_cfg_auto_flush_en_wd = reg_wdata[1];
 
-  assign channel_alloc_rx_cfg_auto_flush_count_we = addr_hit[93] & reg_we & !reg_error;
+  assign channel_alloc_rx_cfg_auto_flush_count_we = addr_hit[131] & reg_we & !reg_error;
   assign channel_alloc_rx_cfg_auto_flush_count_wd = reg_wdata[15:8];
 
-  assign channel_alloc_rx_cfg_sync_en_we = addr_hit[93] & reg_we & !reg_error;
+  assign channel_alloc_rx_cfg_sync_en_we = addr_hit[131] & reg_we & !reg_error;
   assign channel_alloc_rx_cfg_sync_en_wd = reg_wdata[16];
 
-  assign channel_alloc_rx_ctrl_we = addr_hit[94] & reg_we & !reg_error;
+  assign channel_alloc_rx_ctrl_we = addr_hit[132] & reg_we & !reg_error;
   assign channel_alloc_rx_ctrl_wd = reg_wdata[0];
 
-  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_0_we = addr_hit[95] & reg_we & !reg_error;
+  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_0_we = addr_hit[133] & reg_we & !reg_error;
   assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_0_wd = reg_wdata[0];
 
-  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_1_we = addr_hit[95] & reg_we & !reg_error;
+  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_1_we = addr_hit[133] & reg_we & !reg_error;
   assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_1_wd = reg_wdata[1];
 
-  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_2_we = addr_hit[95] & reg_we & !reg_error;
+  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_2_we = addr_hit[133] & reg_we & !reg_error;
   assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_2_wd = reg_wdata[2];
 
-  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_3_we = addr_hit[95] & reg_we & !reg_error;
+  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_3_we = addr_hit[133] & reg_we & !reg_error;
   assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_3_wd = reg_wdata[3];
 
-  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_4_we = addr_hit[95] & reg_we & !reg_error;
+  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_4_we = addr_hit[133] & reg_we & !reg_error;
   assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_4_wd = reg_wdata[4];
 
-  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_5_we = addr_hit[95] & reg_we & !reg_error;
+  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_5_we = addr_hit[133] & reg_we & !reg_error;
   assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_5_wd = reg_wdata[5];
 
-  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_6_we = addr_hit[95] & reg_we & !reg_error;
+  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_6_we = addr_hit[133] & reg_we & !reg_error;
   assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_6_wd = reg_wdata[6];
 
-  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_7_we = addr_hit[95] & reg_we & !reg_error;
+  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_7_we = addr_hit[133] & reg_we & !reg_error;
   assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_7_wd = reg_wdata[7];
 
-  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_8_we = addr_hit[95] & reg_we & !reg_error;
+  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_8_we = addr_hit[133] & reg_we & !reg_error;
   assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_8_wd = reg_wdata[8];
 
-  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_9_we = addr_hit[95] & reg_we & !reg_error;
+  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_9_we = addr_hit[133] & reg_we & !reg_error;
   assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_9_wd = reg_wdata[9];
 
-  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_10_we = addr_hit[95] & reg_we & !reg_error;
+  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_10_we = addr_hit[133] & reg_we & !reg_error;
   assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_10_wd = reg_wdata[10];
 
-  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_11_we = addr_hit[95] & reg_we & !reg_error;
+  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_11_we = addr_hit[133] & reg_we & !reg_error;
   assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_11_wd = reg_wdata[11];
 
-  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_12_we = addr_hit[95] & reg_we & !reg_error;
+  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_12_we = addr_hit[133] & reg_we & !reg_error;
   assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_12_wd = reg_wdata[12];
 
-  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_13_we = addr_hit[95] & reg_we & !reg_error;
+  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_13_we = addr_hit[133] & reg_we & !reg_error;
   assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_13_wd = reg_wdata[13];
 
-  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_14_we = addr_hit[95] & reg_we & !reg_error;
+  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_14_we = addr_hit[133] & reg_we & !reg_error;
   assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_14_wd = reg_wdata[14];
 
-  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_15_we = addr_hit[95] & reg_we & !reg_error;
+  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_15_we = addr_hit[133] & reg_we & !reg_error;
   assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_15_wd = reg_wdata[15];
 
-  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_16_we = addr_hit[95] & reg_we & !reg_error;
+  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_16_we = addr_hit[133] & reg_we & !reg_error;
   assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_16_wd = reg_wdata[16];
 
-  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_17_we = addr_hit[95] & reg_we & !reg_error;
+  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_17_we = addr_hit[133] & reg_we & !reg_error;
   assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_17_wd = reg_wdata[17];
 
-  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_18_we = addr_hit[95] & reg_we & !reg_error;
+  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_18_we = addr_hit[133] & reg_we & !reg_error;
   assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_18_wd = reg_wdata[18];
 
-  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_19_we = addr_hit[95] & reg_we & !reg_error;
+  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_19_we = addr_hit[133] & reg_we & !reg_error;
   assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_19_wd = reg_wdata[19];
 
-  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_20_we = addr_hit[95] & reg_we & !reg_error;
+  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_20_we = addr_hit[133] & reg_we & !reg_error;
   assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_20_wd = reg_wdata[20];
 
-  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_21_we = addr_hit[95] & reg_we & !reg_error;
+  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_21_we = addr_hit[133] & reg_we & !reg_error;
   assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_21_wd = reg_wdata[21];
 
-  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_22_we = addr_hit[95] & reg_we & !reg_error;
+  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_22_we = addr_hit[133] & reg_we & !reg_error;
   assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_22_wd = reg_wdata[22];
 
-  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_23_we = addr_hit[95] & reg_we & !reg_error;
+  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_23_we = addr_hit[133] & reg_we & !reg_error;
   assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_23_wd = reg_wdata[23];
 
-  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_24_we = addr_hit[95] & reg_we & !reg_error;
+  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_24_we = addr_hit[133] & reg_we & !reg_error;
   assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_24_wd = reg_wdata[24];
 
-  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_25_we = addr_hit[95] & reg_we & !reg_error;
+  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_25_we = addr_hit[133] & reg_we & !reg_error;
   assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_25_wd = reg_wdata[25];
 
-  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_26_we = addr_hit[95] & reg_we & !reg_error;
+  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_26_we = addr_hit[133] & reg_we & !reg_error;
   assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_26_wd = reg_wdata[26];
 
-  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_27_we = addr_hit[95] & reg_we & !reg_error;
+  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_27_we = addr_hit[133] & reg_we & !reg_error;
   assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_27_wd = reg_wdata[27];
 
-  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_28_we = addr_hit[95] & reg_we & !reg_error;
+  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_28_we = addr_hit[133] & reg_we & !reg_error;
   assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_28_wd = reg_wdata[28];
 
-  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_29_we = addr_hit[95] & reg_we & !reg_error;
+  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_29_we = addr_hit[133] & reg_we & !reg_error;
   assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_29_wd = reg_wdata[29];
 
-  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_30_we = addr_hit[95] & reg_we & !reg_error;
+  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_30_we = addr_hit[133] & reg_we & !reg_error;
   assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_30_wd = reg_wdata[30];
 
-  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_31_we = addr_hit[95] & reg_we & !reg_error;
+  assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_31_we = addr_hit[133] & reg_we & !reg_error;
   assign channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_31_wd = reg_wdata[31];
 
-  assign channel_alloc_rx_ch_en_1_channel_alloc_rx_ch_en_32_we = addr_hit[96] & reg_we & !reg_error;
+  assign channel_alloc_rx_ch_en_1_channel_alloc_rx_ch_en_32_we = addr_hit[134] & reg_we & !reg_error;
   assign channel_alloc_rx_ch_en_1_channel_alloc_rx_ch_en_32_wd = reg_wdata[0];
 
-  assign channel_alloc_rx_ch_en_1_channel_alloc_rx_ch_en_33_we = addr_hit[96] & reg_we & !reg_error;
+  assign channel_alloc_rx_ch_en_1_channel_alloc_rx_ch_en_33_we = addr_hit[134] & reg_we & !reg_error;
   assign channel_alloc_rx_ch_en_1_channel_alloc_rx_ch_en_33_wd = reg_wdata[1];
 
-  assign channel_alloc_rx_ch_en_1_channel_alloc_rx_ch_en_34_we = addr_hit[96] & reg_we & !reg_error;
+  assign channel_alloc_rx_ch_en_1_channel_alloc_rx_ch_en_34_we = addr_hit[134] & reg_we & !reg_error;
   assign channel_alloc_rx_ch_en_1_channel_alloc_rx_ch_en_34_wd = reg_wdata[2];
 
-  assign channel_alloc_rx_ch_en_1_channel_alloc_rx_ch_en_35_we = addr_hit[96] & reg_we & !reg_error;
+  assign channel_alloc_rx_ch_en_1_channel_alloc_rx_ch_en_35_we = addr_hit[134] & reg_we & !reg_error;
   assign channel_alloc_rx_ch_en_1_channel_alloc_rx_ch_en_35_wd = reg_wdata[3];
 
-  assign channel_alloc_rx_ch_en_1_channel_alloc_rx_ch_en_36_we = addr_hit[96] & reg_we & !reg_error;
+  assign channel_alloc_rx_ch_en_1_channel_alloc_rx_ch_en_36_we = addr_hit[134] & reg_we & !reg_error;
   assign channel_alloc_rx_ch_en_1_channel_alloc_rx_ch_en_36_wd = reg_wdata[4];
 
-  assign channel_alloc_rx_ch_en_1_channel_alloc_rx_ch_en_37_we = addr_hit[96] & reg_we & !reg_error;
+  assign channel_alloc_rx_ch_en_1_channel_alloc_rx_ch_en_37_we = addr_hit[134] & reg_we & !reg_error;
   assign channel_alloc_rx_ch_en_1_channel_alloc_rx_ch_en_37_wd = reg_wdata[5];
 
   // Read data return
@@ -9265,204 +9305,318 @@ module serial_link_reg_top #(
       end
 
       addr_hit[40]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_0_clk_shift_start_0_qs;
-        reg_rdata_next[10:0] = tx_phy_ctrl2_0_clk_shift_end_0_qs;
+        reg_rdata_next[10:0] = tx_phy_ctrl2_0_qs;
       end
 
       addr_hit[41]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_1_clk_shift_start_1_qs;
-        reg_rdata_next[10:0] = tx_phy_ctrl2_1_clk_shift_end_1_qs;
+        reg_rdata_next[10:0] = tx_phy_ctrl2_1_qs;
       end
 
       addr_hit[42]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_2_clk_shift_start_2_qs;
-        reg_rdata_next[10:0] = tx_phy_ctrl2_2_clk_shift_end_2_qs;
+        reg_rdata_next[10:0] = tx_phy_ctrl2_2_qs;
       end
 
       addr_hit[43]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_3_clk_shift_start_3_qs;
-        reg_rdata_next[10:0] = tx_phy_ctrl2_3_clk_shift_end_3_qs;
+        reg_rdata_next[10:0] = tx_phy_ctrl2_3_qs;
       end
 
       addr_hit[44]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_4_clk_shift_start_4_qs;
-        reg_rdata_next[10:0] = tx_phy_ctrl2_4_clk_shift_end_4_qs;
+        reg_rdata_next[10:0] = tx_phy_ctrl2_4_qs;
       end
 
       addr_hit[45]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_5_clk_shift_start_5_qs;
-        reg_rdata_next[10:0] = tx_phy_ctrl2_5_clk_shift_end_5_qs;
+        reg_rdata_next[10:0] = tx_phy_ctrl2_5_qs;
       end
 
       addr_hit[46]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_6_clk_shift_start_6_qs;
-        reg_rdata_next[10:0] = tx_phy_ctrl2_6_clk_shift_end_6_qs;
+        reg_rdata_next[10:0] = tx_phy_ctrl2_6_qs;
       end
 
       addr_hit[47]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_7_clk_shift_start_7_qs;
-        reg_rdata_next[10:0] = tx_phy_ctrl2_7_clk_shift_end_7_qs;
+        reg_rdata_next[10:0] = tx_phy_ctrl2_7_qs;
       end
 
       addr_hit[48]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_8_clk_shift_start_8_qs;
-        reg_rdata_next[10:0] = tx_phy_ctrl2_8_clk_shift_end_8_qs;
+        reg_rdata_next[10:0] = tx_phy_ctrl2_8_qs;
       end
 
       addr_hit[49]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_9_clk_shift_start_9_qs;
-        reg_rdata_next[10:0] = tx_phy_ctrl2_9_clk_shift_end_9_qs;
+        reg_rdata_next[10:0] = tx_phy_ctrl2_9_qs;
       end
 
       addr_hit[50]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_10_clk_shift_start_10_qs;
-        reg_rdata_next[10:0] = tx_phy_ctrl2_10_clk_shift_end_10_qs;
+        reg_rdata_next[10:0] = tx_phy_ctrl2_10_qs;
       end
 
       addr_hit[51]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_11_clk_shift_start_11_qs;
-        reg_rdata_next[10:0] = tx_phy_ctrl2_11_clk_shift_end_11_qs;
+        reg_rdata_next[10:0] = tx_phy_ctrl2_11_qs;
       end
 
       addr_hit[52]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_12_clk_shift_start_12_qs;
-        reg_rdata_next[10:0] = tx_phy_ctrl2_12_clk_shift_end_12_qs;
+        reg_rdata_next[10:0] = tx_phy_ctrl2_12_qs;
       end
 
       addr_hit[53]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_13_clk_shift_start_13_qs;
-        reg_rdata_next[10:0] = tx_phy_ctrl2_13_clk_shift_end_13_qs;
+        reg_rdata_next[10:0] = tx_phy_ctrl2_13_qs;
       end
 
       addr_hit[54]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_14_clk_shift_start_14_qs;
-        reg_rdata_next[10:0] = tx_phy_ctrl2_14_clk_shift_end_14_qs;
+        reg_rdata_next[10:0] = tx_phy_ctrl2_14_qs;
       end
 
       addr_hit[55]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_15_clk_shift_start_15_qs;
-        reg_rdata_next[10:0] = tx_phy_ctrl2_15_clk_shift_end_15_qs;
+        reg_rdata_next[10:0] = tx_phy_ctrl2_15_qs;
       end
 
       addr_hit[56]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_16_clk_shift_start_16_qs;
-        reg_rdata_next[10:0] = tx_phy_ctrl2_16_clk_shift_end_16_qs;
+        reg_rdata_next[10:0] = tx_phy_ctrl2_16_qs;
       end
 
       addr_hit[57]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_17_clk_shift_start_17_qs;
-        reg_rdata_next[10:0] = tx_phy_ctrl2_17_clk_shift_end_17_qs;
+        reg_rdata_next[10:0] = tx_phy_ctrl2_17_qs;
       end
 
       addr_hit[58]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_18_clk_shift_start_18_qs;
-        reg_rdata_next[10:0] = tx_phy_ctrl2_18_clk_shift_end_18_qs;
+        reg_rdata_next[10:0] = tx_phy_ctrl2_18_qs;
       end
 
       addr_hit[59]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_19_clk_shift_start_19_qs;
-        reg_rdata_next[10:0] = tx_phy_ctrl2_19_clk_shift_end_19_qs;
+        reg_rdata_next[10:0] = tx_phy_ctrl2_19_qs;
       end
 
       addr_hit[60]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_20_clk_shift_start_20_qs;
-        reg_rdata_next[10:0] = tx_phy_ctrl2_20_clk_shift_end_20_qs;
+        reg_rdata_next[10:0] = tx_phy_ctrl2_20_qs;
       end
 
       addr_hit[61]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_21_clk_shift_start_21_qs;
-        reg_rdata_next[10:0] = tx_phy_ctrl2_21_clk_shift_end_21_qs;
+        reg_rdata_next[10:0] = tx_phy_ctrl2_21_qs;
       end
 
       addr_hit[62]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_22_clk_shift_start_22_qs;
-        reg_rdata_next[10:0] = tx_phy_ctrl2_22_clk_shift_end_22_qs;
+        reg_rdata_next[10:0] = tx_phy_ctrl2_22_qs;
       end
 
       addr_hit[63]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_23_clk_shift_start_23_qs;
-        reg_rdata_next[10:0] = tx_phy_ctrl2_23_clk_shift_end_23_qs;
+        reg_rdata_next[10:0] = tx_phy_ctrl2_23_qs;
       end
 
       addr_hit[64]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_24_clk_shift_start_24_qs;
-        reg_rdata_next[10:0] = tx_phy_ctrl2_24_clk_shift_end_24_qs;
+        reg_rdata_next[10:0] = tx_phy_ctrl2_24_qs;
       end
 
       addr_hit[65]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_25_clk_shift_start_25_qs;
-        reg_rdata_next[10:0] = tx_phy_ctrl2_25_clk_shift_end_25_qs;
+        reg_rdata_next[10:0] = tx_phy_ctrl2_25_qs;
       end
 
       addr_hit[66]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_26_clk_shift_start_26_qs;
-        reg_rdata_next[10:0] = tx_phy_ctrl2_26_clk_shift_end_26_qs;
+        reg_rdata_next[10:0] = tx_phy_ctrl2_26_qs;
       end
 
       addr_hit[67]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_27_clk_shift_start_27_qs;
-        reg_rdata_next[10:0] = tx_phy_ctrl2_27_clk_shift_end_27_qs;
+        reg_rdata_next[10:0] = tx_phy_ctrl2_27_qs;
       end
 
       addr_hit[68]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_28_clk_shift_start_28_qs;
-        reg_rdata_next[10:0] = tx_phy_ctrl2_28_clk_shift_end_28_qs;
+        reg_rdata_next[10:0] = tx_phy_ctrl2_28_qs;
       end
 
       addr_hit[69]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_29_clk_shift_start_29_qs;
-        reg_rdata_next[10:0] = tx_phy_ctrl2_29_clk_shift_end_29_qs;
+        reg_rdata_next[10:0] = tx_phy_ctrl2_29_qs;
       end
 
       addr_hit[70]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_30_clk_shift_start_30_qs;
-        reg_rdata_next[10:0] = tx_phy_ctrl2_30_clk_shift_end_30_qs;
+        reg_rdata_next[10:0] = tx_phy_ctrl2_30_qs;
       end
 
       addr_hit[71]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_31_clk_shift_start_31_qs;
-        reg_rdata_next[10:0] = tx_phy_ctrl2_31_clk_shift_end_31_qs;
+        reg_rdata_next[10:0] = tx_phy_ctrl2_31_qs;
       end
 
       addr_hit[72]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_32_clk_shift_start_32_qs;
-        reg_rdata_next[10:0] = tx_phy_ctrl2_32_clk_shift_end_32_qs;
+        reg_rdata_next[10:0] = tx_phy_ctrl2_32_qs;
       end
 
       addr_hit[73]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_33_clk_shift_start_33_qs;
-        reg_rdata_next[10:0] = tx_phy_ctrl2_33_clk_shift_end_33_qs;
+        reg_rdata_next[10:0] = tx_phy_ctrl2_33_qs;
       end
 
       addr_hit[74]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_34_clk_shift_start_34_qs;
-        reg_rdata_next[10:0] = tx_phy_ctrl2_34_clk_shift_end_34_qs;
+        reg_rdata_next[10:0] = tx_phy_ctrl2_34_qs;
       end
 
       addr_hit[75]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_35_clk_shift_start_35_qs;
-        reg_rdata_next[10:0] = tx_phy_ctrl2_35_clk_shift_end_35_qs;
+        reg_rdata_next[10:0] = tx_phy_ctrl2_35_qs;
       end
 
       addr_hit[76]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_36_clk_shift_start_36_qs;
-        reg_rdata_next[10:0] = tx_phy_ctrl2_36_clk_shift_end_36_qs;
+        reg_rdata_next[10:0] = tx_phy_ctrl2_36_qs;
       end
 
       addr_hit[77]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_37_clk_shift_start_37_qs;
-        reg_rdata_next[10:0] = tx_phy_ctrl2_37_clk_shift_end_37_qs;
+        reg_rdata_next[10:0] = tx_phy_ctrl2_37_qs;
       end
 
       addr_hit[78]: begin
-        reg_rdata_next[0] = '0;
+        reg_rdata_next[10:0] = tx_phy_ctrl3_0_qs;
       end
 
       addr_hit[79]: begin
-        reg_rdata_next[5:0] = '0;
+        reg_rdata_next[10:0] = tx_phy_ctrl3_1_qs;
       end
 
       addr_hit[80]: begin
+        reg_rdata_next[10:0] = tx_phy_ctrl3_2_qs;
+      end
+
+      addr_hit[81]: begin
+        reg_rdata_next[10:0] = tx_phy_ctrl3_3_qs;
+      end
+
+      addr_hit[82]: begin
+        reg_rdata_next[10:0] = tx_phy_ctrl3_4_qs;
+      end
+
+      addr_hit[83]: begin
+        reg_rdata_next[10:0] = tx_phy_ctrl3_5_qs;
+      end
+
+      addr_hit[84]: begin
+        reg_rdata_next[10:0] = tx_phy_ctrl3_6_qs;
+      end
+
+      addr_hit[85]: begin
+        reg_rdata_next[10:0] = tx_phy_ctrl3_7_qs;
+      end
+
+      addr_hit[86]: begin
+        reg_rdata_next[10:0] = tx_phy_ctrl3_8_qs;
+      end
+
+      addr_hit[87]: begin
+        reg_rdata_next[10:0] = tx_phy_ctrl3_9_qs;
+      end
+
+      addr_hit[88]: begin
+        reg_rdata_next[10:0] = tx_phy_ctrl3_10_qs;
+      end
+
+      addr_hit[89]: begin
+        reg_rdata_next[10:0] = tx_phy_ctrl3_11_qs;
+      end
+
+      addr_hit[90]: begin
+        reg_rdata_next[10:0] = tx_phy_ctrl3_12_qs;
+      end
+
+      addr_hit[91]: begin
+        reg_rdata_next[10:0] = tx_phy_ctrl3_13_qs;
+      end
+
+      addr_hit[92]: begin
+        reg_rdata_next[10:0] = tx_phy_ctrl3_14_qs;
+      end
+
+      addr_hit[93]: begin
+        reg_rdata_next[10:0] = tx_phy_ctrl3_15_qs;
+      end
+
+      addr_hit[94]: begin
+        reg_rdata_next[10:0] = tx_phy_ctrl3_16_qs;
+      end
+
+      addr_hit[95]: begin
+        reg_rdata_next[10:0] = tx_phy_ctrl3_17_qs;
+      end
+
+      addr_hit[96]: begin
+        reg_rdata_next[10:0] = tx_phy_ctrl3_18_qs;
+      end
+
+      addr_hit[97]: begin
+        reg_rdata_next[10:0] = tx_phy_ctrl3_19_qs;
+      end
+
+      addr_hit[98]: begin
+        reg_rdata_next[10:0] = tx_phy_ctrl3_20_qs;
+      end
+
+      addr_hit[99]: begin
+        reg_rdata_next[10:0] = tx_phy_ctrl3_21_qs;
+      end
+
+      addr_hit[100]: begin
+        reg_rdata_next[10:0] = tx_phy_ctrl3_22_qs;
+      end
+
+      addr_hit[101]: begin
+        reg_rdata_next[10:0] = tx_phy_ctrl3_23_qs;
+      end
+
+      addr_hit[102]: begin
+        reg_rdata_next[10:0] = tx_phy_ctrl3_24_qs;
+      end
+
+      addr_hit[103]: begin
+        reg_rdata_next[10:0] = tx_phy_ctrl3_25_qs;
+      end
+
+      addr_hit[104]: begin
+        reg_rdata_next[10:0] = tx_phy_ctrl3_26_qs;
+      end
+
+      addr_hit[105]: begin
+        reg_rdata_next[10:0] = tx_phy_ctrl3_27_qs;
+      end
+
+      addr_hit[106]: begin
+        reg_rdata_next[10:0] = tx_phy_ctrl3_28_qs;
+      end
+
+      addr_hit[107]: begin
+        reg_rdata_next[10:0] = tx_phy_ctrl3_29_qs;
+      end
+
+      addr_hit[108]: begin
+        reg_rdata_next[10:0] = tx_phy_ctrl3_30_qs;
+      end
+
+      addr_hit[109]: begin
+        reg_rdata_next[10:0] = tx_phy_ctrl3_31_qs;
+      end
+
+      addr_hit[110]: begin
+        reg_rdata_next[10:0] = tx_phy_ctrl3_32_qs;
+      end
+
+      addr_hit[111]: begin
+        reg_rdata_next[10:0] = tx_phy_ctrl3_33_qs;
+      end
+
+      addr_hit[112]: begin
+        reg_rdata_next[10:0] = tx_phy_ctrl3_34_qs;
+      end
+
+      addr_hit[113]: begin
+        reg_rdata_next[10:0] = tx_phy_ctrl3_35_qs;
+      end
+
+      addr_hit[114]: begin
+        reg_rdata_next[10:0] = tx_phy_ctrl3_36_qs;
+      end
+
+      addr_hit[115]: begin
+        reg_rdata_next[10:0] = tx_phy_ctrl3_37_qs;
+      end
+
+      addr_hit[116]: begin
+        reg_rdata_next[0] = '0;
+      end
+
+      addr_hit[117]: begin
+        reg_rdata_next[5:0] = '0;
+      end
+
+      addr_hit[118]: begin
         reg_rdata_next[0] = raw_mode_in_data_valid_0_raw_mode_in_data_valid_0_qs;
         reg_rdata_next[1] = raw_mode_in_data_valid_0_raw_mode_in_data_valid_1_qs;
         reg_rdata_next[2] = raw_mode_in_data_valid_0_raw_mode_in_data_valid_2_qs;
@@ -9497,7 +9651,7 @@ module serial_link_reg_top #(
         reg_rdata_next[31] = raw_mode_in_data_valid_0_raw_mode_in_data_valid_31_qs;
       end
 
-      addr_hit[81]: begin
+      addr_hit[119]: begin
         reg_rdata_next[0] = raw_mode_in_data_valid_1_raw_mode_in_data_valid_32_qs;
         reg_rdata_next[1] = raw_mode_in_data_valid_1_raw_mode_in_data_valid_33_qs;
         reg_rdata_next[2] = raw_mode_in_data_valid_1_raw_mode_in_data_valid_34_qs;
@@ -9506,11 +9660,11 @@ module serial_link_reg_top #(
         reg_rdata_next[5] = raw_mode_in_data_valid_1_raw_mode_in_data_valid_37_qs;
       end
 
-      addr_hit[82]: begin
+      addr_hit[120]: begin
         reg_rdata_next[15:0] = raw_mode_in_data_qs;
       end
 
-      addr_hit[83]: begin
+      addr_hit[121]: begin
         reg_rdata_next[0] = '0;
         reg_rdata_next[1] = '0;
         reg_rdata_next[2] = '0;
@@ -9545,7 +9699,7 @@ module serial_link_reg_top #(
         reg_rdata_next[31] = '0;
       end
 
-      addr_hit[84]: begin
+      addr_hit[122]: begin
         reg_rdata_next[0] = '0;
         reg_rdata_next[1] = '0;
         reg_rdata_next[2] = '0;
@@ -9554,31 +9708,31 @@ module serial_link_reg_top #(
         reg_rdata_next[5] = '0;
       end
 
-      addr_hit[85]: begin
+      addr_hit[123]: begin
         reg_rdata_next[15:0] = '0;
       end
 
-      addr_hit[86]: begin
+      addr_hit[124]: begin
         reg_rdata_next[0] = '0;
         reg_rdata_next[10:8] = raw_mode_out_data_fifo_ctrl_fill_state_qs;
         reg_rdata_next[31] = raw_mode_out_data_fifo_ctrl_is_full_qs;
       end
 
-      addr_hit[87]: begin
+      addr_hit[125]: begin
         reg_rdata_next[0] = raw_mode_out_en_qs;
       end
 
-      addr_hit[88]: begin
+      addr_hit[126]: begin
         reg_rdata_next[0] = '0;
       end
 
-      addr_hit[89]: begin
+      addr_hit[127]: begin
         reg_rdata_next[0] = channel_alloc_tx_cfg_bypass_en_qs;
         reg_rdata_next[1] = channel_alloc_tx_cfg_auto_flush_en_qs;
         reg_rdata_next[15:8] = channel_alloc_tx_cfg_auto_flush_count_qs;
       end
 
-      addr_hit[90]: begin
+      addr_hit[128]: begin
         reg_rdata_next[0] = channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_0_qs;
         reg_rdata_next[1] = channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_1_qs;
         reg_rdata_next[2] = channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_2_qs;
@@ -9613,7 +9767,7 @@ module serial_link_reg_top #(
         reg_rdata_next[31] = channel_alloc_tx_ch_en_0_channel_alloc_tx_ch_en_31_qs;
       end
 
-      addr_hit[91]: begin
+      addr_hit[129]: begin
         reg_rdata_next[0] = channel_alloc_tx_ch_en_1_channel_alloc_tx_ch_en_32_qs;
         reg_rdata_next[1] = channel_alloc_tx_ch_en_1_channel_alloc_tx_ch_en_33_qs;
         reg_rdata_next[2] = channel_alloc_tx_ch_en_1_channel_alloc_tx_ch_en_34_qs;
@@ -9622,23 +9776,23 @@ module serial_link_reg_top #(
         reg_rdata_next[5] = channel_alloc_tx_ch_en_1_channel_alloc_tx_ch_en_37_qs;
       end
 
-      addr_hit[92]: begin
+      addr_hit[130]: begin
         reg_rdata_next[0] = '0;
         reg_rdata_next[1] = '0;
       end
 
-      addr_hit[93]: begin
+      addr_hit[131]: begin
         reg_rdata_next[0] = channel_alloc_rx_cfg_bypass_en_qs;
         reg_rdata_next[1] = channel_alloc_rx_cfg_auto_flush_en_qs;
         reg_rdata_next[15:8] = channel_alloc_rx_cfg_auto_flush_count_qs;
         reg_rdata_next[16] = channel_alloc_rx_cfg_sync_en_qs;
       end
 
-      addr_hit[94]: begin
+      addr_hit[132]: begin
         reg_rdata_next[0] = '0;
       end
 
-      addr_hit[95]: begin
+      addr_hit[133]: begin
         reg_rdata_next[0] = channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_0_qs;
         reg_rdata_next[1] = channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_1_qs;
         reg_rdata_next[2] = channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_2_qs;
@@ -9673,7 +9827,7 @@ module serial_link_reg_top #(
         reg_rdata_next[31] = channel_alloc_rx_ch_en_0_channel_alloc_rx_ch_en_31_qs;
       end
 
-      addr_hit[96]: begin
+      addr_hit[134]: begin
         reg_rdata_next[0] = channel_alloc_rx_ch_en_1_channel_alloc_rx_ch_en_32_qs;
         reg_rdata_next[1] = channel_alloc_rx_ch_en_1_channel_alloc_rx_ch_en_33_qs;
         reg_rdata_next[2] = channel_alloc_rx_ch_en_1_channel_alloc_rx_ch_en_34_qs;
@@ -9704,7 +9858,7 @@ endmodule
 
 module serial_link_reg_top_intf
 #(
-  parameter int AW = 9,
+  parameter int AW = 10,
   localparam int DW = 32
 ) (
   input logic clk_i,

--- a/src/regs/serial_link_single_channel.hjson
+++ b/src/regs/serial_link_single_channel.hjson
@@ -97,10 +97,10 @@
     },
     { multireg:
       {
-        name: "TX_PHY_CTRL1",
+        name: "TX_PHY_CLK_DIV",
         desc: "Holds clock divider factor for forwarded clock of the TX Phys",
         count: "NumChannels",
-        cname: "TX_PHY_CTRL1",
+        cname: "TX_PHY_CLK_DIV",
         swaccess: "rw",
         hwaccess: "hro",
         compact: false,
@@ -115,10 +115,10 @@
     },
     { multireg:
       {
-        name: "TX_PHY_CTRL2",
+        name: "TX_PHY_CLK_START",
         desc: "Controls duty cycle and phase of rising edge in TX Phys",
         count: "NumChannels",
-        cname: "TX_PHY_CTRL2",
+        cname: "TX_PHY_CLK_START",
         compact: false,
         swaccess: "rw",
         hwaccess: "hro",
@@ -133,10 +133,10 @@
     },
     { multireg:
       {
-        name: "TX_PHY_CTRL3",
+        name: "TX_PHY_CLK_END",
         desc: "Controls duty cycle and phase of falling edge in TX Phys",
         count: "NumChannels",
-        cname: "TX_PHY_CTRL3",
+        cname: "TX_PHY_CLK_END",
         compact: false,
         swaccess: "rw",
         hwaccess: "hro",

--- a/src/regs/serial_link_single_channel.hjson
+++ b/src/regs/serial_link_single_channel.hjson
@@ -116,7 +116,7 @@
     { multireg:
       {
         name: "TX_PHY_CTRL2",
-        desc: "Controls duty cycle and phase of rising and falling edge in TX Phys",
+        desc: "Controls duty cycle and phase of rising edge in TX Phys",
         count: "NumChannels",
         cname: "TX_PHY_CTRL2",
         compact: false,
@@ -127,7 +127,20 @@
             name: "clk_shift_start",
             desc: "Positive Edge of divided, shifted clock",
             resval: 2
-          },
+          }
+        ]
+      }
+    },
+    { multireg:
+      {
+        name: "TX_PHY_CTRL3",
+        desc: "Controls duty cycle and phase of falling edge in TX Phys",
+        count: "NumChannels",
+        cname: "TX_PHY_CTRL3",
+        compact: false,
+        swaccess: "rw",
+        hwaccess: "hro",
+        fields: [
           { bits: "Log2MaxClkDiv:0",
             name: "clk_shift_end",
             desc: "Negative Edge of divided, shifted clock",

--- a/src/regs/serial_link_single_channel_reg_pkg.sv
+++ b/src/regs/serial_link_single_channel_reg_pkg.sv
@@ -37,15 +37,15 @@ package serial_link_single_channel_reg_pkg;
 
   typedef struct packed {
     logic [10:0] q;
-  } serial_link_single_channel_reg2hw_tx_phy_ctrl1_mreg_t;
+  } serial_link_single_channel_reg2hw_tx_phy_clk_div_mreg_t;
 
   typedef struct packed {
     logic [10:0] q;
-  } serial_link_single_channel_reg2hw_tx_phy_ctrl2_mreg_t;
+  } serial_link_single_channel_reg2hw_tx_phy_clk_start_mreg_t;
 
   typedef struct packed {
     logic [10:0] q;
-  } serial_link_single_channel_reg2hw_tx_phy_ctrl3_mreg_t;
+  } serial_link_single_channel_reg2hw_tx_phy_clk_end_mreg_t;
 
   typedef struct packed {
     logic        q;
@@ -114,9 +114,9 @@ package serial_link_single_channel_reg_pkg;
   // Register -> HW type
   typedef struct packed {
     serial_link_single_channel_reg2hw_ctrl_reg_t ctrl; // [78:75]
-    serial_link_single_channel_reg2hw_tx_phy_ctrl1_mreg_t [0:0] tx_phy_ctrl1; // [74:64]
-    serial_link_single_channel_reg2hw_tx_phy_ctrl2_mreg_t [0:0] tx_phy_ctrl2; // [63:53]
-    serial_link_single_channel_reg2hw_tx_phy_ctrl3_mreg_t [0:0] tx_phy_ctrl3; // [52:42]
+    serial_link_single_channel_reg2hw_tx_phy_clk_div_mreg_t [0:0] tx_phy_clk_div; // [74:64]
+    serial_link_single_channel_reg2hw_tx_phy_clk_start_mreg_t [0:0] tx_phy_clk_start; // [63:53]
+    serial_link_single_channel_reg2hw_tx_phy_clk_end_mreg_t [0:0] tx_phy_clk_end; // [52:42]
     serial_link_single_channel_reg2hw_raw_mode_en_reg_t raw_mode_en; // [41:41]
     serial_link_single_channel_reg2hw_raw_mode_in_ch_sel_reg_t raw_mode_in_ch_sel; // [40:40]
     serial_link_single_channel_reg2hw_raw_mode_in_data_reg_t raw_mode_in_data; // [39:23]
@@ -138,9 +138,9 @@ package serial_link_single_channel_reg_pkg;
   // Register offsets
   parameter logic [BlockAw-1:0] SERIAL_LINK_SINGLE_CHANNEL_CTRL_OFFSET = 6'h 0;
   parameter logic [BlockAw-1:0] SERIAL_LINK_SINGLE_CHANNEL_ISOLATED_OFFSET = 6'h 4;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_SINGLE_CHANNEL_TX_PHY_CTRL1_OFFSET = 6'h 8;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_SINGLE_CHANNEL_TX_PHY_CTRL2_OFFSET = 6'h c;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_SINGLE_CHANNEL_TX_PHY_CTRL3_OFFSET = 6'h 10;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_SINGLE_CHANNEL_TX_PHY_CLK_DIV_OFFSET = 6'h 8;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_SINGLE_CHANNEL_TX_PHY_CLK_START_OFFSET = 6'h c;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_SINGLE_CHANNEL_TX_PHY_CLK_END_OFFSET = 6'h 10;
   parameter logic [BlockAw-1:0] SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_EN_OFFSET = 6'h 14;
   parameter logic [BlockAw-1:0] SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_IN_CH_SEL_OFFSET = 6'h 18;
   parameter logic [BlockAw-1:0] SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_IN_DATA_VALID_OFFSET = 6'h 1c;
@@ -167,9 +167,9 @@ package serial_link_single_channel_reg_pkg;
   typedef enum int {
     SERIAL_LINK_SINGLE_CHANNEL_CTRL,
     SERIAL_LINK_SINGLE_CHANNEL_ISOLATED,
-    SERIAL_LINK_SINGLE_CHANNEL_TX_PHY_CTRL1,
-    SERIAL_LINK_SINGLE_CHANNEL_TX_PHY_CTRL2,
-    SERIAL_LINK_SINGLE_CHANNEL_TX_PHY_CTRL3,
+    SERIAL_LINK_SINGLE_CHANNEL_TX_PHY_CLK_DIV,
+    SERIAL_LINK_SINGLE_CHANNEL_TX_PHY_CLK_START,
+    SERIAL_LINK_SINGLE_CHANNEL_TX_PHY_CLK_END,
     SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_EN,
     SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_IN_CH_SEL,
     SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_IN_DATA_VALID,
@@ -185,9 +185,9 @@ package serial_link_single_channel_reg_pkg;
   parameter logic [3:0] SERIAL_LINK_SINGLE_CHANNEL_PERMIT [14] = '{
     4'b 0011, // index[ 0] SERIAL_LINK_SINGLE_CHANNEL_CTRL
     4'b 0001, // index[ 1] SERIAL_LINK_SINGLE_CHANNEL_ISOLATED
-    4'b 0011, // index[ 2] SERIAL_LINK_SINGLE_CHANNEL_TX_PHY_CTRL1
-    4'b 0011, // index[ 3] SERIAL_LINK_SINGLE_CHANNEL_TX_PHY_CTRL2
-    4'b 0011, // index[ 4] SERIAL_LINK_SINGLE_CHANNEL_TX_PHY_CTRL3
+    4'b 0011, // index[ 2] SERIAL_LINK_SINGLE_CHANNEL_TX_PHY_CLK_DIV
+    4'b 0011, // index[ 3] SERIAL_LINK_SINGLE_CHANNEL_TX_PHY_CLK_START
+    4'b 0011, // index[ 4] SERIAL_LINK_SINGLE_CHANNEL_TX_PHY_CLK_END
     4'b 0001, // index[ 5] SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_EN
     4'b 0001, // index[ 6] SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_IN_CH_SEL
     4'b 0001, // index[ 7] SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_IN_DATA_VALID

--- a/src/regs/serial_link_single_channel_reg_pkg.sv
+++ b/src/regs/serial_link_single_channel_reg_pkg.sv
@@ -40,13 +40,12 @@ package serial_link_single_channel_reg_pkg;
   } serial_link_single_channel_reg2hw_tx_phy_ctrl1_mreg_t;
 
   typedef struct packed {
-    struct packed {
-      logic [10:0] q;
-    } clk_shift_start;
-    struct packed {
-      logic [10:0] q;
-    } clk_shift_end;
+    logic [10:0] q;
   } serial_link_single_channel_reg2hw_tx_phy_ctrl2_mreg_t;
+
+  typedef struct packed {
+    logic [10:0] q;
+  } serial_link_single_channel_reg2hw_tx_phy_ctrl3_mreg_t;
 
   typedef struct packed {
     logic        q;
@@ -116,7 +115,8 @@ package serial_link_single_channel_reg_pkg;
   typedef struct packed {
     serial_link_single_channel_reg2hw_ctrl_reg_t ctrl; // [78:75]
     serial_link_single_channel_reg2hw_tx_phy_ctrl1_mreg_t [0:0] tx_phy_ctrl1; // [74:64]
-    serial_link_single_channel_reg2hw_tx_phy_ctrl2_mreg_t [0:0] tx_phy_ctrl2; // [63:42]
+    serial_link_single_channel_reg2hw_tx_phy_ctrl2_mreg_t [0:0] tx_phy_ctrl2; // [63:53]
+    serial_link_single_channel_reg2hw_tx_phy_ctrl3_mreg_t [0:0] tx_phy_ctrl3; // [52:42]
     serial_link_single_channel_reg2hw_raw_mode_en_reg_t raw_mode_en; // [41:41]
     serial_link_single_channel_reg2hw_raw_mode_in_ch_sel_reg_t raw_mode_in_ch_sel; // [40:40]
     serial_link_single_channel_reg2hw_raw_mode_in_data_reg_t raw_mode_in_data; // [39:23]
@@ -140,15 +140,16 @@ package serial_link_single_channel_reg_pkg;
   parameter logic [BlockAw-1:0] SERIAL_LINK_SINGLE_CHANNEL_ISOLATED_OFFSET = 6'h 4;
   parameter logic [BlockAw-1:0] SERIAL_LINK_SINGLE_CHANNEL_TX_PHY_CTRL1_OFFSET = 6'h 8;
   parameter logic [BlockAw-1:0] SERIAL_LINK_SINGLE_CHANNEL_TX_PHY_CTRL2_OFFSET = 6'h c;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_EN_OFFSET = 6'h 10;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_IN_CH_SEL_OFFSET = 6'h 14;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_IN_DATA_VALID_OFFSET = 6'h 18;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_IN_DATA_OFFSET = 6'h 1c;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_OUT_CH_MASK_OFFSET = 6'h 20;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_OUT_DATA_FIFO_OFFSET = 6'h 24;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_OUT_DATA_FIFO_CTRL_OFFSET = 6'h 28;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_OUT_EN_OFFSET = 6'h 2c;
-  parameter logic [BlockAw-1:0] SERIAL_LINK_SINGLE_CHANNEL_FLOW_CONTROL_FIFO_CLEAR_OFFSET = 6'h 30;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_SINGLE_CHANNEL_TX_PHY_CTRL3_OFFSET = 6'h 10;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_EN_OFFSET = 6'h 14;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_IN_CH_SEL_OFFSET = 6'h 18;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_IN_DATA_VALID_OFFSET = 6'h 1c;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_IN_DATA_OFFSET = 6'h 20;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_OUT_CH_MASK_OFFSET = 6'h 24;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_OUT_DATA_FIFO_OFFSET = 6'h 28;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_OUT_DATA_FIFO_CTRL_OFFSET = 6'h 2c;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_OUT_EN_OFFSET = 6'h 30;
+  parameter logic [BlockAw-1:0] SERIAL_LINK_SINGLE_CHANNEL_FLOW_CONTROL_FIFO_CLEAR_OFFSET = 6'h 34;
 
   // Reset values for hwext registers and their fields
   parameter logic [1:0] SERIAL_LINK_SINGLE_CHANNEL_ISOLATED_RESVAL = 2'h 3;
@@ -168,6 +169,7 @@ package serial_link_single_channel_reg_pkg;
     SERIAL_LINK_SINGLE_CHANNEL_ISOLATED,
     SERIAL_LINK_SINGLE_CHANNEL_TX_PHY_CTRL1,
     SERIAL_LINK_SINGLE_CHANNEL_TX_PHY_CTRL2,
+    SERIAL_LINK_SINGLE_CHANNEL_TX_PHY_CTRL3,
     SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_EN,
     SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_IN_CH_SEL,
     SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_IN_DATA_VALID,
@@ -180,20 +182,21 @@ package serial_link_single_channel_reg_pkg;
   } serial_link_single_channel_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] SERIAL_LINK_SINGLE_CHANNEL_PERMIT [13] = '{
+  parameter logic [3:0] SERIAL_LINK_SINGLE_CHANNEL_PERMIT [14] = '{
     4'b 0011, // index[ 0] SERIAL_LINK_SINGLE_CHANNEL_CTRL
     4'b 0001, // index[ 1] SERIAL_LINK_SINGLE_CHANNEL_ISOLATED
     4'b 0011, // index[ 2] SERIAL_LINK_SINGLE_CHANNEL_TX_PHY_CTRL1
     4'b 0011, // index[ 3] SERIAL_LINK_SINGLE_CHANNEL_TX_PHY_CTRL2
-    4'b 0001, // index[ 4] SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_EN
-    4'b 0001, // index[ 5] SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_IN_CH_SEL
-    4'b 0001, // index[ 6] SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_IN_DATA_VALID
-    4'b 0011, // index[ 7] SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_IN_DATA
-    4'b 0001, // index[ 8] SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_OUT_CH_MASK
-    4'b 0011, // index[ 9] SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_OUT_DATA_FIFO
-    4'b 1111, // index[10] SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_OUT_DATA_FIFO_CTRL
-    4'b 0001, // index[11] SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_OUT_EN
-    4'b 0001  // index[12] SERIAL_LINK_SINGLE_CHANNEL_FLOW_CONTROL_FIFO_CLEAR
+    4'b 0011, // index[ 4] SERIAL_LINK_SINGLE_CHANNEL_TX_PHY_CTRL3
+    4'b 0001, // index[ 5] SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_EN
+    4'b 0001, // index[ 6] SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_IN_CH_SEL
+    4'b 0001, // index[ 7] SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_IN_DATA_VALID
+    4'b 0011, // index[ 8] SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_IN_DATA
+    4'b 0001, // index[ 9] SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_OUT_CH_MASK
+    4'b 0011, // index[10] SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_OUT_DATA_FIFO
+    4'b 1111, // index[11] SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_OUT_DATA_FIFO_CTRL
+    4'b 0001, // index[12] SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_OUT_EN
+    4'b 0001  // index[13] SERIAL_LINK_SINGLE_CHANNEL_FLOW_CONTROL_FIFO_CLEAR
   };
 
 endpackage

--- a/src/regs/serial_link_single_channel_reg_top.sv
+++ b/src/regs/serial_link_single_channel_reg_top.sv
@@ -84,15 +84,15 @@ module serial_link_single_channel_reg_top #(
   logic isolated_axi_in_re;
   logic isolated_axi_out_qs;
   logic isolated_axi_out_re;
-  logic [10:0] tx_phy_ctrl1_qs;
-  logic [10:0] tx_phy_ctrl1_wd;
-  logic tx_phy_ctrl1_we;
-  logic [10:0] tx_phy_ctrl2_qs;
-  logic [10:0] tx_phy_ctrl2_wd;
-  logic tx_phy_ctrl2_we;
-  logic [10:0] tx_phy_ctrl3_qs;
-  logic [10:0] tx_phy_ctrl3_wd;
-  logic tx_phy_ctrl3_we;
+  logic [10:0] tx_phy_clk_div_qs;
+  logic [10:0] tx_phy_clk_div_wd;
+  logic tx_phy_clk_div_we;
+  logic [10:0] tx_phy_clk_start_qs;
+  logic [10:0] tx_phy_clk_start_wd;
+  logic tx_phy_clk_start_we;
+  logic [10:0] tx_phy_clk_end_qs;
+  logic [10:0] tx_phy_clk_end_wd;
+  logic tx_phy_clk_end_we;
   logic raw_mode_en_wd;
   logic raw_mode_en_we;
   logic raw_mode_in_ch_sel_wd;
@@ -257,20 +257,20 @@ module serial_link_single_channel_reg_top #(
 
 
 
-  // Subregister 0 of Multireg tx_phy_ctrl1
-  // R[tx_phy_ctrl1]: V(False)
+  // Subregister 0 of Multireg tx_phy_clk_div
+  // R[tx_phy_clk_div]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h8)
-  ) u_tx_phy_ctrl1 (
+  ) u_tx_phy_clk_div (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl1_we),
-    .wd     (tx_phy_ctrl1_wd),
+    .we     (tx_phy_clk_div_we),
+    .wd     (tx_phy_clk_div_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -278,28 +278,28 @@ module serial_link_single_channel_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl1[0].q ),
+    .q      (reg2hw.tx_phy_clk_div[0].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl1_qs)
+    .qs     (tx_phy_clk_div_qs)
   );
 
 
 
-  // Subregister 0 of Multireg tx_phy_ctrl2
-  // R[tx_phy_ctrl2]: V(False)
+  // Subregister 0 of Multireg tx_phy_clk_start
+  // R[tx_phy_clk_start]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2 (
+  ) u_tx_phy_clk_start (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_we),
-    .wd     (tx_phy_ctrl2_wd),
+    .we     (tx_phy_clk_start_we),
+    .wd     (tx_phy_clk_start_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -307,28 +307,28 @@ module serial_link_single_channel_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[0].q ),
+    .q      (reg2hw.tx_phy_clk_start[0].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_qs)
+    .qs     (tx_phy_clk_start_qs)
   );
 
 
 
-  // Subregister 0 of Multireg tx_phy_ctrl3
-  // R[tx_phy_ctrl3]: V(False)
+  // Subregister 0 of Multireg tx_phy_clk_end
+  // R[tx_phy_clk_end]: V(False)
 
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl3 (
+  ) u_tx_phy_clk_end (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl3_we),
-    .wd     (tx_phy_ctrl3_wd),
+    .we     (tx_phy_clk_end_we),
+    .wd     (tx_phy_clk_end_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -336,10 +336,10 @@ module serial_link_single_channel_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl3[0].q ),
+    .q      (reg2hw.tx_phy_clk_end[0].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl3_qs)
+    .qs     (tx_phy_clk_end_qs)
   );
 
 
@@ -576,9 +576,9 @@ module serial_link_single_channel_reg_top #(
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == SERIAL_LINK_SINGLE_CHANNEL_CTRL_OFFSET);
     addr_hit[ 1] = (reg_addr == SERIAL_LINK_SINGLE_CHANNEL_ISOLATED_OFFSET);
-    addr_hit[ 2] = (reg_addr == SERIAL_LINK_SINGLE_CHANNEL_TX_PHY_CTRL1_OFFSET);
-    addr_hit[ 3] = (reg_addr == SERIAL_LINK_SINGLE_CHANNEL_TX_PHY_CTRL2_OFFSET);
-    addr_hit[ 4] = (reg_addr == SERIAL_LINK_SINGLE_CHANNEL_TX_PHY_CTRL3_OFFSET);
+    addr_hit[ 2] = (reg_addr == SERIAL_LINK_SINGLE_CHANNEL_TX_PHY_CLK_DIV_OFFSET);
+    addr_hit[ 3] = (reg_addr == SERIAL_LINK_SINGLE_CHANNEL_TX_PHY_CLK_START_OFFSET);
+    addr_hit[ 4] = (reg_addr == SERIAL_LINK_SINGLE_CHANNEL_TX_PHY_CLK_END_OFFSET);
     addr_hit[ 5] = (reg_addr == SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_EN_OFFSET);
     addr_hit[ 6] = (reg_addr == SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_IN_CH_SEL_OFFSET);
     addr_hit[ 7] = (reg_addr == SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_IN_DATA_VALID_OFFSET);
@@ -627,14 +627,14 @@ module serial_link_single_channel_reg_top #(
 
   assign isolated_axi_out_re = addr_hit[1] & reg_re & !reg_error;
 
-  assign tx_phy_ctrl1_we = addr_hit[2] & reg_we & !reg_error;
-  assign tx_phy_ctrl1_wd = reg_wdata[10:0];
+  assign tx_phy_clk_div_we = addr_hit[2] & reg_we & !reg_error;
+  assign tx_phy_clk_div_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_we = addr_hit[3] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_wd = reg_wdata[10:0];
+  assign tx_phy_clk_start_we = addr_hit[3] & reg_we & !reg_error;
+  assign tx_phy_clk_start_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl3_we = addr_hit[4] & reg_we & !reg_error;
-  assign tx_phy_ctrl3_wd = reg_wdata[10:0];
+  assign tx_phy_clk_end_we = addr_hit[4] & reg_we & !reg_error;
+  assign tx_phy_clk_end_wd = reg_wdata[10:0];
 
   assign raw_mode_en_we = addr_hit[5] & reg_we & !reg_error;
   assign raw_mode_en_wd = reg_wdata[0];
@@ -682,15 +682,15 @@ module serial_link_single_channel_reg_top #(
       end
 
       addr_hit[2]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl1_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_div_qs;
       end
 
       addr_hit[3]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_start_qs;
       end
 
       addr_hit[4]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl3_qs;
+        reg_rdata_next[10:0] = tx_phy_clk_end_qs;
       end
 
       addr_hit[5]: begin

--- a/src/regs/serial_link_single_channel_reg_top.sv
+++ b/src/regs/serial_link_single_channel_reg_top.sv
@@ -87,12 +87,12 @@ module serial_link_single_channel_reg_top #(
   logic [10:0] tx_phy_ctrl1_qs;
   logic [10:0] tx_phy_ctrl1_wd;
   logic tx_phy_ctrl1_we;
-  logic [10:0] tx_phy_ctrl2_clk_shift_start_0_qs;
-  logic [10:0] tx_phy_ctrl2_clk_shift_start_0_wd;
-  logic tx_phy_ctrl2_clk_shift_start_0_we;
-  logic [10:0] tx_phy_ctrl2_clk_shift_end_0_qs;
-  logic [10:0] tx_phy_ctrl2_clk_shift_end_0_wd;
-  logic tx_phy_ctrl2_clk_shift_end_0_we;
+  logic [10:0] tx_phy_ctrl2_qs;
+  logic [10:0] tx_phy_ctrl2_wd;
+  logic tx_phy_ctrl2_we;
+  logic [10:0] tx_phy_ctrl3_qs;
+  logic [10:0] tx_phy_ctrl3_wd;
+  logic tx_phy_ctrl3_we;
   logic raw_mode_en_wd;
   logic raw_mode_en_we;
   logic raw_mode_in_ch_sel_wd;
@@ -289,18 +289,17 @@ module serial_link_single_channel_reg_top #(
   // Subregister 0 of Multireg tx_phy_ctrl2
   // R[tx_phy_ctrl2]: V(False)
 
-  // F[clk_shift_start_0]: 10:0
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h2)
-  ) u_tx_phy_ctrl2_clk_shift_start_0 (
+  ) u_tx_phy_ctrl2 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_clk_shift_start_0_we),
-    .wd     (tx_phy_ctrl2_clk_shift_start_0_wd),
+    .we     (tx_phy_ctrl2_we),
+    .wd     (tx_phy_ctrl2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -308,25 +307,28 @@ module serial_link_single_channel_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[0].clk_shift_start.q ),
+    .q      (reg2hw.tx_phy_ctrl2[0].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_clk_shift_start_0_qs)
+    .qs     (tx_phy_ctrl2_qs)
   );
 
 
-  // F[clk_shift_end_0]: 10:0
+
+  // Subregister 0 of Multireg tx_phy_ctrl3
+  // R[tx_phy_ctrl3]: V(False)
+
   prim_subreg #(
     .DW      (11),
     .SWACCESS("RW"),
     .RESVAL  (11'h6)
-  ) u_tx_phy_ctrl2_clk_shift_end_0 (
+  ) u_tx_phy_ctrl3 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (tx_phy_ctrl2_clk_shift_end_0_we),
-    .wd     (tx_phy_ctrl2_clk_shift_end_0_wd),
+    .we     (tx_phy_ctrl3_we),
+    .wd     (tx_phy_ctrl3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -334,12 +336,11 @@ module serial_link_single_channel_reg_top #(
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.tx_phy_ctrl2[0].clk_shift_end.q ),
+    .q      (reg2hw.tx_phy_ctrl3[0].q ),
 
     // to register interface (read)
-    .qs     (tx_phy_ctrl2_clk_shift_end_0_qs)
+    .qs     (tx_phy_ctrl3_qs)
   );
-
 
 
   // R[raw_mode_en]: V(False)
@@ -570,22 +571,23 @@ module serial_link_single_channel_reg_top #(
 
 
 
-  logic [12:0] addr_hit;
+  logic [13:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == SERIAL_LINK_SINGLE_CHANNEL_CTRL_OFFSET);
     addr_hit[ 1] = (reg_addr == SERIAL_LINK_SINGLE_CHANNEL_ISOLATED_OFFSET);
     addr_hit[ 2] = (reg_addr == SERIAL_LINK_SINGLE_CHANNEL_TX_PHY_CTRL1_OFFSET);
     addr_hit[ 3] = (reg_addr == SERIAL_LINK_SINGLE_CHANNEL_TX_PHY_CTRL2_OFFSET);
-    addr_hit[ 4] = (reg_addr == SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_EN_OFFSET);
-    addr_hit[ 5] = (reg_addr == SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_IN_CH_SEL_OFFSET);
-    addr_hit[ 6] = (reg_addr == SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_IN_DATA_VALID_OFFSET);
-    addr_hit[ 7] = (reg_addr == SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_IN_DATA_OFFSET);
-    addr_hit[ 8] = (reg_addr == SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_OUT_CH_MASK_OFFSET);
-    addr_hit[ 9] = (reg_addr == SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_OUT_DATA_FIFO_OFFSET);
-    addr_hit[10] = (reg_addr == SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_OUT_DATA_FIFO_CTRL_OFFSET);
-    addr_hit[11] = (reg_addr == SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_OUT_EN_OFFSET);
-    addr_hit[12] = (reg_addr == SERIAL_LINK_SINGLE_CHANNEL_FLOW_CONTROL_FIFO_CLEAR_OFFSET);
+    addr_hit[ 4] = (reg_addr == SERIAL_LINK_SINGLE_CHANNEL_TX_PHY_CTRL3_OFFSET);
+    addr_hit[ 5] = (reg_addr == SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_EN_OFFSET);
+    addr_hit[ 6] = (reg_addr == SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_IN_CH_SEL_OFFSET);
+    addr_hit[ 7] = (reg_addr == SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_IN_DATA_VALID_OFFSET);
+    addr_hit[ 8] = (reg_addr == SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_IN_DATA_OFFSET);
+    addr_hit[ 9] = (reg_addr == SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_OUT_CH_MASK_OFFSET);
+    addr_hit[10] = (reg_addr == SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_OUT_DATA_FIFO_OFFSET);
+    addr_hit[11] = (reg_addr == SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_OUT_DATA_FIFO_CTRL_OFFSET);
+    addr_hit[12] = (reg_addr == SERIAL_LINK_SINGLE_CHANNEL_RAW_MODE_OUT_EN_OFFSET);
+    addr_hit[13] = (reg_addr == SERIAL_LINK_SINGLE_CHANNEL_FLOW_CONTROL_FIFO_CLEAR_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -605,7 +607,8 @@ module serial_link_single_channel_reg_top #(
                (addr_hit[ 9] & (|(SERIAL_LINK_SINGLE_CHANNEL_PERMIT[ 9] & ~reg_be))) |
                (addr_hit[10] & (|(SERIAL_LINK_SINGLE_CHANNEL_PERMIT[10] & ~reg_be))) |
                (addr_hit[11] & (|(SERIAL_LINK_SINGLE_CHANNEL_PERMIT[11] & ~reg_be))) |
-               (addr_hit[12] & (|(SERIAL_LINK_SINGLE_CHANNEL_PERMIT[12] & ~reg_be)))));
+               (addr_hit[12] & (|(SERIAL_LINK_SINGLE_CHANNEL_PERMIT[12] & ~reg_be))) |
+               (addr_hit[13] & (|(SERIAL_LINK_SINGLE_CHANNEL_PERMIT[13] & ~reg_be)))));
   end
 
   assign ctrl_clk_ena_we = addr_hit[0] & reg_we & !reg_error;
@@ -627,39 +630,39 @@ module serial_link_single_channel_reg_top #(
   assign tx_phy_ctrl1_we = addr_hit[2] & reg_we & !reg_error;
   assign tx_phy_ctrl1_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_clk_shift_start_0_we = addr_hit[3] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_clk_shift_start_0_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl2_we = addr_hit[3] & reg_we & !reg_error;
+  assign tx_phy_ctrl2_wd = reg_wdata[10:0];
 
-  assign tx_phy_ctrl2_clk_shift_end_0_we = addr_hit[3] & reg_we & !reg_error;
-  assign tx_phy_ctrl2_clk_shift_end_0_wd = reg_wdata[10:0];
+  assign tx_phy_ctrl3_we = addr_hit[4] & reg_we & !reg_error;
+  assign tx_phy_ctrl3_wd = reg_wdata[10:0];
 
-  assign raw_mode_en_we = addr_hit[4] & reg_we & !reg_error;
+  assign raw_mode_en_we = addr_hit[5] & reg_we & !reg_error;
   assign raw_mode_en_wd = reg_wdata[0];
 
-  assign raw_mode_in_ch_sel_we = addr_hit[5] & reg_we & !reg_error;
+  assign raw_mode_in_ch_sel_we = addr_hit[6] & reg_we & !reg_error;
   assign raw_mode_in_ch_sel_wd = reg_wdata[0];
 
-  assign raw_mode_in_data_valid_re = addr_hit[6] & reg_re & !reg_error;
+  assign raw_mode_in_data_valid_re = addr_hit[7] & reg_re & !reg_error;
 
-  assign raw_mode_in_data_re = addr_hit[7] & reg_re & !reg_error;
+  assign raw_mode_in_data_re = addr_hit[8] & reg_re & !reg_error;
 
-  assign raw_mode_out_ch_mask_we = addr_hit[8] & reg_we & !reg_error;
+  assign raw_mode_out_ch_mask_we = addr_hit[9] & reg_we & !reg_error;
   assign raw_mode_out_ch_mask_wd = reg_wdata[0];
 
-  assign raw_mode_out_data_fifo_we = addr_hit[9] & reg_we & !reg_error;
+  assign raw_mode_out_data_fifo_we = addr_hit[10] & reg_we & !reg_error;
   assign raw_mode_out_data_fifo_wd = reg_wdata[15:0];
 
-  assign raw_mode_out_data_fifo_ctrl_clear_we = addr_hit[10] & reg_we & !reg_error;
+  assign raw_mode_out_data_fifo_ctrl_clear_we = addr_hit[11] & reg_we & !reg_error;
   assign raw_mode_out_data_fifo_ctrl_clear_wd = reg_wdata[0];
 
-  assign raw_mode_out_data_fifo_ctrl_fill_state_re = addr_hit[10] & reg_re & !reg_error;
+  assign raw_mode_out_data_fifo_ctrl_fill_state_re = addr_hit[11] & reg_re & !reg_error;
 
-  assign raw_mode_out_data_fifo_ctrl_is_full_re = addr_hit[10] & reg_re & !reg_error;
+  assign raw_mode_out_data_fifo_ctrl_is_full_re = addr_hit[11] & reg_re & !reg_error;
 
-  assign raw_mode_out_en_we = addr_hit[11] & reg_we & !reg_error;
+  assign raw_mode_out_en_we = addr_hit[12] & reg_we & !reg_error;
   assign raw_mode_out_en_wd = reg_wdata[0];
 
-  assign flow_control_fifo_clear_we = addr_hit[12] & reg_we & !reg_error;
+  assign flow_control_fifo_clear_we = addr_hit[13] & reg_we & !reg_error;
   assign flow_control_fifo_clear_wd = reg_wdata[0];
 
   // Read data return
@@ -683,12 +686,11 @@ module serial_link_single_channel_reg_top #(
       end
 
       addr_hit[3]: begin
-        reg_rdata_next[10:0] = tx_phy_ctrl2_clk_shift_start_0_qs;
-        reg_rdata_next[10:0] = tx_phy_ctrl2_clk_shift_end_0_qs;
+        reg_rdata_next[10:0] = tx_phy_ctrl2_qs;
       end
 
       addr_hit[4]: begin
-        reg_rdata_next[0] = '0;
+        reg_rdata_next[10:0] = tx_phy_ctrl3_qs;
       end
 
       addr_hit[5]: begin
@@ -696,32 +698,36 @@ module serial_link_single_channel_reg_top #(
       end
 
       addr_hit[6]: begin
-        reg_rdata_next[0] = raw_mode_in_data_valid_qs;
-      end
-
-      addr_hit[7]: begin
-        reg_rdata_next[15:0] = raw_mode_in_data_qs;
-      end
-
-      addr_hit[8]: begin
         reg_rdata_next[0] = '0;
       end
 
+      addr_hit[7]: begin
+        reg_rdata_next[0] = raw_mode_in_data_valid_qs;
+      end
+
+      addr_hit[8]: begin
+        reg_rdata_next[15:0] = raw_mode_in_data_qs;
+      end
+
       addr_hit[9]: begin
-        reg_rdata_next[15:0] = '0;
+        reg_rdata_next[0] = '0;
       end
 
       addr_hit[10]: begin
+        reg_rdata_next[15:0] = '0;
+      end
+
+      addr_hit[11]: begin
         reg_rdata_next[0] = '0;
         reg_rdata_next[10:8] = raw_mode_out_data_fifo_ctrl_fill_state_qs;
         reg_rdata_next[31] = raw_mode_out_data_fifo_ctrl_is_full_qs;
       end
 
-      addr_hit[11]: begin
+      addr_hit[12]: begin
         reg_rdata_next[0] = raw_mode_out_en_qs;
       end
 
-      addr_hit[12]: begin
+      addr_hit[13]: begin
         reg_rdata_next[0] = '0;
       end
 

--- a/src/serial_link.sv
+++ b/src/serial_link.sv
@@ -291,21 +291,21 @@ import serial_link_pkg::*;
       .FifoDepth        ( RawModeFifoDepth  ),
       .MaxClkDiv        ( MaxClkDiv         )
     ) i_serial_link_physical (
-      .clk_i             ( clk_sl_i                                 ),
-      .rst_ni            ( rst_sl_ni                                ),
-      .clk_div_i         ( reg2hw.tx_phy_ctrl1[i].q                 ),
-      .clk_shift_start_i ( reg2hw.tx_phy_ctrl2[i].clk_shift_start.q ),
-      .clk_shift_end_i   ( reg2hw.tx_phy_ctrl2[i].clk_shift_end.q   ),
-      .ddr_rcv_clk_i     ( ddr_rcv_clk_i[i]                         ),
-      .ddr_rcv_clk_o     ( ddr_rcv_clk_o[i]                         ),
-      .data_out_i        ( alloc2phy_data_out[i]                    ),
-      .data_out_valid_i  ( alloc2phy_data_out_valid[i]              ),
-      .data_out_ready_o  ( phy2alloc_data_out_ready[i]              ),
-      .data_in_o         ( phy2alloc_data_in[i]                     ),
-      .data_in_valid_o   ( phy2alloc_data_in_valid[i]               ),
-      .data_in_ready_i   ( alloc2phy_data_in_ready[i]               ),
-      .ddr_i             ( ddr_i[i]                                 ),
-      .ddr_o             ( ddr_o[i]                                 )
+      .clk_i             ( clk_sl_i                     ),
+      .rst_ni            ( rst_sl_ni                    ),
+      .clk_div_i         ( reg2hw.tx_phy_clk_div[i].q   ),
+      .clk_shift_start_i ( reg2hw.tx_phy_clk_start[i].q ),
+      .clk_shift_end_i   ( reg2hw.tx_phy_clk_end[i].q   ),
+      .ddr_rcv_clk_i     ( ddr_rcv_clk_i[i]             ),
+      .ddr_rcv_clk_o     ( ddr_rcv_clk_o[i]             ),
+      .data_out_i        ( alloc2phy_data_out[i]        ),
+      .data_out_valid_i  ( alloc2phy_data_out_valid[i]  ),
+      .data_out_ready_o  ( phy2alloc_data_out_ready[i]  ),
+      .data_in_o         ( phy2alloc_data_in[i]         ),
+      .data_in_valid_o   ( phy2alloc_data_in_valid[i]   ),
+      .data_in_ready_i   ( alloc2phy_data_in_ready[i]   ),
+      .ddr_i             ( ddr_i[i]                     ),
+      .ddr_o             ( ddr_o[i]                     )
     );
   end
 


### PR DESCRIPTION
The `start` and `end` cycle of the clock divison was mapped to the same bits of the configuration register which made it impossible to reconfigure the clock division.