### PR TITLE
phy: Use combinational signal to mux DDR output data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Changed
+
+- The DDR output data is now muxed by a normal signal instead of a clock signal. Some tools infer a clock gate when a clock signal is used as a mux select signal.
+
 ## 1.1.0 - 2023-07-03
 
 ### Changed

--- a/doc/constraints.md
+++ b/doc/constraints.md
@@ -1,5 +1,5 @@
 ## Constraints
-The Serial Link has Double-Data-Rate (DDR) and a source-synchronous interface with generated clocks which makes the constraints quite involved.
+The Serial Link has Double-Data-Rate (DDR) and a source-synchronous interface with generated clocks which makes the constraints quite involved. The constraints were by the *Source-Synchronous DDR IO Timing Constraints Cookbook* by David Olsen, Altera Corporation, 2010.
 
 ### Generated and Virtual Clocks
 The data is synchronous to a zero phase shifted clock. This clock needs to be defined as virtual since it does not exist at the receiver side. The actual clock is shifted with respect to the virtual clock by -90 or +270 degrees (resp. shifted by +90 degrees and then inverted). The clocks on RX side are generated the following way:
@@ -48,6 +48,11 @@ set_false_path -hold  -fall_from [get_clocks vir_clk_ddr_in] -rise_to [get_clock
 # Output
 set_false_path -hold  -rise_from [get_clocks clk_slow] -fall_to [get_clocks clk_ddr_out]
 set_false_path -hold  -fall_from [get_clocks clk_slow] -rise_to [get_clocks clk_ddr_out]
+```
+
+There is on last false path from the system/fll clock to the forwarded clock
+```sdc
+set_false_path -from [get_pins my_system_clock_pin] -to [get_ports my_clk_ddr_out_port]
 ```
 
 ### I/O Delays

--- a/src/serial_link_physical.sv
+++ b/src/serial_link_physical.sv
@@ -30,6 +30,7 @@ module serial_link_physical_tx #(
   logic clk_enable;
   logic clk_toggle, clk_slow_toggle;
   logic clk_slow;
+  logic ddr_sel;
 
   // Valid is always set, but
   // src_clk is clock gated
@@ -65,8 +66,9 @@ module serial_link_physical_tx #(
 
   always_ff @(posedge clk_i, negedge rst_ni) begin
     if (~rst_ni) begin
-      ddr_rcv_clk_o = '1;
-      clk_slow <= '0;
+      ddr_rcv_clk_o = 1'b1;
+      clk_slow <= 1'b0;
+      ddr_sel <= 1'b0;
     end else begin
       if (clk_enable) begin
         if (clk_toggle) begin
@@ -74,10 +76,12 @@ module serial_link_physical_tx #(
         end
         if (clk_slow_toggle) begin
           clk_slow <= !clk_slow;
+          ddr_sel <= !ddr_sel;
         end
       end else begin
-        ddr_rcv_clk_o = '1;
-        clk_slow <= '0;
+        ddr_rcv_clk_o = 1'b1;
+        clk_slow <= 1'b0;
+        ddr_sel <= 1'b0;
       end
     end
   end
@@ -86,7 +90,7 @@ module serial_link_physical_tx #(
   //   DDR OUT   //
   /////////////////
   `FF(data_out_q, data_out_i, '0, clk_slow, rst_ni)
-  assign ddr_o = (clk_slow)? data_out_q[NumLanes-1:0] : data_out_q[NumLanes*2-1:NumLanes];
+  assign ddr_o = (ddr_sel)? data_out_q[NumLanes-1:0] : data_out_q[NumLanes*2-1:NumLanes];
 
 endmodule
 

--- a/util/verible.waiver
+++ b/util/verible.waiver
@@ -3,9 +3,9 @@
 # SPDX-License-Identifier: SHL-0.51
 
 # This rule does not apply to flip-flops that drive other FF's clock pin. There non-blocking assingments can cause race conditions!
-waive --rule=always-ff-non-blocking --line=68 --location="src/serial_link_physical.sv"
-waive --rule=always-ff-non-blocking --line=73 --location="src/serial_link_physical.sv"
-waive --rule=always-ff-non-blocking --line=79 --location="src/serial_link_physical.sv"
+waive --rule=always-ff-non-blocking --line=69 --location="src/serial_link_physical.sv"
+waive --rule=always-ff-non-blocking --line=75 --location="src/serial_link_physical.sv"
+waive --rule=always-ff-non-blocking --line=82 --location="src/serial_link_physical.sv"
 # The AXIS package is waived to stay compatible with other AXIS IPs
 waive --rule=parameter-name-style --location="src/axis/*"
 waive --rule=interface-name-style --location="src/axis/*"


### PR DESCRIPTION
This PR is dedicated to @yichao-zh ❤️

Previously, the slow clock (with zero phase shift) was used to mux the data out for the DDR. However, this can cause issues in the backend because the mux might be seen as a clock gate which causes timing checks.

Adding another FF that is identical to the clock should solve this issue.

