### PR TITLE
bender: Don't import testbenches under simulation target

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -50,9 +50,12 @@ sources:
       files:
       - src/serial_link_synth_wrapper.sv
 
-    - target: simulation
+    - target: any(simulation, test)
       files:
       - test/axi_channel_compare.sv
+
+    - target: test
+      files:
       - test/tb_axi_serial_link.sv
       - test/tb_ch_calib_serial_link.sv
       - test/tb_stream_chopper.sv


### PR DESCRIPTION
This PR splits the bender targets to not import testbenches under the `simulation` target. Verilator (v5.028-44-g1d79f5c59) cannot handle some of the testbenches.