### PR TITLE
feat: add serializer w/o PHY

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -44,6 +44,7 @@ sources:
     - include_dirs:
       - src/include
       files:
+      - src/slink_serializer.sv
       - src/slink.sv
 
     # Wrapper for additional isolation

--- a/src/regs/slink_addrmap.svh
+++ b/src/regs/slink_addrmap.svh
@@ -8,7 +8,7 @@
 `define SLINK_REG_SVH
 
 `define SLINK_REG_BASE_ADDR 64'h0
-`define SLINK_REG_SIZE 64'h50
+`define SLINK_REG_SIZE 64'h58
 
 `define SLINK_REG_CTRL_BASE_ADDR 64'h0
 
@@ -19,44 +19,48 @@
 `define SLINK_REG_RAW_MODE_IN_DATA_BASE_ADDR(raw_mode_in_data_idx) (64'hC + (raw_mode_in_data_idx * 64'h4) )
 `define SLINK_REG_RAW_MODE_IN_DATA_NUM 64'h1
 
-`define SLINK_REG_RAW_MODE_IN_CH_SEL_BASE_ADDR 64'h10
+`define SLINK_REG_RAW_MODE_POP_BASE_ADDR 64'h10
 
-`define SLINK_REG_RAW_MODE_OUT_DATA_FIFO_BASE_ADDR(raw_mode_out_data_fifo_idx) (64'h14 + (raw_mode_out_data_fifo_idx * 64'h4) )
+`define SLINK_REG_RAW_MODE_IN_CH_SEL_BASE_ADDR 64'h14
+
+`define SLINK_REG_RAW_MODE_OUT_DATA_FIFO_BASE_ADDR(raw_mode_out_data_fifo_idx) (64'h18 + (raw_mode_out_data_fifo_idx * 64'h4) )
 `define SLINK_REG_RAW_MODE_OUT_DATA_FIFO_NUM 64'h1
 
-`define SLINK_REG_RAW_MODE_OUT_DATA_FIFO_CTRL_BASE_ADDR 64'h18
+`define SLINK_REG_RAW_MODE_PUSH_BASE_ADDR 64'h1C
 
-`define SLINK_REG_RAW_MODE_OUT_EN_BASE_ADDR 64'h1C
+`define SLINK_REG_RAW_MODE_OUT_DATA_FIFO_CTRL_BASE_ADDR 64'h20
 
-`define SLINK_REG_FLOW_CONTROL_FIFO_CLEAR_BASE_ADDR 64'h20
+`define SLINK_REG_RAW_MODE_OUT_EN_BASE_ADDR 64'h24
 
-`define SLINK_REG_RAW_MODE_IN_DATA_VALID_BASE_ADDR(raw_mode_in_data_valid_idx) (64'h24 + (raw_mode_in_data_valid_idx * 64'h4) )
+`define SLINK_REG_FLOW_CONTROL_FIFO_CLEAR_BASE_ADDR 64'h28
+
+`define SLINK_REG_RAW_MODE_IN_DATA_VALID_BASE_ADDR(raw_mode_in_data_valid_idx) (64'h2C + (raw_mode_in_data_valid_idx * 64'h4) )
 `define SLINK_REG_RAW_MODE_IN_DATA_VALID_NUM 64'h1
 
-`define SLINK_REG_RAW_MODE_OUT_CH_MASK_BASE_ADDR(raw_mode_out_ch_mask_idx) (64'h28 + (raw_mode_out_ch_mask_idx * 64'h4) )
+`define SLINK_REG_RAW_MODE_OUT_CH_MASK_BASE_ADDR(raw_mode_out_ch_mask_idx) (64'h30 + (raw_mode_out_ch_mask_idx * 64'h4) )
 `define SLINK_REG_RAW_MODE_OUT_CH_MASK_NUM 64'h1
 
-`define SLINK_REG_TX_PHY_CLK_DIV_BASE_ADDR(tx_phy_clk_div_idx) (64'h2C + (tx_phy_clk_div_idx * 64'h4) )
+`define SLINK_REG_TX_PHY_CLK_DIV_BASE_ADDR(tx_phy_clk_div_idx) (64'h34 + (tx_phy_clk_div_idx * 64'h4) )
 `define SLINK_REG_TX_PHY_CLK_DIV_NUM 64'h1
 
-`define SLINK_REG_TX_PHY_CLK_START_BASE_ADDR(tx_phy_clk_start_idx) (64'h30 + (tx_phy_clk_start_idx * 64'h4) )
+`define SLINK_REG_TX_PHY_CLK_START_BASE_ADDR(tx_phy_clk_start_idx) (64'h38 + (tx_phy_clk_start_idx * 64'h4) )
 `define SLINK_REG_TX_PHY_CLK_START_NUM 64'h1
 
-`define SLINK_REG_TX_PHY_CLK_END_BASE_ADDR(tx_phy_clk_end_idx) (64'h34 + (tx_phy_clk_end_idx * 64'h4) )
+`define SLINK_REG_TX_PHY_CLK_END_BASE_ADDR(tx_phy_clk_end_idx) (64'h3C + (tx_phy_clk_end_idx * 64'h4) )
 `define SLINK_REG_TX_PHY_CLK_END_NUM 64'h1
 
-`define SLINK_REG_CHANNEL_ALLOC_TX_CFG_BASE_ADDR 64'h38
+`define SLINK_REG_CHANNEL_ALLOC_TX_CFG_BASE_ADDR 64'h40
 
-`define SLINK_REG_CHANNEL_ALLOC_TX_CTRL_BASE_ADDR 64'h3C
+`define SLINK_REG_CHANNEL_ALLOC_TX_CTRL_BASE_ADDR 64'h44
 
-`define SLINK_REG_CHANNEL_ALLOC_RX_CFG_BASE_ADDR 64'h40
+`define SLINK_REG_CHANNEL_ALLOC_RX_CFG_BASE_ADDR 64'h48
 
-`define SLINK_REG_CHANNEL_ALLOC_RX_CTRL_BASE_ADDR 64'h44
+`define SLINK_REG_CHANNEL_ALLOC_RX_CTRL_BASE_ADDR 64'h4C
 
-`define SLINK_REG_CHANNEL_ALLOC_TX_CH_EN_BASE_ADDR(channel_alloc_tx_ch_en_idx) (64'h48 + (channel_alloc_tx_ch_en_idx * 64'h4) )
+`define SLINK_REG_CHANNEL_ALLOC_TX_CH_EN_BASE_ADDR(channel_alloc_tx_ch_en_idx) (64'h50 + (channel_alloc_tx_ch_en_idx * 64'h4) )
 `define SLINK_REG_CHANNEL_ALLOC_TX_CH_EN_NUM 64'h1
 
-`define SLINK_REG_CHANNEL_ALLOC_RX_CH_EN_BASE_ADDR(channel_alloc_rx_ch_en_idx) (64'h4C + (channel_alloc_rx_ch_en_idx * 64'h4) )
+`define SLINK_REG_CHANNEL_ALLOC_RX_CH_EN_BASE_ADDR(channel_alloc_rx_ch_en_idx) (64'h54 + (channel_alloc_rx_ch_en_idx * 64'h4) )
 `define SLINK_REG_CHANNEL_ALLOC_RX_CH_EN_NUM 64'h1
 
 `endif /* SLINK_REG_SVH */

--- a/src/regs/slink_addrmap.svh
+++ b/src/regs/slink_addrmap.svh
@@ -8,7 +8,7 @@
 `define SLINK_REG_SVH
 
 `define SLINK_REG_BASE_ADDR 64'h0
-`define SLINK_REG_SIZE 64'h804
+`define SLINK_REG_SIZE 64'h50
 
 `define SLINK_REG_CTRL_BASE_ADDR 64'h0
 
@@ -16,11 +16,13 @@
 
 `define SLINK_REG_RAW_MODE_EN_BASE_ADDR 64'h8
 
-`define SLINK_REG_RAW_MODE_IN_DATA_BASE_ADDR 64'hC
+`define SLINK_REG_RAW_MODE_IN_DATA_BASE_ADDR(raw_mode_in_data_idx) (64'hC + (raw_mode_in_data_idx * 64'h4) )
+`define SLINK_REG_RAW_MODE_IN_DATA_NUM 64'h1
 
 `define SLINK_REG_RAW_MODE_IN_CH_SEL_BASE_ADDR 64'h10
 
-`define SLINK_REG_RAW_MODE_OUT_DATA_FIFO_BASE_ADDR 64'h14
+`define SLINK_REG_RAW_MODE_OUT_DATA_FIFO_BASE_ADDR(raw_mode_out_data_fifo_idx) (64'h14 + (raw_mode_out_data_fifo_idx * 64'h4) )
+`define SLINK_REG_RAW_MODE_OUT_DATA_FIFO_NUM 64'h1
 
 `define SLINK_REG_RAW_MODE_OUT_DATA_FIFO_CTRL_BASE_ADDR 64'h18
 
@@ -28,33 +30,33 @@
 
 `define SLINK_REG_FLOW_CONTROL_FIFO_CLEAR_BASE_ADDR 64'h20
 
-`define SLINK_REG_RAW_MODE_IN_DATA_VALID_BASE_ADDR(raw_mode_in_data_valid_idx) (64'h100 + (raw_mode_in_data_valid_idx * 64'h4) )
+`define SLINK_REG_RAW_MODE_IN_DATA_VALID_BASE_ADDR(raw_mode_in_data_valid_idx) (64'h24 + (raw_mode_in_data_valid_idx * 64'h4) )
 `define SLINK_REG_RAW_MODE_IN_DATA_VALID_NUM 64'h1
 
-`define SLINK_REG_RAW_MODE_OUT_CH_MASK_BASE_ADDR(raw_mode_out_ch_mask_idx) (64'h200 + (raw_mode_out_ch_mask_idx * 64'h4) )
+`define SLINK_REG_RAW_MODE_OUT_CH_MASK_BASE_ADDR(raw_mode_out_ch_mask_idx) (64'h28 + (raw_mode_out_ch_mask_idx * 64'h4) )
 `define SLINK_REG_RAW_MODE_OUT_CH_MASK_NUM 64'h1
 
-`define SLINK_REG_TX_PHY_CLK_DIV_BASE_ADDR(tx_phy_clk_div_idx) (64'h300 + (tx_phy_clk_div_idx * 64'h4) )
+`define SLINK_REG_TX_PHY_CLK_DIV_BASE_ADDR(tx_phy_clk_div_idx) (64'h2C + (tx_phy_clk_div_idx * 64'h4) )
 `define SLINK_REG_TX_PHY_CLK_DIV_NUM 64'h1
 
-`define SLINK_REG_TX_PHY_CLK_START_BASE_ADDR(tx_phy_clk_start_idx) (64'h400 + (tx_phy_clk_start_idx * 64'h4) )
+`define SLINK_REG_TX_PHY_CLK_START_BASE_ADDR(tx_phy_clk_start_idx) (64'h30 + (tx_phy_clk_start_idx * 64'h4) )
 `define SLINK_REG_TX_PHY_CLK_START_NUM 64'h1
 
-`define SLINK_REG_TX_PHY_CLK_END_BASE_ADDR(tx_phy_clk_end_idx) (64'h500 + (tx_phy_clk_end_idx * 64'h4) )
+`define SLINK_REG_TX_PHY_CLK_END_BASE_ADDR(tx_phy_clk_end_idx) (64'h34 + (tx_phy_clk_end_idx * 64'h4) )
 `define SLINK_REG_TX_PHY_CLK_END_NUM 64'h1
 
-`define SLINK_REG_CHANNEL_ALLOC_TX_CFG_BASE_ADDR 64'h600
+`define SLINK_REG_CHANNEL_ALLOC_TX_CFG_BASE_ADDR 64'h38
 
-`define SLINK_REG_CHANNEL_ALLOC_TX_CTRL_BASE_ADDR 64'h604
+`define SLINK_REG_CHANNEL_ALLOC_TX_CTRL_BASE_ADDR 64'h3C
 
-`define SLINK_REG_CHANNEL_ALLOC_RX_CFG_BASE_ADDR 64'h608
+`define SLINK_REG_CHANNEL_ALLOC_RX_CFG_BASE_ADDR 64'h40
 
-`define SLINK_REG_CHANNEL_ALLOC_RX_CTRL_BASE_ADDR 64'h60C
+`define SLINK_REG_CHANNEL_ALLOC_RX_CTRL_BASE_ADDR 64'h44
 
-`define SLINK_REG_CHANNEL_ALLOC_TX_CH_EN_BASE_ADDR(channel_alloc_tx_ch_en_idx) (64'h700 + (channel_alloc_tx_ch_en_idx * 64'h4) )
+`define SLINK_REG_CHANNEL_ALLOC_TX_CH_EN_BASE_ADDR(channel_alloc_tx_ch_en_idx) (64'h48 + (channel_alloc_tx_ch_en_idx * 64'h4) )
 `define SLINK_REG_CHANNEL_ALLOC_TX_CH_EN_NUM 64'h1
 
-`define SLINK_REG_CHANNEL_ALLOC_RX_CH_EN_BASE_ADDR(channel_alloc_rx_ch_en_idx) (64'h800 + (channel_alloc_rx_ch_en_idx * 64'h4) )
+`define SLINK_REG_CHANNEL_ALLOC_RX_CH_EN_BASE_ADDR(channel_alloc_rx_ch_en_idx) (64'h4C + (channel_alloc_rx_ch_en_idx * 64'h4) )
 `define SLINK_REG_CHANNEL_ALLOC_RX_CH_EN_NUM 64'h1
 
 `endif /* SLINK_REG_SVH */

--- a/src/regs/slink_reg.rdl
+++ b/src/regs/slink_reg.rdl
@@ -113,8 +113,17 @@ addrmap slink_reg #(
     reg raw_mode_in_data {
         default sw = r;
         default hw = w;
-        desc = "One 32-bit word of data received by the selected channel in RAW mode. Reading word 0 captures/pops one full raw-mode sample; following words expose the captured sample.";
+        desc = "One 32-bit word of the currently parked raw-mode RX sample for the selected channel.";
         field {} raw_mode_in_data[31:0];
+    };
+
+    reg raw_mode_pop {
+        default sw = w;
+        default hw = r;
+        desc = "Write to pop RAW mode RX FIFO to the next sample. Write only after reading all RawModeNumWords words of raw_mode_in_data.";
+        field {
+            singlepulse;
+        } raw_mode_pop[0:0] = 0x0;
     };
 
     reg raw_mode_out_ch_mask {
@@ -127,10 +136,17 @@ addrmap slink_reg #(
     reg raw_mode_out_data_fifo {
         default sw = w;
         default hw = r;
-        desc = "One 32-bit word of data that will be pushed to the RAW mode output FIFO. Writing the last word commits the full raw-mode sample.";
+        desc = "One 32-bit word of the next raw-mode TX sample to push to the output FIFO.";
+        field {} raw_mode_out_data_fifo[31:0] = 0x0;
+    };
+
+    reg raw_mode_push {
+        default sw = w;
+        default hw = r;
+        desc = "Write to push the sample held in raw_mode_out_data_fifo into the RAW mode TX FIFO. Write only after writing all RawModeNumWords words.";
         field {
-            swmod;
-        } raw_mode_out_data_fifo[31:0] = 0x0;
+            singlepulse;
+        } raw_mode_push[0:0] = 0x0;
     };
 
     reg raw_mode_out_data_fifo_ctrl {
@@ -256,8 +272,10 @@ addrmap slink_reg #(
     external isolated                    isolated;
              raw_mode_en                 raw_mode_en;
     external raw_mode_in_data            raw_mode_in_data[RawModeNumWords];
+             raw_mode_pop                raw_mode_pop;
              raw_mode_in_ch_sel          raw_mode_in_ch_sel;
              raw_mode_out_data_fifo      raw_mode_out_data_fifo[RawModeNumWords];
+             raw_mode_push               raw_mode_push;
     external raw_mode_out_data_fifo_ctrl raw_mode_out_data_fifo_ctrl;
              raw_mode_out_en             raw_mode_out_en;
     external flow_control_fifo_clear     flow_control_fifo_clear;

--- a/src/regs/slink_reg.rdl
+++ b/src/regs/slink_reg.rdl
@@ -17,7 +17,8 @@ addrmap slink_reg #(
     longint unsigned Log2MaxClkDiv = 10,
     longint unsigned FlushCounterWidth = 8,
     longint unsigned Log2RawModeTXFifoDepth = 3, // 8 entries
-    longint unsigned EnChAlloc = (NumChannels > 1)
+    longint unsigned EnChAlloc = (NumChannels > 1),
+    longint unsigned RawModeNumWords = (NumBits + 31) / 32
 ) {
 
     default regwidth = 32;
@@ -112,8 +113,8 @@ addrmap slink_reg #(
     reg raw_mode_in_data {
         default sw = r;
         default hw = w;
-        desc = "Data received by the selected channel in RAW mode";
-        field {} raw_mode_in_data[NumBits-1:0];
+        desc = "One 32-bit word of data received by the selected channel in RAW mode. Reading word 0 captures/pops one full raw-mode sample; following words expose the captured sample.";
+        field {} raw_mode_in_data[31:0];
     };
 
     reg raw_mode_out_ch_mask {
@@ -126,10 +127,10 @@ addrmap slink_reg #(
     reg raw_mode_out_data_fifo {
         default sw = w;
         default hw = r;
-        desc = "Data that will be pushed to the RAW mode output FIFO";
+        desc = "One 32-bit word of data that will be pushed to the RAW mode output FIFO. Writing the last word commits the full raw-mode sample.";
         field {
             swmod;
-        } raw_mode_out_data_fifo[NumBits-1:0] = 0x0;
+        } raw_mode_out_data_fifo[31:0] = 0x0;
     };
 
     reg raw_mode_out_data_fifo_ctrl {
@@ -251,27 +252,26 @@ addrmap slink_reg #(
         } channel_alloc_rx_ch_en[0:0] = 0x1;
     };
 
-
-             ctrl                        ctrl @0x0;
-    external isolated                    isolated @0x4;
-             raw_mode_en                 raw_mode_en @0x8;
-    external raw_mode_in_data            raw_mode_in_data @0x0c;
-             raw_mode_in_ch_sel          raw_mode_in_ch_sel @0x10;
-             raw_mode_out_data_fifo      raw_mode_out_data_fifo @0x14;
-    external raw_mode_out_data_fifo_ctrl raw_mode_out_data_fifo_ctrl @0x18;
-             raw_mode_out_en             raw_mode_out_en @0x1c;
-    external flow_control_fifo_clear     flow_control_fifo_clear @0x20;
-    external raw_mode_in_data_valid      raw_mode_in_data_valid[NumChannels] @0x100;
-             raw_mode_out_ch_mask        raw_mode_out_ch_mask[NumChannels] @0x200;
-             tx_phy_clk_div              tx_phy_clk_div[NumChannels] @0x300;
-             tx_phy_clk_start            tx_phy_clk_start[NumChannels] @0x400;
-             tx_phy_clk_end              tx_phy_clk_end[NumChannels] @0x500;
-             channel_alloc_tx_cfg        channel_alloc_tx_cfg @0x600;
-    external channel_alloc_tx_ctrl       channel_alloc_tx_ctrl @0x604;
-             channel_alloc_rx_cfg        channel_alloc_rx_cfg @0x608;
-    external channel_alloc_rx_ctrl       channel_alloc_rx_ctrl @0x60c;
-             channel_alloc_tx_ch_en      channel_alloc_tx_ch_en[NumChannels] @0x700;
-             channel_alloc_rx_ch_en      channel_alloc_rx_ch_en[NumChannels] @0x800;
+             ctrl                        ctrl;
+    external isolated                    isolated;
+             raw_mode_en                 raw_mode_en;
+    external raw_mode_in_data            raw_mode_in_data[RawModeNumWords];
+             raw_mode_in_ch_sel          raw_mode_in_ch_sel;
+             raw_mode_out_data_fifo      raw_mode_out_data_fifo[RawModeNumWords];
+    external raw_mode_out_data_fifo_ctrl raw_mode_out_data_fifo_ctrl;
+             raw_mode_out_en             raw_mode_out_en;
+    external flow_control_fifo_clear     flow_control_fifo_clear;
+    external raw_mode_in_data_valid      raw_mode_in_data_valid[NumChannels];
+             raw_mode_out_ch_mask        raw_mode_out_ch_mask[NumChannels];
+             tx_phy_clk_div              tx_phy_clk_div[NumChannels];
+             tx_phy_clk_start            tx_phy_clk_start[NumChannels];
+             tx_phy_clk_end              tx_phy_clk_end[NumChannels];
+             channel_alloc_tx_cfg        channel_alloc_tx_cfg;
+    external channel_alloc_tx_ctrl       channel_alloc_tx_ctrl;
+             channel_alloc_rx_cfg        channel_alloc_rx_cfg;
+    external channel_alloc_rx_ctrl       channel_alloc_rx_ctrl;
+             channel_alloc_tx_ch_en      channel_alloc_tx_ch_en[NumChannels];
+             channel_alloc_rx_ch_en      channel_alloc_rx_ch_en[NumChannels];
 };
 
 `endif // SERIAL_LINK_BASE_RDL

--- a/src/regs/slink_reg.sv
+++ b/src/regs/slink_reg.sv
@@ -13,7 +13,7 @@ module slink_reg (
         input wire s_apb_penable,
         input wire s_apb_pwrite,
         input wire [2:0] s_apb_pprot,
-        input wire [11:0] s_apb_paddr,
+        input wire [6:0] s_apb_paddr,
         input wire [31:0] s_apb_pwdata,
         input wire [3:0] s_apb_pstrb,
         output logic s_apb_pready,
@@ -29,7 +29,7 @@ module slink_reg (
     //--------------------------------------------------------------------------
     logic cpuif_req;
     logic cpuif_req_is_wr;
-    logic [11:0] cpuif_addr;
+    logic [6:0] cpuif_addr;
     logic [31:0] cpuif_wr_data;
     logic [31:0] cpuif_wr_biten;
     logic cpuif_req_stall_wr;
@@ -58,7 +58,7 @@ module slink_reg (
                     is_active <= '1;
                     cpuif_req <= '1;
                     cpuif_req_is_wr <= s_apb_pwrite;
-                    cpuif_addr <= {s_apb_paddr[11:2], 2'b0};
+                    cpuif_addr <= {s_apb_paddr[6:2], 2'b0};
                     cpuif_wr_data <= s_apb_pwdata;
                     for(int i=0; i<4; i++) begin
                         cpuif_wr_biten[i*8 +: 8] <= {8{s_apb_pstrb[i]}};
@@ -113,9 +113,9 @@ module slink_reg (
         logic ctrl;
         logic isolated;
         logic raw_mode_en;
-        logic raw_mode_in_data;
+        logic raw_mode_in_data[1];
         logic raw_mode_in_ch_sel;
-        logic raw_mode_out_data_fifo;
+        logic raw_mode_out_data_fifo[1];
         logic raw_mode_out_data_fifo_ctrl;
         logic raw_mode_out_en;
         logic flow_control_fifo_clear;
@@ -147,46 +147,50 @@ module slink_reg (
         is_external = '0;
         is_valid_addr = '1; // No error checking on valid address access
         is_invalid_rw = '0;
-        decoded_reg_strb.ctrl = cpuif_req_masked & (cpuif_addr == 12'h0);
-        decoded_reg_strb.isolated = cpuif_req_masked & (cpuif_addr == 12'h4) & !cpuif_req_is_wr;
-        is_external |= cpuif_req_masked & (cpuif_addr == 12'h4) & !cpuif_req_is_wr;
-        decoded_reg_strb.raw_mode_en = cpuif_req_masked & (cpuif_addr == 12'h8) & cpuif_req_is_wr;
-        decoded_reg_strb.raw_mode_in_data = cpuif_req_masked & (cpuif_addr == 12'hc) & !cpuif_req_is_wr;
-        is_external |= cpuif_req_masked & (cpuif_addr == 12'hc) & !cpuif_req_is_wr;
-        decoded_reg_strb.raw_mode_in_ch_sel = cpuif_req_masked & (cpuif_addr == 12'h10) & cpuif_req_is_wr;
-        decoded_reg_strb.raw_mode_out_data_fifo = cpuif_req_masked & (cpuif_addr == 12'h14) & cpuif_req_is_wr;
-        decoded_reg_strb.raw_mode_out_data_fifo_ctrl = cpuif_req_masked & (cpuif_addr == 12'h18);
-        is_external |= cpuif_req_masked & (cpuif_addr == 12'h18);
-        decoded_reg_strb.raw_mode_out_en = cpuif_req_masked & (cpuif_addr == 12'h1c);
-        decoded_reg_strb.flow_control_fifo_clear = cpuif_req_masked & (cpuif_addr == 12'h20) & cpuif_req_is_wr;
-        is_external |= cpuif_req_masked & (cpuif_addr == 12'h20) & cpuif_req_is_wr;
+        decoded_reg_strb.ctrl = cpuif_req_masked & (cpuif_addr == 7'h0);
+        decoded_reg_strb.isolated = cpuif_req_masked & (cpuif_addr == 7'h4) & !cpuif_req_is_wr;
+        is_external |= cpuif_req_masked & (cpuif_addr == 7'h4) & !cpuif_req_is_wr;
+        decoded_reg_strb.raw_mode_en = cpuif_req_masked & (cpuif_addr == 7'h8) & cpuif_req_is_wr;
         for(int i0=0; i0<1; i0++) begin
-            decoded_reg_strb.raw_mode_in_data_valid[i0] = cpuif_req_masked & (cpuif_addr == 12'h100 + (12)'(i0) * 12'h4) & !cpuif_req_is_wr;
-            is_external |= cpuif_req_masked & (cpuif_addr == 12'h100 + (12)'(i0) * 12'h4) & !cpuif_req_is_wr;
+            decoded_reg_strb.raw_mode_in_data[i0] = cpuif_req_masked & (cpuif_addr == 7'hc + (7)'(i0) * 7'h4) & !cpuif_req_is_wr;
+            is_external |= cpuif_req_masked & (cpuif_addr == 7'hc + (7)'(i0) * 7'h4) & !cpuif_req_is_wr;
+        end
+        decoded_reg_strb.raw_mode_in_ch_sel = cpuif_req_masked & (cpuif_addr == 7'h10) & cpuif_req_is_wr;
+        for(int i0=0; i0<1; i0++) begin
+            decoded_reg_strb.raw_mode_out_data_fifo[i0] = cpuif_req_masked & (cpuif_addr == 7'h14 + (7)'(i0) * 7'h4) & cpuif_req_is_wr;
+        end
+        decoded_reg_strb.raw_mode_out_data_fifo_ctrl = cpuif_req_masked & (cpuif_addr == 7'h18);
+        is_external |= cpuif_req_masked & (cpuif_addr == 7'h18);
+        decoded_reg_strb.raw_mode_out_en = cpuif_req_masked & (cpuif_addr == 7'h1c);
+        decoded_reg_strb.flow_control_fifo_clear = cpuif_req_masked & (cpuif_addr == 7'h20) & cpuif_req_is_wr;
+        is_external |= cpuif_req_masked & (cpuif_addr == 7'h20) & cpuif_req_is_wr;
+        for(int i0=0; i0<1; i0++) begin
+            decoded_reg_strb.raw_mode_in_data_valid[i0] = cpuif_req_masked & (cpuif_addr == 7'h24 + (7)'(i0) * 7'h4) & !cpuif_req_is_wr;
+            is_external |= cpuif_req_masked & (cpuif_addr == 7'h24 + (7)'(i0) * 7'h4) & !cpuif_req_is_wr;
         end
         for(int i0=0; i0<1; i0++) begin
-            decoded_reg_strb.raw_mode_out_ch_mask[i0] = cpuif_req_masked & (cpuif_addr == 12'h200 + (12)'(i0) * 12'h4) & cpuif_req_is_wr;
+            decoded_reg_strb.raw_mode_out_ch_mask[i0] = cpuif_req_masked & (cpuif_addr == 7'h28 + (7)'(i0) * 7'h4) & cpuif_req_is_wr;
         end
         for(int i0=0; i0<1; i0++) begin
-            decoded_reg_strb.tx_phy_clk_div[i0] = cpuif_req_masked & (cpuif_addr == 12'h300 + (12)'(i0) * 12'h4);
+            decoded_reg_strb.tx_phy_clk_div[i0] = cpuif_req_masked & (cpuif_addr == 7'h2c + (7)'(i0) * 7'h4);
         end
         for(int i0=0; i0<1; i0++) begin
-            decoded_reg_strb.tx_phy_clk_start[i0] = cpuif_req_masked & (cpuif_addr == 12'h400 + (12)'(i0) * 12'h4);
+            decoded_reg_strb.tx_phy_clk_start[i0] = cpuif_req_masked & (cpuif_addr == 7'h30 + (7)'(i0) * 7'h4);
         end
         for(int i0=0; i0<1; i0++) begin
-            decoded_reg_strb.tx_phy_clk_end[i0] = cpuif_req_masked & (cpuif_addr == 12'h500 + (12)'(i0) * 12'h4);
+            decoded_reg_strb.tx_phy_clk_end[i0] = cpuif_req_masked & (cpuif_addr == 7'h34 + (7)'(i0) * 7'h4);
         end
-        decoded_reg_strb.channel_alloc_tx_cfg = cpuif_req_masked & (cpuif_addr == 12'h600) & !cpuif_req_is_wr;
-        decoded_reg_strb.channel_alloc_tx_ctrl = cpuif_req_masked & (cpuif_addr == 12'h604) & !cpuif_req_is_wr;
-        is_external |= cpuif_req_masked & (cpuif_addr == 12'h604) & !cpuif_req_is_wr;
-        decoded_reg_strb.channel_alloc_rx_cfg = cpuif_req_masked & (cpuif_addr == 12'h608) & !cpuif_req_is_wr;
-        decoded_reg_strb.channel_alloc_rx_ctrl = cpuif_req_masked & (cpuif_addr == 12'h60c) & !cpuif_req_is_wr;
-        is_external |= cpuif_req_masked & (cpuif_addr == 12'h60c) & !cpuif_req_is_wr;
+        decoded_reg_strb.channel_alloc_tx_cfg = cpuif_req_masked & (cpuif_addr == 7'h38) & !cpuif_req_is_wr;
+        decoded_reg_strb.channel_alloc_tx_ctrl = cpuif_req_masked & (cpuif_addr == 7'h3c) & !cpuif_req_is_wr;
+        is_external |= cpuif_req_masked & (cpuif_addr == 7'h3c) & !cpuif_req_is_wr;
+        decoded_reg_strb.channel_alloc_rx_cfg = cpuif_req_masked & (cpuif_addr == 7'h40) & !cpuif_req_is_wr;
+        decoded_reg_strb.channel_alloc_rx_ctrl = cpuif_req_masked & (cpuif_addr == 7'h44) & !cpuif_req_is_wr;
+        is_external |= cpuif_req_masked & (cpuif_addr == 7'h44) & !cpuif_req_is_wr;
         for(int i0=0; i0<1; i0++) begin
-            decoded_reg_strb.channel_alloc_tx_ch_en[i0] = cpuif_req_masked & (cpuif_addr == 12'h700 + (12)'(i0) * 12'h4) & !cpuif_req_is_wr;
+            decoded_reg_strb.channel_alloc_tx_ch_en[i0] = cpuif_req_masked & (cpuif_addr == 7'h48 + (7)'(i0) * 7'h4) & !cpuif_req_is_wr;
         end
         for(int i0=0; i0<1; i0++) begin
-            decoded_reg_strb.channel_alloc_rx_ch_en[i0] = cpuif_req_masked & (cpuif_addr == 12'h800 + (12)'(i0) * 12'h4) & !cpuif_req_is_wr;
+            decoded_reg_strb.channel_alloc_rx_ch_en[i0] = cpuif_req_masked & (cpuif_addr == 7'h4c + (7)'(i0) * 7'h4) & !cpuif_req_is_wr;
         end
         decoded_err = (~is_valid_addr | is_invalid_rw) & decoded_req;
         decoded_strb_is_external = is_external;
@@ -235,10 +239,10 @@ module slink_reg (
         } raw_mode_in_ch_sel;
         struct {
             struct {
-                logic [15:0] next;
+                logic [31:0] next;
                 logic load_next;
             } raw_mode_out_data_fifo;
-        } raw_mode_out_data_fifo;
+        } raw_mode_out_data_fifo[1];
         struct {
             struct {
                 logic next;
@@ -299,9 +303,9 @@ module slink_reg (
         } raw_mode_in_ch_sel;
         struct {
             struct {
-                logic [15:0] value;
+                logic [31:0] value;
             } raw_mode_out_data_fifo;
-        } raw_mode_out_data_fifo;
+        } raw_mode_out_data_fifo[1];
         struct {
             struct {
                 logic value;
@@ -449,10 +453,12 @@ module slink_reg (
         end
     end
     assign hwif_out.raw_mode_en.raw_mode_en.value = field_storage.raw_mode_en.raw_mode_en.value;
-    // External register: slink_reg.raw_mode_in_data
+    for(genvar i0=0; i0<1; i0++) begin
+        // External register: slink_reg.raw_mode_in_data[]
 
-    assign hwif_out.raw_mode_in_data.req = !decoded_req_is_wr ? decoded_reg_strb.raw_mode_in_data : '0;
-    assign hwif_out.raw_mode_in_data.req_is_wr = decoded_req_is_wr;
+        assign hwif_out.raw_mode_in_data[i0].req = !decoded_req_is_wr ? decoded_reg_strb.raw_mode_in_data[i0] : '0;
+        assign hwif_out.raw_mode_in_data[i0].req_is_wr = decoded_req_is_wr;
+    end
     // Field: slink_reg.raw_mode_in_ch_sel.raw_mode_in_ch_sel
     always_comb begin
         automatic logic [7:0] next_c;
@@ -476,30 +482,32 @@ module slink_reg (
         end
     end
     assign hwif_out.raw_mode_in_ch_sel.raw_mode_in_ch_sel.value = field_storage.raw_mode_in_ch_sel.raw_mode_in_ch_sel.value;
-    // Field: slink_reg.raw_mode_out_data_fifo.raw_mode_out_data_fifo
-    always_comb begin
-        automatic logic [15:0] next_c;
-        automatic logic load_next_c;
-        next_c = field_storage.raw_mode_out_data_fifo.raw_mode_out_data_fifo.value;
-        load_next_c = '0;
-        if(decoded_reg_strb.raw_mode_out_data_fifo && decoded_req_is_wr) begin // SW write
-            next_c = (field_storage.raw_mode_out_data_fifo.raw_mode_out_data_fifo.value & ~decoded_wr_biten[15:0]) | (decoded_wr_data[15:0] & decoded_wr_biten[15:0]);
-            load_next_c = '1;
+    for(genvar i0=0; i0<1; i0++) begin
+        // Field: slink_reg.raw_mode_out_data_fifo[].raw_mode_out_data_fifo
+        always_comb begin
+            automatic logic [31:0] next_c;
+            automatic logic load_next_c;
+            next_c = field_storage.raw_mode_out_data_fifo[i0].raw_mode_out_data_fifo.value;
+            load_next_c = '0;
+            if(decoded_reg_strb.raw_mode_out_data_fifo[i0] && decoded_req_is_wr) begin // SW write
+                next_c = (field_storage.raw_mode_out_data_fifo[i0].raw_mode_out_data_fifo.value & ~decoded_wr_biten[31:0]) | (decoded_wr_data[31:0] & decoded_wr_biten[31:0]);
+                load_next_c = '1;
+            end
+            field_combo.raw_mode_out_data_fifo[i0].raw_mode_out_data_fifo.next = next_c;
+            field_combo.raw_mode_out_data_fifo[i0].raw_mode_out_data_fifo.load_next = load_next_c;
         end
-        field_combo.raw_mode_out_data_fifo.raw_mode_out_data_fifo.next = next_c;
-        field_combo.raw_mode_out_data_fifo.raw_mode_out_data_fifo.load_next = load_next_c;
-    end
-    always_ff @(posedge clk or negedge arst_n) begin
-        if(~arst_n) begin
-            field_storage.raw_mode_out_data_fifo.raw_mode_out_data_fifo.value <= 16'h0;
-        end else begin
-            if(field_combo.raw_mode_out_data_fifo.raw_mode_out_data_fifo.load_next) begin
-                field_storage.raw_mode_out_data_fifo.raw_mode_out_data_fifo.value <= field_combo.raw_mode_out_data_fifo.raw_mode_out_data_fifo.next;
+        always_ff @(posedge clk or negedge arst_n) begin
+            if(~arst_n) begin
+                field_storage.raw_mode_out_data_fifo[i0].raw_mode_out_data_fifo.value <= 32'h0;
+            end else begin
+                if(field_combo.raw_mode_out_data_fifo[i0].raw_mode_out_data_fifo.load_next) begin
+                    field_storage.raw_mode_out_data_fifo[i0].raw_mode_out_data_fifo.value <= field_combo.raw_mode_out_data_fifo[i0].raw_mode_out_data_fifo.next;
+                end
             end
         end
+        assign hwif_out.raw_mode_out_data_fifo[i0].raw_mode_out_data_fifo.value = field_storage.raw_mode_out_data_fifo[i0].raw_mode_out_data_fifo.value;
+        assign hwif_out.raw_mode_out_data_fifo[i0].raw_mode_out_data_fifo.swmod = decoded_reg_strb.raw_mode_out_data_fifo[i0] && decoded_req_is_wr && |(decoded_wr_biten[31:0]);
     end
-    assign hwif_out.raw_mode_out_data_fifo.raw_mode_out_data_fifo.value = field_storage.raw_mode_out_data_fifo.raw_mode_out_data_fifo.value;
-    assign hwif_out.raw_mode_out_data_fifo.raw_mode_out_data_fifo.swmod = decoded_reg_strb.raw_mode_out_data_fifo && decoded_req_is_wr && |(decoded_wr_biten[15:0]);
     // External register: slink_reg.raw_mode_out_data_fifo_ctrl
     assign hwif_out.raw_mode_out_data_fifo_ctrl.req = decoded_reg_strb.raw_mode_out_data_fifo_ctrl;
     assign hwif_out.raw_mode_out_data_fifo_ctrl.req_is_wr = decoded_req_is_wr;
@@ -684,7 +692,9 @@ module slink_reg (
         automatic logic rd_ack;
         rd_ack = '0;
         rd_ack |= hwif_in.isolated.rd_ack;
-        rd_ack |= hwif_in.raw_mode_in_data.rd_ack;
+        for(int i0=0; i0<1; i0++) begin
+            rd_ack |= hwif_in.raw_mode_in_data[i0].rd_ack;
+        end
         rd_ack |= hwif_in.raw_mode_out_data_fifo_ctrl.rd_ack;
         for(int i0=0; i0<1; i0++) begin
             rd_ack |= hwif_in.raw_mode_in_data_valid[i0].rd_ack;
@@ -711,7 +721,9 @@ module slink_reg (
     assign readback_array[0][9:9] = (decoded_reg_strb.ctrl && !decoded_req_is_wr) ? field_storage.ctrl.axi_out_isolate.value : '0;
     assign readback_array[0][31:10] = '0;
     assign readback_array[1] = hwif_in.isolated.rd_ack ? hwif_in.isolated.rd_data : '0;
-    assign readback_array[2] = hwif_in.raw_mode_in_data.rd_ack ? hwif_in.raw_mode_in_data.rd_data : '0;
+    for(genvar i0=0; i0<1; i0++) begin
+        assign readback_array[i0 * 1 + 2] = hwif_in.raw_mode_in_data[i0].rd_ack ? hwif_in.raw_mode_in_data[i0].rd_data : '0;
+    end
     assign readback_array[3] = hwif_in.raw_mode_out_data_fifo_ctrl.rd_ack ? hwif_in.raw_mode_out_data_fifo_ctrl.rd_data : '0;
     assign readback_array[4][0:0] = (decoded_reg_strb.raw_mode_out_en && !decoded_req_is_wr) ? field_storage.raw_mode_out_en.raw_mode_out_en.value : '0;
     assign readback_array[4][31:1] = '0;

--- a/src/regs/slink_reg.sv
+++ b/src/regs/slink_reg.sv
@@ -114,8 +114,10 @@ module slink_reg (
         logic isolated;
         logic raw_mode_en;
         logic raw_mode_in_data[1];
+        logic raw_mode_pop;
         logic raw_mode_in_ch_sel;
         logic raw_mode_out_data_fifo[1];
+        logic raw_mode_push;
         logic raw_mode_out_data_fifo_ctrl;
         logic raw_mode_out_en;
         logic flow_control_fifo_clear;
@@ -155,42 +157,44 @@ module slink_reg (
             decoded_reg_strb.raw_mode_in_data[i0] = cpuif_req_masked & (cpuif_addr == 7'hc + (7)'(i0) * 7'h4) & !cpuif_req_is_wr;
             is_external |= cpuif_req_masked & (cpuif_addr == 7'hc + (7)'(i0) * 7'h4) & !cpuif_req_is_wr;
         end
-        decoded_reg_strb.raw_mode_in_ch_sel = cpuif_req_masked & (cpuif_addr == 7'h10) & cpuif_req_is_wr;
+        decoded_reg_strb.raw_mode_pop = cpuif_req_masked & (cpuif_addr == 7'h10) & cpuif_req_is_wr;
+        decoded_reg_strb.raw_mode_in_ch_sel = cpuif_req_masked & (cpuif_addr == 7'h14) & cpuif_req_is_wr;
         for(int i0=0; i0<1; i0++) begin
-            decoded_reg_strb.raw_mode_out_data_fifo[i0] = cpuif_req_masked & (cpuif_addr == 7'h14 + (7)'(i0) * 7'h4) & cpuif_req_is_wr;
+            decoded_reg_strb.raw_mode_out_data_fifo[i0] = cpuif_req_masked & (cpuif_addr == 7'h18 + (7)'(i0) * 7'h4) & cpuif_req_is_wr;
         end
-        decoded_reg_strb.raw_mode_out_data_fifo_ctrl = cpuif_req_masked & (cpuif_addr == 7'h18);
-        is_external |= cpuif_req_masked & (cpuif_addr == 7'h18);
-        decoded_reg_strb.raw_mode_out_en = cpuif_req_masked & (cpuif_addr == 7'h1c);
-        decoded_reg_strb.flow_control_fifo_clear = cpuif_req_masked & (cpuif_addr == 7'h20) & cpuif_req_is_wr;
-        is_external |= cpuif_req_masked & (cpuif_addr == 7'h20) & cpuif_req_is_wr;
+        decoded_reg_strb.raw_mode_push = cpuif_req_masked & (cpuif_addr == 7'h1c) & cpuif_req_is_wr;
+        decoded_reg_strb.raw_mode_out_data_fifo_ctrl = cpuif_req_masked & (cpuif_addr == 7'h20);
+        is_external |= cpuif_req_masked & (cpuif_addr == 7'h20);
+        decoded_reg_strb.raw_mode_out_en = cpuif_req_masked & (cpuif_addr == 7'h24);
+        decoded_reg_strb.flow_control_fifo_clear = cpuif_req_masked & (cpuif_addr == 7'h28) & cpuif_req_is_wr;
+        is_external |= cpuif_req_masked & (cpuif_addr == 7'h28) & cpuif_req_is_wr;
         for(int i0=0; i0<1; i0++) begin
-            decoded_reg_strb.raw_mode_in_data_valid[i0] = cpuif_req_masked & (cpuif_addr == 7'h24 + (7)'(i0) * 7'h4) & !cpuif_req_is_wr;
-            is_external |= cpuif_req_masked & (cpuif_addr == 7'h24 + (7)'(i0) * 7'h4) & !cpuif_req_is_wr;
-        end
-        for(int i0=0; i0<1; i0++) begin
-            decoded_reg_strb.raw_mode_out_ch_mask[i0] = cpuif_req_masked & (cpuif_addr == 7'h28 + (7)'(i0) * 7'h4) & cpuif_req_is_wr;
-        end
-        for(int i0=0; i0<1; i0++) begin
-            decoded_reg_strb.tx_phy_clk_div[i0] = cpuif_req_masked & (cpuif_addr == 7'h2c + (7)'(i0) * 7'h4);
+            decoded_reg_strb.raw_mode_in_data_valid[i0] = cpuif_req_masked & (cpuif_addr == 7'h2c + (7)'(i0) * 7'h4) & !cpuif_req_is_wr;
+            is_external |= cpuif_req_masked & (cpuif_addr == 7'h2c + (7)'(i0) * 7'h4) & !cpuif_req_is_wr;
         end
         for(int i0=0; i0<1; i0++) begin
-            decoded_reg_strb.tx_phy_clk_start[i0] = cpuif_req_masked & (cpuif_addr == 7'h30 + (7)'(i0) * 7'h4);
+            decoded_reg_strb.raw_mode_out_ch_mask[i0] = cpuif_req_masked & (cpuif_addr == 7'h30 + (7)'(i0) * 7'h4) & cpuif_req_is_wr;
         end
         for(int i0=0; i0<1; i0++) begin
-            decoded_reg_strb.tx_phy_clk_end[i0] = cpuif_req_masked & (cpuif_addr == 7'h34 + (7)'(i0) * 7'h4);
+            decoded_reg_strb.tx_phy_clk_div[i0] = cpuif_req_masked & (cpuif_addr == 7'h34 + (7)'(i0) * 7'h4);
         end
-        decoded_reg_strb.channel_alloc_tx_cfg = cpuif_req_masked & (cpuif_addr == 7'h38) & !cpuif_req_is_wr;
-        decoded_reg_strb.channel_alloc_tx_ctrl = cpuif_req_masked & (cpuif_addr == 7'h3c) & !cpuif_req_is_wr;
-        is_external |= cpuif_req_masked & (cpuif_addr == 7'h3c) & !cpuif_req_is_wr;
-        decoded_reg_strb.channel_alloc_rx_cfg = cpuif_req_masked & (cpuif_addr == 7'h40) & !cpuif_req_is_wr;
-        decoded_reg_strb.channel_alloc_rx_ctrl = cpuif_req_masked & (cpuif_addr == 7'h44) & !cpuif_req_is_wr;
+        for(int i0=0; i0<1; i0++) begin
+            decoded_reg_strb.tx_phy_clk_start[i0] = cpuif_req_masked & (cpuif_addr == 7'h38 + (7)'(i0) * 7'h4);
+        end
+        for(int i0=0; i0<1; i0++) begin
+            decoded_reg_strb.tx_phy_clk_end[i0] = cpuif_req_masked & (cpuif_addr == 7'h3c + (7)'(i0) * 7'h4);
+        end
+        decoded_reg_strb.channel_alloc_tx_cfg = cpuif_req_masked & (cpuif_addr == 7'h40) & !cpuif_req_is_wr;
+        decoded_reg_strb.channel_alloc_tx_ctrl = cpuif_req_masked & (cpuif_addr == 7'h44) & !cpuif_req_is_wr;
         is_external |= cpuif_req_masked & (cpuif_addr == 7'h44) & !cpuif_req_is_wr;
+        decoded_reg_strb.channel_alloc_rx_cfg = cpuif_req_masked & (cpuif_addr == 7'h48) & !cpuif_req_is_wr;
+        decoded_reg_strb.channel_alloc_rx_ctrl = cpuif_req_masked & (cpuif_addr == 7'h4c) & !cpuif_req_is_wr;
+        is_external |= cpuif_req_masked & (cpuif_addr == 7'h4c) & !cpuif_req_is_wr;
         for(int i0=0; i0<1; i0++) begin
-            decoded_reg_strb.channel_alloc_tx_ch_en[i0] = cpuif_req_masked & (cpuif_addr == 7'h48 + (7)'(i0) * 7'h4) & !cpuif_req_is_wr;
+            decoded_reg_strb.channel_alloc_tx_ch_en[i0] = cpuif_req_masked & (cpuif_addr == 7'h50 + (7)'(i0) * 7'h4) & !cpuif_req_is_wr;
         end
         for(int i0=0; i0<1; i0++) begin
-            decoded_reg_strb.channel_alloc_rx_ch_en[i0] = cpuif_req_masked & (cpuif_addr == 7'h4c + (7)'(i0) * 7'h4) & !cpuif_req_is_wr;
+            decoded_reg_strb.channel_alloc_rx_ch_en[i0] = cpuif_req_masked & (cpuif_addr == 7'h54 + (7)'(i0) * 7'h4) & !cpuif_req_is_wr;
         end
         decoded_err = (~is_valid_addr | is_invalid_rw) & decoded_req;
         decoded_strb_is_external = is_external;
@@ -233,6 +237,12 @@ module slink_reg (
         } raw_mode_en;
         struct {
             struct {
+                logic next;
+                logic load_next;
+            } raw_mode_pop;
+        } raw_mode_pop;
+        struct {
+            struct {
                 logic [7:0] next;
                 logic load_next;
             } raw_mode_in_ch_sel;
@@ -243,6 +253,12 @@ module slink_reg (
                 logic load_next;
             } raw_mode_out_data_fifo;
         } raw_mode_out_data_fifo[1];
+        struct {
+            struct {
+                logic next;
+                logic load_next;
+            } raw_mode_push;
+        } raw_mode_push;
         struct {
             struct {
                 logic next;
@@ -298,6 +314,11 @@ module slink_reg (
         } raw_mode_en;
         struct {
             struct {
+                logic value;
+            } raw_mode_pop;
+        } raw_mode_pop;
+        struct {
+            struct {
                 logic [7:0] value;
             } raw_mode_in_ch_sel;
         } raw_mode_in_ch_sel;
@@ -306,6 +327,11 @@ module slink_reg (
                 logic [31:0] value;
             } raw_mode_out_data_fifo;
         } raw_mode_out_data_fifo[1];
+        struct {
+            struct {
+                logic value;
+            } raw_mode_push;
+        } raw_mode_push;
         struct {
             struct {
                 logic value;
@@ -459,6 +485,32 @@ module slink_reg (
         assign hwif_out.raw_mode_in_data[i0].req = !decoded_req_is_wr ? decoded_reg_strb.raw_mode_in_data[i0] : '0;
         assign hwif_out.raw_mode_in_data[i0].req_is_wr = decoded_req_is_wr;
     end
+    // Field: slink_reg.raw_mode_pop.raw_mode_pop
+    always_comb begin
+        automatic logic [0:0] next_c;
+        automatic logic load_next_c;
+        next_c = field_storage.raw_mode_pop.raw_mode_pop.value;
+        load_next_c = '0;
+        if(decoded_reg_strb.raw_mode_pop && decoded_req_is_wr) begin // SW write
+            next_c = (field_storage.raw_mode_pop.raw_mode_pop.value & ~decoded_wr_biten[0:0]) | (decoded_wr_data[0:0] & decoded_wr_biten[0:0]);
+            load_next_c = '1;
+        end else begin // singlepulse clears back to 0
+            next_c = '0;
+            load_next_c = '1;
+        end
+        field_combo.raw_mode_pop.raw_mode_pop.next = next_c;
+        field_combo.raw_mode_pop.raw_mode_pop.load_next = load_next_c;
+    end
+    always_ff @(posedge clk or negedge arst_n) begin
+        if(~arst_n) begin
+            field_storage.raw_mode_pop.raw_mode_pop.value <= 1'h0;
+        end else begin
+            if(field_combo.raw_mode_pop.raw_mode_pop.load_next) begin
+                field_storage.raw_mode_pop.raw_mode_pop.value <= field_combo.raw_mode_pop.raw_mode_pop.next;
+            end
+        end
+    end
+    assign hwif_out.raw_mode_pop.raw_mode_pop.value = field_storage.raw_mode_pop.raw_mode_pop.value;
     // Field: slink_reg.raw_mode_in_ch_sel.raw_mode_in_ch_sel
     always_comb begin
         automatic logic [7:0] next_c;
@@ -506,8 +558,33 @@ module slink_reg (
             end
         end
         assign hwif_out.raw_mode_out_data_fifo[i0].raw_mode_out_data_fifo.value = field_storage.raw_mode_out_data_fifo[i0].raw_mode_out_data_fifo.value;
-        assign hwif_out.raw_mode_out_data_fifo[i0].raw_mode_out_data_fifo.swmod = decoded_reg_strb.raw_mode_out_data_fifo[i0] && decoded_req_is_wr && |(decoded_wr_biten[31:0]);
     end
+    // Field: slink_reg.raw_mode_push.raw_mode_push
+    always_comb begin
+        automatic logic [0:0] next_c;
+        automatic logic load_next_c;
+        next_c = field_storage.raw_mode_push.raw_mode_push.value;
+        load_next_c = '0;
+        if(decoded_reg_strb.raw_mode_push && decoded_req_is_wr) begin // SW write
+            next_c = (field_storage.raw_mode_push.raw_mode_push.value & ~decoded_wr_biten[0:0]) | (decoded_wr_data[0:0] & decoded_wr_biten[0:0]);
+            load_next_c = '1;
+        end else begin // singlepulse clears back to 0
+            next_c = '0;
+            load_next_c = '1;
+        end
+        field_combo.raw_mode_push.raw_mode_push.next = next_c;
+        field_combo.raw_mode_push.raw_mode_push.load_next = load_next_c;
+    end
+    always_ff @(posedge clk or negedge arst_n) begin
+        if(~arst_n) begin
+            field_storage.raw_mode_push.raw_mode_push.value <= 1'h0;
+        end else begin
+            if(field_combo.raw_mode_push.raw_mode_push.load_next) begin
+                field_storage.raw_mode_push.raw_mode_push.value <= field_combo.raw_mode_push.raw_mode_push.next;
+            end
+        end
+    end
+    assign hwif_out.raw_mode_push.raw_mode_push.value = field_storage.raw_mode_push.raw_mode_push.value;
     // External register: slink_reg.raw_mode_out_data_fifo_ctrl
     assign hwif_out.raw_mode_out_data_fifo_ctrl.req = decoded_reg_strb.raw_mode_out_data_fifo_ctrl;
     assign hwif_out.raw_mode_out_data_fifo_ctrl.req_is_wr = decoded_req_is_wr;

--- a/src/regs/slink_reg_pkg.sv
+++ b/src/regs/slink_reg_pkg.sv
@@ -9,7 +9,7 @@ package slink_reg_pkg;
 
     localparam SLINK_REG_DATA_WIDTH = 32;
     localparam SLINK_REG_MIN_ADDR_WIDTH = 7;
-    localparam SLINK_REG_SIZE = 'h50;
+    localparam SLINK_REG_SIZE = 'h58;
     localparam NumChannels = 'h1;
     localparam NumLanes = 'h8;
     localparam EnDdr = 'h1;
@@ -140,6 +140,14 @@ package slink_reg_pkg;
     } slink_reg__raw_mode_in_data__external__out_t;
 
     typedef struct {
+        logic value;
+    } slink_reg__raw_mode_pop__raw_mode_pop__out_t;
+
+    typedef struct {
+        slink_reg__raw_mode_pop__raw_mode_pop__out_t raw_mode_pop;
+    } slink_reg__raw_mode_pop__out_t;
+
+    typedef struct {
         logic [7:0] value;
     } slink_reg__raw_mode_in_ch_sel__raw_mode_in_ch_sel__out_t;
 
@@ -149,12 +157,19 @@ package slink_reg_pkg;
 
     typedef struct {
         logic [31:0] value;
-        logic swmod;
     } slink_reg__raw_mode_out_data_fifo__raw_mode_out_data_fifo__out_t;
 
     typedef struct {
         slink_reg__raw_mode_out_data_fifo__raw_mode_out_data_fifo__out_t raw_mode_out_data_fifo;
     } slink_reg__raw_mode_out_data_fifo__out_t;
+
+    typedef struct {
+        logic value;
+    } slink_reg__raw_mode_push__raw_mode_push__out_t;
+
+    typedef struct {
+        slink_reg__raw_mode_push__raw_mode_push__out_t raw_mode_push;
+    } slink_reg__raw_mode_push__out_t;
 
     typedef struct packed {
         logic [30:0] _reserved_31_1;
@@ -297,8 +312,10 @@ package slink_reg_pkg;
         slink_reg__isolated__external__out_t isolated;
         slink_reg__raw_mode_en__out_t raw_mode_en;
         slink_reg__raw_mode_in_data__external__out_t raw_mode_in_data[1];
+        slink_reg__raw_mode_pop__out_t raw_mode_pop;
         slink_reg__raw_mode_in_ch_sel__out_t raw_mode_in_ch_sel;
         slink_reg__raw_mode_out_data_fifo__out_t raw_mode_out_data_fifo[1];
+        slink_reg__raw_mode_push__out_t raw_mode_push;
         slink_reg__raw_mode_out_data_fifo_ctrl__external__out_t raw_mode_out_data_fifo_ctrl;
         slink_reg__raw_mode_out_en__out_t raw_mode_out_en;
         slink_reg__flow_control_fifo_clear__external__out_t flow_control_fifo_clear;

--- a/src/regs/slink_reg_pkg.sv
+++ b/src/regs/slink_reg_pkg.sv
@@ -8,8 +8,8 @@
 package slink_reg_pkg;
 
     localparam SLINK_REG_DATA_WIDTH = 32;
-    localparam SLINK_REG_MIN_ADDR_WIDTH = 12;
-    localparam SLINK_REG_SIZE = 'h804;
+    localparam SLINK_REG_MIN_ADDR_WIDTH = 7;
+    localparam SLINK_REG_SIZE = 'h50;
     localparam NumChannels = 'h1;
     localparam NumLanes = 'h8;
     localparam EnDdr = 'h1;
@@ -18,6 +18,7 @@ package slink_reg_pkg;
     localparam FlushCounterWidth = 'h8;
     localparam Log2RawModeTXFifoDepth = 'h3;
     localparam EnChAlloc = 'h0;
+    localparam RawModeNumWords = 'h1;
 
     typedef struct packed {
         logic [29:0] _reserved_31_2;
@@ -31,8 +32,7 @@ package slink_reg_pkg;
     } slink_reg__isolated__external__in_t;
 
     typedef struct packed {
-        logic [15:0] _reserved_31_16;
-        logic [15:0] raw_mode_in_data;
+        logic [31:0] raw_mode_in_data;
     } slink_reg__raw_mode_in_data__external__fields__in_t;
 
     typedef struct {
@@ -90,7 +90,7 @@ package slink_reg_pkg;
 
     typedef struct {
         slink_reg__isolated__external__in_t isolated;
-        slink_reg__raw_mode_in_data__external__in_t raw_mode_in_data;
+        slink_reg__raw_mode_in_data__external__in_t raw_mode_in_data[1];
         slink_reg__raw_mode_out_data_fifo_ctrl__external__in_t raw_mode_out_data_fifo_ctrl;
         slink_reg__flow_control_fifo_clear__external__in_t flow_control_fifo_clear;
         slink_reg__raw_mode_in_data_valid__external__in_t raw_mode_in_data_valid[1];
@@ -148,7 +148,7 @@ package slink_reg_pkg;
     } slink_reg__raw_mode_in_ch_sel__out_t;
 
     typedef struct {
-        logic [15:0] value;
+        logic [31:0] value;
         logic swmod;
     } slink_reg__raw_mode_out_data_fifo__raw_mode_out_data_fifo__out_t;
 
@@ -296,9 +296,9 @@ package slink_reg_pkg;
         slink_reg__ctrl__out_t ctrl;
         slink_reg__isolated__external__out_t isolated;
         slink_reg__raw_mode_en__out_t raw_mode_en;
-        slink_reg__raw_mode_in_data__external__out_t raw_mode_in_data;
+        slink_reg__raw_mode_in_data__external__out_t raw_mode_in_data[1];
         slink_reg__raw_mode_in_ch_sel__out_t raw_mode_in_ch_sel;
-        slink_reg__raw_mode_out_data_fifo__out_t raw_mode_out_data_fifo;
+        slink_reg__raw_mode_out_data_fifo__out_t raw_mode_out_data_fifo[1];
         slink_reg__raw_mode_out_data_fifo_ctrl__external__out_t raw_mode_out_data_fifo_ctrl;
         slink_reg__raw_mode_out_en__out_t raw_mode_out_en;
         slink_reg__flow_control_fifo_clear__external__out_t flow_control_fifo_clear;

--- a/src/slink.sv
+++ b/src/slink.sv
@@ -203,7 +203,6 @@ module slink
   end
 
   phy_data_t raw_mode_in_data_out;
-  logic raw_mode_pop_req, raw_mode_push_req;
   raw_mode_words_t raw_mode_in_data_words;
   raw_mode_words_t raw_mode_out_data_words;
   logic [cc_pkg::cnt_width(RawModeFifoDepth)-1:0] raw_mode_out_data_fill_state;
@@ -238,7 +237,7 @@ module slink
       reg2hw.raw_mode_in_ch_sel.raw_mode_in_ch_sel.value[cc_pkg::idx_width(NumChannels)-1:0] ),
     .cfg_raw_mode_in_data_o                  ( raw_mode_in_data_out ),
     .cfg_raw_mode_in_data_valid_o            ( raw_mode_in_data_valid                           ),
-    .cfg_raw_mode_in_data_ready_i            ( raw_mode_pop_req                                 ),
+    .cfg_raw_mode_in_data_ready_i            ( reg2hw.raw_mode_pop.raw_mode_pop.value           ),
     .cfg_raw_mode_out_ch_mask_i              ( raw_mode_out_ch_mask                             ),
     .cfg_raw_mode_out_data_i                 ( phy_data_t'(raw_mode_out_data_words) ),
     .cfg_raw_mode_out_data_valid_i           ( raw_mode_out_data_valid ),
@@ -248,9 +247,6 @@ module slink
     .cfg_raw_mode_out_data_fifo_fill_state_o ( raw_mode_out_data_fill_state ),
     .cfg_raw_mode_out_data_fifo_is_full_o    ( raw_mode_out_data_is_full )
   );
-
-  assign raw_mode_pop_req  = reg2hw.raw_mode_pop.raw_mode_pop.value;
-  assign raw_mode_push_req = reg2hw.raw_mode_push.raw_mode_push.value;
 
   always_comb begin
     raw_mode_out_data_words = '0;
@@ -285,7 +281,7 @@ module slink
   `SLINK_ASSIGN_RDL_WR_ACK(raw_mode_out_data_fifo_ctrl)
   `SLINK_ASSIGN_RDL_WR_ACK(flow_control_fifo_clear)
 
-  assign raw_mode_out_data_valid = raw_mode_push_req;
+  assign raw_mode_out_data_valid = reg2hw.raw_mode_push.raw_mode_push.value;
 
   ///////////////////////
   // CHANNEL ALLOCATOR //

--- a/src/slink.sv
+++ b/src/slink.sv
@@ -80,13 +80,24 @@ module slink
   clk_div_t [NumChannels-1:0]   tx_phy_clk_shift_start;
   clk_div_t [NumChannels-1:0]   tx_phy_clk_shift_end;
 
+  apb_req_t apb_req;
+  apb_rsp_t apb_rsp;
+
+  slink_reg_pkg::slink_reg__out_t reg2hw;
+  slink_reg_pkg::slink_reg__in_t  hw2reg;
+
   ////////////////////////////
   //   SERIALIZER (FRONT-END) //
   ////////////////////////////
 
   slink_serializer #(
     .NumCredits     ( NumCredits    ),
-    .NoRegCdc       ( NoRegCdc      ),
+    .NumChannels    ( NumChannels   ),
+    .NumLanes       ( NumLanes      ),
+    .EnDdr          ( EnDdr         ),
+    .Log2MaxClkDiv  ( Log2MaxClkDiv ),
+    .Log2RawModeTXFifoDepth ( Log2RawModeTXFifoDepth ),
+    .EnChAlloc      ( EnChAlloc     ),
     .axi_req_t      ( axi_req_t     ),
     .axi_rsp_t      ( axi_rsp_t     ),
     .aw_chan_t      ( aw_chan_t     ),
@@ -94,24 +105,19 @@ module slink
     .r_chan_t       ( r_chan_t      ),
     .w_chan_t       ( w_chan_t      ),
     .b_chan_t       ( b_chan_t      ),
-    .apb_req_t      ( apb_req_t     ),
-    .apb_rsp_t      ( apb_rsp_t     ),
-    .apb_addr_t     ( apb_addr_t    ),
-    .apb_data_t     ( apb_data_t    ),
-    .apb_strb_t     ( apb_strb_t    )
+    .hwif_in_t      ( slink_reg_pkg::slink_reg__in_t  ),
+    .hwif_out_t     ( slink_reg_pkg::slink_reg__out_t )
   ) i_slink_serializer (
     .clk_i                    ( clk_i                          ),
     .rst_ni                   ( rst_ni                         ),
     .clk_sl_i                 ( clk_sl_i                       ),
     .rst_sl_ni                ( rst_sl_ni                      ),
-    .clk_reg_i                ( clk_reg_i                      ),
-    .rst_reg_ni               ( rst_reg_ni                     ),
     .axi_in_req_i             ( axi_in_req_i                   ),
     .axi_in_rsp_o             ( axi_in_rsp_o                   ),
     .axi_out_req_o            ( axi_out_req_o                  ),
     .axi_out_rsp_i            ( axi_out_rsp_i                  ),
-    .apb_req_i                ( apb_req_i                      ),
-    .apb_rsp_o                ( apb_rsp_o                      ),
+    .hwif_out_i               ( reg2hw                         ),
+    .hwif_in_o                ( hw2reg                         ),
     .phy_data_out_o           ( serializer2phy_data_out         ),
     .phy_data_out_valid_o     ( serializer2phy_data_out_valid   ),
     .phy_data_out_ready_i     ( phy2serializer_data_out_ready   ),
@@ -156,5 +162,52 @@ module slink
       .ddr_o             ( ddr_o[i]                         )
     );
   end
+
+  /////////////////////////////////
+  //   CONFIGURATION REGISTERS   //
+  /////////////////////////////////
+
+  if (!NoRegCdc) begin : gen_reg_cdc
+    apb_cdc #(
+      .LogDepth ( 1          ),
+      .req_t    ( apb_req_t  ),
+      .resp_t   ( apb_rsp_t  ),
+      .addr_t   ( apb_addr_t ),
+      .data_t   ( apb_data_t ),
+      .strb_t   ( apb_strb_t )
+    ) i_cdc_cfg (
+      .src_pclk_i    ( clk_reg_i   ),
+      .src_preset_ni ( rst_reg_ni  ),
+      .src_req_i     ( apb_req_i   ),
+      .src_resp_o    ( apb_rsp_o   ),
+
+      .dst_pclk_i    ( clk_i       ),
+      .dst_preset_ni ( rst_ni      ),
+      .dst_req_o     ( apb_req     ),
+      .dst_resp_i    ( apb_rsp     )
+    );
+  end else begin : gen_no_reg_cdc
+    assign apb_req = apb_req_i;
+    assign apb_rsp_o = apb_rsp;
+  end
+
+  slink_reg i_serial_link_reg (
+    .clk  (clk_i),
+    .arst_n (rst_ni),
+
+    .s_apb_psel    (apb_req.psel),
+    .s_apb_penable (apb_req.penable),
+    .s_apb_pwrite  (apb_req.pwrite),
+    .s_apb_pprot   (apb_req.pprot),
+    .s_apb_paddr   (apb_req.paddr[slink_reg_pkg::SLINK_REG_MIN_ADDR_WIDTH-1:0]),
+    .s_apb_pwdata  (apb_req.pwdata),
+    .s_apb_pstrb   (apb_req.pstrb),
+    .s_apb_pready  (apb_rsp.pready),
+    .s_apb_prdata  (apb_rsp.prdata),
+    .s_apb_pslverr (apb_rsp.pslverr),
+
+    .hwif_in  (hw2reg),
+    .hwif_out (reg2hw)
+  );
 
 endmodule : slink

--- a/src/slink.sv
+++ b/src/slink.sv
@@ -7,11 +7,8 @@
 //  - Manuel Eggimann <meggimann@iis.ee.ethz.ch>
 
 `include "common_cells/registers.svh"
-`include "common_cells/assertions.svh"
-`include "axi_stream/typedef.svh"
-`include "rdl_assign.svh"
 
-/// A simple serial link to go off-chip
+/// A simple serial link to go off-chip.
 module slink
   import slink_reg_pkg::*;
 #(
@@ -68,274 +65,67 @@ module slink
   localparam int unsigned RawModeFifoDepth = 2**Log2RawModeTXFifoDepth;
   localparam int unsigned MaxClkDiv = 2**Log2MaxClkDiv;
 
-  typedef logic [$clog2(NumCredits):0] credit_t;
   typedef logic [NumBitsPerCycle-1:0] phy_data_t;
+  typedef logic [$clog2(MaxClkDiv):0] clk_div_t;
 
-  // Determine the largest sized AXI channel
-  localparam int AxiChannels[5] = {$bits(b_chan_t),
-                          $bits(aw_chan_t),
-                          $bits(w_chan_t),
-                          $bits(ar_chan_t),
-                          $bits(r_chan_t)};
-  localparam int MaxAxiChannelBits =
-  slink_pkg::find_max_channel(AxiChannels);
+  phy_data_t [NumChannels-1:0]  serializer2phy_data_out;
+  logic      [NumChannels-1:0]  serializer2phy_data_out_valid;
+  logic      [NumChannels-1:0]  phy2serializer_data_out_ready;
 
+  phy_data_t [NumChannels-1:0]  phy2serializer_data_in;
+  logic      [NumChannels-1:0]  phy2serializer_data_in_valid;
+  logic      [NumChannels-1:0]  serializer2phy_data_in_ready;
 
-  // The payload that is converted into an AXI stream consists of
-  // 1) AXI Beat
-  // 2) B Channel (which is always transmitted)
-  // 3) Header
-  // 4) Credit for flow control
-  typedef struct packed {
-    logic [MaxAxiChannelBits-1:0] axi_ch;
-    logic b_valid;
-    b_chan_t b;
-    slink_pkg::tag_e hdr;
-    credit_t credit;
-  } payload_t;
+  clk_div_t [NumChannels-1:0]   tx_phy_clk_div;
+  clk_div_t [NumChannels-1:0]   tx_phy_clk_shift_start;
+  clk_div_t [NumChannels-1:0]   tx_phy_clk_shift_end;
 
-  localparam int BandWidth = NumChannels * NumBitsPerCycle; // doubled BW if DDR enabled
-  localparam int PayloadSplits = ($bits(payload_t) + BandWidth - 1) / BandWidth;
-  localparam int RecvFifoDepth = NumCredits * PayloadSplits;
+  ////////////////////////////
+  //   SERIALIZER (FRONT-END) //
+  ////////////////////////////
 
-  // Axi stream dimension must be a multiple of 8 bits
-  localparam int StreamDataBytes = ($bits(payload_t) + 7) / 8;
-
-  // Typdefs for Axi Stream interface
-  // All except tdata_t are unused at the moment
-  typedef logic [StreamDataBytes*8-1:0] tdata_t;
-  typedef logic [StreamDataBytes-1:0] tstrb_t;
-  typedef logic [StreamDataBytes-1:0] tkeep_t;
-  typedef logic tid_t;
-  typedef logic tdest_t;
-  typedef logic tuser_t;
-  `AXI_STREAM_TYPEDEF_ALL(axis, tdata_t, tstrb_t, tkeep_t, tid_t, tdest_t, tuser_t)
-
-  apb_req_t apb_req;
-  apb_rsp_t apb_rsp;
-
-  axis_req_t  axis_out_req, axis_in_req;
-  axis_rsp_t  axis_out_rsp, axis_in_rsp;
-
-  slink_reg__out_t reg2hw;
-  slink_reg__in_t hw2reg;
-
-  phy_data_t [NumChannels-1:0]  data_link2alloc_data_out;
-  logic [NumChannels-1:0]       data_link2alloc_data_out_valid;
-  logic                         alloc2data_link_data_out_ready;
-
-  phy_data_t [NumChannels-1:0]  alloc2data_link_data_in;
-  logic [NumChannels-1:0]       alloc2data_link_data_in_valid;
-  logic [NumChannels-1:0]       data_link2alloc_data_in_ready;
-
-  phy_data_t [NumChannels-1:0]  alloc2phy_data_out;
-  logic [NumChannels-1:0]       alloc2phy_data_out_valid;
-  logic [NumChannels-1:0]       phy2alloc_data_out_ready;
-
-  phy_data_t [NumChannels-1:0]  phy2alloc_data_in;
-  logic [NumChannels-1:0]       phy2alloc_data_in_valid;
-  logic [NumChannels-1:0]       alloc2phy_data_in_ready;
-
-
-  ////////////////////////
-  //   PROTOCOL LAYER   //
-  ////////////////////////
-
-  slink_prot_layer #(
+  slink_serializer #(
     .NumCredits     ( NumCredits    ),
+    .NoRegCdc       ( NoRegCdc      ),
     .axi_req_t      ( axi_req_t     ),
     .axi_rsp_t      ( axi_rsp_t     ),
-    .axis_req_t     ( axis_req_t    ),
-    .axis_rsp_t     ( axis_rsp_t    ),
     .aw_chan_t      ( aw_chan_t     ),
-    .w_chan_t       ( w_chan_t      ),
-    .b_chan_t       ( b_chan_t      ),
     .ar_chan_t      ( ar_chan_t     ),
     .r_chan_t       ( r_chan_t      ),
-    .payload_t      ( payload_t     ),
-    .credit_t       ( credit_t      )
-  ) i_serial_link_protocol (
-    .clk_i          ( clk_sl_i        ),
-    .rst_ni         ( rst_sl_ni       ),
-    .axi_in_req_i   ( axi_in_req_i    ),
-    .axi_in_rsp_o   ( axi_in_rsp_o    ),
-    .axi_out_req_o  ( axi_out_req_o   ),
-    .axi_out_rsp_i  ( axi_out_rsp_i   ),
-    .axis_in_req_i  ( axis_in_req     ),
-    .axis_in_rsp_o  ( axis_in_rsp     ),
-    .axis_out_req_o ( axis_out_req    ),
-    .axis_out_rsp_i ( axis_out_rsp    )
+    .w_chan_t       ( w_chan_t      ),
+    .b_chan_t       ( b_chan_t      ),
+    .apb_req_t      ( apb_req_t     ),
+    .apb_rsp_t      ( apb_rsp_t     ),
+    .apb_addr_t     ( apb_addr_t    ),
+    .apb_data_t     ( apb_data_t    ),
+    .apb_strb_t     ( apb_strb_t    )
+  ) i_slink_serializer (
+    .clk_i                    ( clk_i                          ),
+    .rst_ni                   ( rst_ni                         ),
+    .clk_sl_i                 ( clk_sl_i                       ),
+    .rst_sl_ni                ( rst_sl_ni                      ),
+    .clk_reg_i                ( clk_reg_i                      ),
+    .rst_reg_ni               ( rst_reg_ni                     ),
+    .axi_in_req_i             ( axi_in_req_i                   ),
+    .axi_in_rsp_o             ( axi_in_rsp_o                   ),
+    .axi_out_req_o            ( axi_out_req_o                  ),
+    .axi_out_rsp_i            ( axi_out_rsp_i                  ),
+    .apb_req_i                ( apb_req_i                      ),
+    .apb_rsp_o                ( apb_rsp_o                      ),
+    .phy_data_out_o           ( serializer2phy_data_out         ),
+    .phy_data_out_valid_o     ( serializer2phy_data_out_valid   ),
+    .phy_data_out_ready_i     ( phy2serializer_data_out_ready   ),
+    .phy_data_in_i            ( phy2serializer_data_in          ),
+    .phy_data_in_valid_i      ( phy2serializer_data_in_valid    ),
+    .phy_data_in_ready_o      ( serializer2phy_data_in_ready    ),
+    .tx_phy_clk_div_o         ( tx_phy_clk_div                  ),
+    .tx_phy_clk_shift_start_o ( tx_phy_clk_shift_start          ),
+    .tx_phy_clk_shift_end_o   ( tx_phy_clk_shift_end            ),
+    .isolated_i               ( isolated_i                     ),
+    .isolate_o                ( isolate_o                      ),
+    .clk_ena_o                ( clk_ena_o                      ),
+    .reset_no                 ( reset_no                       )
   );
-
-  /////////////////////////
-  //   DATA LINK LAYER   //
-  /////////////////////////
-
-  logic cfg_flow_control_fifo_clear;
-  logic cfg_raw_mode_out_data_fifo_clear;
-  logic raw_mode_out_data_valid;
-  logic [NumChannels-1:0] raw_mode_in_data_valid;
-  logic [NumChannels-1:0] raw_mode_out_ch_mask;
-
-  assign cfg_flow_control_fifo_clear =
-      reg2hw.flow_control_fifo_clear.wr_data.flow_control_fifo_clear
-    & reg2hw.flow_control_fifo_clear.req
-    & reg2hw.flow_control_fifo_clear.req_is_wr
-    & reg2hw.flow_control_fifo_clear.wr_biten.flow_control_fifo_clear;
-  assign cfg_raw_mode_out_data_fifo_clear =
-      reg2hw.raw_mode_out_data_fifo_ctrl.wr_data.clear
-    & reg2hw.raw_mode_out_data_fifo_ctrl.req
-    & reg2hw.raw_mode_out_data_fifo_ctrl.req_is_wr
-    & reg2hw.raw_mode_out_data_fifo_ctrl.wr_biten.clear;
-  for (genvar i = 0; i < NumChannels; i++) begin : gen_raw_mode_in_data_valid
-    assign raw_mode_out_ch_mask[i] =
-      reg2hw.raw_mode_out_ch_mask[i].raw_mode_out_ch_mask.value;
-  end
-
-  phy_data_t raw_mode_in_data_out;
-  logic [cc_pkg::cnt_width(RawModeFifoDepth)-1:0] raw_mode_out_data_fill_state;
-  logic raw_mode_out_data_is_full;
-
-  slink_link_layer #(
-    .axis_req_t       ( axis_req_t        ),
-    .axis_rsp_t       ( axis_rsp_t        ),
-    .phy_data_t       ( phy_data_t        ),
-    .NumChannels      ( NumChannels       ),
-    .NumLanes         ( NumLanes          ),
-    .RecvFifoDepth    ( RecvFifoDepth     ),
-    .RawModeFifoDepth ( RawModeFifoDepth  ),
-    .PayloadSplits    ( PayloadSplits     ),
-    .EnDdr            ( EnDdr             )
-  ) i_serial_link_data_link (
-    .clk_i                                   ( clk_sl_i                                         ),
-    .rst_ni                                  ( rst_sl_ni                                        ),
-    .axis_in_req_i                           ( axis_out_req                                     ),
-    .axis_in_rsp_o                           ( axis_out_rsp                                     ),
-    .axis_out_req_o                          ( axis_in_req                                      ),
-    .axis_out_rsp_i                          ( axis_in_rsp                                      ),
-    .data_out_o                              ( data_link2alloc_data_out                         ),
-    .data_out_valid_o                        ( data_link2alloc_data_out_valid                   ),
-    .data_out_ready_i                        ( alloc2data_link_data_out_ready                   ),
-    .data_in_i                               ( alloc2data_link_data_in                          ),
-    .data_in_valid_i                         ( alloc2data_link_data_in_valid                    ),
-    .data_in_ready_o                         ( data_link2alloc_data_in_ready                    ),
-    .cfg_flow_control_fifo_clear_i           ( cfg_flow_control_fifo_clear                      ),
-    .cfg_raw_mode_en_i                       ( reg2hw.raw_mode_en.raw_mode_en.value ),
-    .cfg_raw_mode_in_ch_sel_i                (
-      reg2hw.raw_mode_in_ch_sel.raw_mode_in_ch_sel.value[cc_pkg::idx_width(NumChannels)-1:0] ),
-    .cfg_raw_mode_in_data_o                  ( raw_mode_in_data_out ),
-    .cfg_raw_mode_in_data_valid_o            ( raw_mode_in_data_valid                           ),
-    .cfg_raw_mode_in_data_ready_i            (
-      reg2hw.raw_mode_in_data.req & ~reg2hw.raw_mode_in_data.req_is_wr ),
-    .cfg_raw_mode_out_ch_mask_i              ( raw_mode_out_ch_mask                             ),
-    .cfg_raw_mode_out_data_i                 (
-      phy_data_t'(reg2hw.raw_mode_out_data_fifo.raw_mode_out_data_fifo.value) ),
-    .cfg_raw_mode_out_data_valid_i           ( raw_mode_out_data_valid ),
-    .cfg_raw_mode_out_en_i                   (
-      reg2hw.raw_mode_out_en.raw_mode_out_en.value ),
-    .cfg_raw_mode_out_data_fifo_clear_i      ( cfg_raw_mode_out_data_fifo_clear                 ),
-    .cfg_raw_mode_out_data_fifo_fill_state_o ( raw_mode_out_data_fill_state ),
-    .cfg_raw_mode_out_data_fifo_is_full_o    ( raw_mode_out_data_is_full )
-  );
-
-  always_comb begin
-    hw2reg.raw_mode_in_data.rd_data = '0;
-    hw2reg.raw_mode_in_data.rd_data.raw_mode_in_data = raw_mode_in_data_out;
-    hw2reg.raw_mode_out_data_fifo_ctrl.rd_data = '0;
-    hw2reg.raw_mode_out_data_fifo_ctrl.rd_data.fill_state = raw_mode_out_data_fill_state;
-    hw2reg.raw_mode_out_data_fifo_ctrl.rd_data.is_full = raw_mode_out_data_is_full;
-    for (int i = 0; i < NumChannels; i++) begin
-      hw2reg.raw_mode_in_data_valid[i].rd_data = '0;
-      hw2reg.raw_mode_in_data_valid[i].rd_data.raw_mode_in_data_valid = raw_mode_in_data_valid[i];
-      `SLINK_SET_RDL_RD_ACK(raw_mode_in_data_valid[i])
-    end
-  end
-
-  `SLINK_ASSIGN_RDL_RD_ACK(raw_mode_in_data)
-  `SLINK_ASSIGN_RDL_RD_ACK(raw_mode_out_data_fifo_ctrl)
-  `SLINK_ASSIGN_RDL_WR_ACK(raw_mode_out_data_fifo_ctrl)
-  `SLINK_ASSIGN_RDL_WR_ACK(flow_control_fifo_clear)
-
-  `FF(raw_mode_out_data_valid, reg2hw.raw_mode_out_data_fifo.raw_mode_out_data_fifo.swmod, '0)
-
-  ///////////////////////
-  // CHANNEL ALLOCATOR //
-  ///////////////////////
-
-  if (!EnChAlloc) begin : gen_no_channel_alloc
-    // Don't instantiate the channel allocator for the single channel serial
-    // link variant. We just feedthrough all the connections
-
-    assign alloc2phy_data_out = data_link2alloc_data_out;
-    assign alloc2phy_data_out_valid = data_link2alloc_data_out_valid;
-    assign alloc2data_link_data_out_ready = phy2alloc_data_out_ready;
-
-    assign alloc2data_link_data_in = phy2alloc_data_in;
-    assign alloc2data_link_data_in_valid = phy2alloc_data_in_valid;
-    assign alloc2phy_data_in_ready = data_link2alloc_data_in_ready;
-
-  end else begin : gen_channel_alloc
-
-    logic cfg_tx_clear, cfg_rx_clear;
-    logic cfg_tx_flush_trigger;
-    logic [NumChannels-1:0] cfg_tx_channel_en, cfg_rx_channel_en;
-
-    assign cfg_tx_clear = reg2hw.channel_alloc_tx_ctrl.wr_data.clear
-      & reg2hw.channel_alloc_tx_ctrl.req
-      & reg2hw.channel_alloc_tx_ctrl.req_is_wr
-      & reg2hw.channel_alloc_tx_ctrl.wr_biten.clear;
-    assign cfg_rx_clear = reg2hw.channel_alloc_rx_ctrl.wr_data.clear
-      & reg2hw.channel_alloc_rx_ctrl.req
-      & reg2hw.channel_alloc_rx_ctrl.req_is_wr
-      & reg2hw.channel_alloc_rx_ctrl.wr_biten.clear;
-    assign cfg_tx_flush_trigger = reg2hw.channel_alloc_tx_ctrl.wr_data.flush
-      & reg2hw.channel_alloc_tx_ctrl.req
-      & reg2hw.channel_alloc_tx_ctrl.req_is_wr
-      & reg2hw.channel_alloc_tx_ctrl.wr_biten.flush;
-    for (genvar i = 0; i < NumChannels; i++) begin : gen_channel_en
-      assign cfg_tx_channel_en[i] =
-        reg2hw.channel_alloc_tx_ch_en[i].channel_alloc_tx_ch_en.value;
-      assign cfg_rx_channel_en[i] =
-        reg2hw.channel_alloc_rx_ch_en[i].channel_alloc_rx_ch_en.value;
-    end
-
-    slink_ch_alloc #(
-      .phy_data_t  ( phy_data_t    ),
-      .NumChannels ( NumChannels   )
-    ) i_channel_allocator(
-      .clk_i                     ( clk_sl_i                                       ),
-      .rst_ni                    ( rst_sl_ni                                      ),
-      .cfg_tx_clear_i            ( cfg_tx_clear                                   ),
-      .cfg_tx_channel_en_i       ( cfg_tx_channel_en                              ),
-      .cfg_tx_bypass_en_i        ( reg2hw.channel_alloc_tx_cfg.bypass_en.value ),
-      .cfg_tx_auto_flush_en_i    ( reg2hw.channel_alloc_tx_cfg.auto_flush_en.value ),
-      .cfg_tx_auto_flush_count_i ( reg2hw.channel_alloc_tx_cfg.auto_flush_count.value ),
-      .cfg_tx_flush_trigger_i    ( cfg_tx_flush_trigger                           ),
-      .cfg_rx_clear_i            ( cfg_rx_clear                                   ),
-      .cfg_rx_bypass_en_i        ( reg2hw.channel_alloc_rx_cfg.bypass_en.value ),
-      .cfg_rx_channel_en_i       ( cfg_rx_channel_en                              ),
-      .cfg_rx_auto_flush_en_i    ( reg2hw.channel_alloc_rx_cfg.auto_flush_en.value ),
-      .cfg_rx_auto_flush_count_i ( reg2hw.channel_alloc_rx_cfg.auto_flush_count.value ),
-      .cfg_rx_sync_en_i          ( reg2hw.channel_alloc_rx_cfg.sync_en.value ),
-      // From Data Link Layer
-      .data_out_i                ( data_link2alloc_data_out                       ),
-      .data_out_valid_i          ( data_link2alloc_data_out_valid                 ),
-      .data_out_ready_o          ( alloc2data_link_data_out_ready                 ),
-      // To Phy
-      .data_out_o                ( alloc2phy_data_out                             ),
-      .data_out_valid_o          ( alloc2phy_data_out_valid                       ),
-      .data_out_ready_i          ( phy2alloc_data_out_ready                       ),
-      // From Phy
-      .data_in_i                 ( phy2alloc_data_in                              ),
-      .data_in_valid_i           ( phy2alloc_data_in_valid                        ),
-      .data_in_ready_o           ( alloc2phy_data_in_ready                        ),
-      // To Data Link Layer
-      .data_in_o                 ( alloc2data_link_data_in                        ),
-      .data_in_valid_o           ( alloc2data_link_data_in_valid                  ),
-      .data_in_ready_i           ( data_link2alloc_data_in_ready                  )
-    );
-  end
-
 
   ////////////////////////
   //   PHYSICAL LAYER   //
@@ -349,96 +139,22 @@ module slink
       .EnDdr            ( EnDdr             ),
       .phy_data_t       ( phy_data_t        )
     ) i_slink_phys_layer (
-      .clk_i             ( clk_sl_i                     ),
-      .rst_ni            ( rst_sl_ni                    ),
-      .clk_div_i         ( reg2hw.tx_phy_clk_div[i].clk_divs.value ),
-      .clk_shift_start_i ( reg2hw.tx_phy_clk_start[i].clk_divs.value ),
-      .clk_shift_end_i   ( reg2hw.tx_phy_clk_end[i].clk_shift_end.value ),
-      .ddr_rcv_clk_i     ( ddr_rcv_clk_i[i]             ),
-      .ddr_rcv_clk_o     ( ddr_rcv_clk_o[i]             ),
-      .data_out_i        ( alloc2phy_data_out[i]        ),
-      .data_out_valid_i  ( alloc2phy_data_out_valid[i]  ),
-      .data_out_ready_o  ( phy2alloc_data_out_ready[i]  ),
-      .data_in_o         ( phy2alloc_data_in[i]         ),
-      .data_in_valid_o   ( phy2alloc_data_in_valid[i]   ),
-      .data_in_ready_i   ( alloc2phy_data_in_ready[i]   ),
-      .ddr_i             ( ddr_i[i]                     ),
-      .ddr_o             ( ddr_o[i]                     )
+      .clk_i             ( clk_sl_i                         ),
+      .rst_ni            ( rst_sl_ni                        ),
+      .clk_div_i         ( tx_phy_clk_div[i]                ),
+      .clk_shift_start_i ( tx_phy_clk_shift_start[i]         ),
+      .clk_shift_end_i   ( tx_phy_clk_shift_end[i]           ),
+      .ddr_rcv_clk_i     ( ddr_rcv_clk_i[i]                 ),
+      .ddr_rcv_clk_o     ( ddr_rcv_clk_o[i]                 ),
+      .data_out_i        ( serializer2phy_data_out[i]        ),
+      .data_out_valid_i  ( serializer2phy_data_out_valid[i]  ),
+      .data_out_ready_o  ( phy2serializer_data_out_ready[i]  ),
+      .data_in_o         ( phy2serializer_data_in[i]         ),
+      .data_in_valid_o   ( phy2serializer_data_in_valid[i]   ),
+      .data_in_ready_i   ( serializer2phy_data_in_ready[i]   ),
+      .ddr_i             ( ddr_i[i]                         ),
+      .ddr_o             ( ddr_o[i]                         )
     );
   end
-
-  /////////////////////////////////
-  //   CONFIGURATION REGISTERS   //
-  /////////////////////////////////
-
-  if (!NoRegCdc) begin : gen_reg_cdc
-    apb_cdc #(
-      .LogDepth ( 1          ),
-      .req_t    ( apb_req_t  ),
-      .resp_t   ( apb_rsp_t  ),
-      .addr_t   ( apb_addr_t ),
-      .data_t   ( apb_data_t ),
-      .strb_t   ( apb_strb_t )
-    ) i_cdc_cfg (
-      .src_pclk_i    ( clk_reg_i   ),
-      .src_preset_ni ( rst_reg_ni  ),
-      .src_req_i     ( apb_req_i   ),
-      .src_resp_o    ( apb_rsp_o   ),
-
-      .dst_pclk_i    ( clk_i       ),
-      .dst_preset_ni ( rst_ni      ),
-      .dst_req_o     ( apb_req     ),
-      .dst_resp_i    ( apb_rsp     )
-    );
-  end else begin : gen_no_reg_cdc
-    assign apb_req = apb_req_i;
-    assign apb_rsp_o = apb_rsp;
-  end
-
-  slink_reg i_serial_link_reg (
-    .clk  (clk_i),
-    .arst_n (rst_ni),
-
-    .s_apb_psel    (apb_req.psel),
-    .s_apb_penable (apb_req.penable),
-    .s_apb_pwrite  (apb_req.pwrite),
-    .s_apb_pprot   (apb_req.pprot),
-    .s_apb_paddr   (apb_req.paddr[slink_reg_pkg::SLINK_REG_MIN_ADDR_WIDTH-1:0]),
-    .s_apb_pwdata  (apb_req.pwdata),
-    .s_apb_pstrb   (apb_req.pstrb),
-    .s_apb_pready  (apb_rsp.pready),
-    .s_apb_prdata  (apb_rsp.prdata),
-    .s_apb_pslverr (apb_rsp.pslverr),
-
-    .hwif_in  (hw2reg),
-    .hwif_out (reg2hw)
-  );
-
-  assign clk_ena_o = reg2hw.ctrl.clk_ena.value;
-  assign reset_no = reg2hw.ctrl.reset_n.value;
-  assign isolate_o = {reg2hw.ctrl.axi_out_isolate.value,
-                      reg2hw.ctrl.axi_in_isolate.value};
-
-  always_comb begin
-    hw2reg.isolated.rd_data  = '0;
-    hw2reg.isolated.rd_data.axi_in = isolated_i[0];
-    hw2reg.isolated.rd_data.axi_out = isolated_i[1];
-  end
-
-  `SLINK_ASSIGN_RDL_RD_ACK(isolated)
-
-  if (EnChAlloc) begin : gen_channel_alloc_regs
-    `SLINK_ASSIGN_RDL_WR_ACK(channel_alloc_tx_ctrl)
-    `SLINK_ASSIGN_RDL_WR_ACK(channel_alloc_rx_ctrl)
-  end else begin : gen_no_channel_alloc_regs
-    assign hw2reg.channel_alloc_tx_ctrl = '{default: '0};
-    assign hw2reg.channel_alloc_rx_ctrl = '{default: '0};
-  end
-
-  ////////////////////
-  //   ASSERTIONS   //
-  ////////////////////
-
-  `ASSERT_INIT(RawModeFifoDim, RecvFifoDepth >= RawModeFifoDepth)
 
 endmodule : slink

--- a/src/slink.sv
+++ b/src/slink.sv
@@ -7,8 +7,17 @@
 //  - Manuel Eggimann <meggimann@iis.ee.ethz.ch>
 
 `include "common_cells/registers.svh"
+`include "common_cells/assertions.svh"
+`include "axi_stream/typedef.svh"
+`include "rdl_assign.svh"
 
 /// A simple serial link to go off-chip.
+///
+/// Monolithic top-level: Protocol + Data Link + Channel Allocator + Physical layers and the
+/// config register file are all instantiated directly here. A standalone, PHY-agnostic front-end
+/// (everything except the physical layer and the register file) is also available as
+/// `slink_serializer` for other consumers that want to drive a different physical backend (e.g.
+/// UCIe) with the same protocol/data-link/channel-allocator logic.
 module slink
   import slink_reg_pkg::*;
 #(
@@ -64,74 +73,314 @@ module slink
   localparam int unsigned NumBitsPerCycle = NumLanes * (1 + EnDdr);
   localparam int unsigned RawModeFifoDepth = 2**Log2RawModeTXFifoDepth;
   localparam int unsigned MaxClkDiv = 2**Log2MaxClkDiv;
+  localparam int unsigned NumRawModeDataWords =
+      (NumBitsPerCycle > 32) ? ((NumBitsPerCycle + 31) / 32) : 1;
+  localparam int unsigned RawModeDataBits = NumRawModeDataWords * 32;
 
+  typedef logic [$clog2(NumCredits):0] credit_t;
   typedef logic [NumBitsPerCycle-1:0] phy_data_t;
-  typedef logic [$clog2(MaxClkDiv):0] clk_div_t;
+  typedef logic [RawModeDataBits-1:0] raw_mode_words_t;
 
-  phy_data_t [NumChannels-1:0]  serializer2phy_data_out;
-  logic      [NumChannels-1:0]  serializer2phy_data_out_valid;
-  logic      [NumChannels-1:0]  phy2serializer_data_out_ready;
+  // Determine the largest sized AXI channel
+  localparam int AxiChannels[5] = {$bits(b_chan_t),
+                          $bits(aw_chan_t),
+                          $bits(w_chan_t),
+                          $bits(ar_chan_t),
+                          $bits(r_chan_t)};
+  localparam int MaxAxiChannelBits =
+  slink_pkg::find_max_channel(AxiChannels);
 
-  phy_data_t [NumChannels-1:0]  phy2serializer_data_in;
-  logic      [NumChannels-1:0]  phy2serializer_data_in_valid;
-  logic      [NumChannels-1:0]  serializer2phy_data_in_ready;
 
-  clk_div_t [NumChannels-1:0]   tx_phy_clk_div;
-  clk_div_t [NumChannels-1:0]   tx_phy_clk_shift_start;
-  clk_div_t [NumChannels-1:0]   tx_phy_clk_shift_end;
+  // The payload that is converted into an AXI stream consists of
+  // 1) AXI Beat
+  // 2) B Channel (which is always transmitted)
+  // 3) Header
+  // 4) Credit for flow control
+  typedef struct packed {
+    logic [MaxAxiChannelBits-1:0] axi_ch;
+    logic b_valid;
+    b_chan_t b;
+    slink_pkg::tag_e hdr;
+    credit_t credit;
+  } payload_t;
+
+  localparam int BandWidth = NumChannels * NumBitsPerCycle; // doubled BW if DDR enabled
+  localparam int PayloadSplits = ($bits(payload_t) + BandWidth - 1) / BandWidth;
+  localparam int RecvFifoDepth = NumCredits * PayloadSplits;
+
+  // Axi stream dimension must be a multiple of 8 bits
+  localparam int StreamDataBytes = ($bits(payload_t) + 7) / 8;
+
+  // Typdefs for Axi Stream interface
+  // All except tdata_t are unused at the moment
+  typedef logic [StreamDataBytes*8-1:0] tdata_t;
+  typedef logic [StreamDataBytes-1:0] tstrb_t;
+  typedef logic [StreamDataBytes-1:0] tkeep_t;
+  typedef logic tid_t;
+  typedef logic tdest_t;
+  typedef logic tuser_t;
+  `AXI_STREAM_TYPEDEF_ALL(axis, tdata_t, tstrb_t, tkeep_t, tid_t, tdest_t, tuser_t)
 
   apb_req_t apb_req;
   apb_rsp_t apb_rsp;
 
-  slink_reg_pkg::slink_reg__out_t reg2hw;
-  slink_reg_pkg::slink_reg__in_t  hw2reg;
+  axis_req_t  axis_out_req, axis_in_req;
+  axis_rsp_t  axis_out_rsp, axis_in_rsp;
 
-  ////////////////////////////
-  //   SERIALIZER (FRONT-END) //
-  ////////////////////////////
+  slink_reg__out_t reg2hw;
+  slink_reg__in_t hw2reg;
 
-  slink_serializer #(
+  phy_data_t [NumChannels-1:0]  data_link2alloc_data_out;
+  logic [NumChannels-1:0]       data_link2alloc_data_out_valid;
+  logic                         alloc2data_link_data_out_ready;
+
+  phy_data_t [NumChannels-1:0]  alloc2data_link_data_in;
+  logic [NumChannels-1:0]       alloc2data_link_data_in_valid;
+  logic [NumChannels-1:0]       data_link2alloc_data_in_ready;
+
+  phy_data_t [NumChannels-1:0]  alloc2phy_data_out;
+  logic [NumChannels-1:0]       alloc2phy_data_out_valid;
+  logic [NumChannels-1:0]       phy2alloc_data_out_ready;
+
+  phy_data_t [NumChannels-1:0]  phy2alloc_data_in;
+  logic [NumChannels-1:0]       phy2alloc_data_in_valid;
+  logic [NumChannels-1:0]       alloc2phy_data_in_ready;
+
+
+  ////////////////////////
+  //   PROTOCOL LAYER   //
+  ////////////////////////
+
+  slink_prot_layer #(
     .NumCredits     ( NumCredits    ),
-    .NumChannels    ( NumChannels   ),
-    .NumLanes       ( NumLanes      ),
-    .EnDdr          ( EnDdr         ),
-    .Log2MaxClkDiv  ( Log2MaxClkDiv ),
-    .Log2RawModeTXFifoDepth ( Log2RawModeTXFifoDepth ),
-    .EnChAlloc      ( EnChAlloc     ),
     .axi_req_t      ( axi_req_t     ),
     .axi_rsp_t      ( axi_rsp_t     ),
+    .axis_req_t     ( axis_req_t    ),
+    .axis_rsp_t     ( axis_rsp_t    ),
     .aw_chan_t      ( aw_chan_t     ),
-    .ar_chan_t      ( ar_chan_t     ),
-    .r_chan_t       ( r_chan_t      ),
     .w_chan_t       ( w_chan_t      ),
     .b_chan_t       ( b_chan_t      ),
-    .hwif_in_t      ( slink_reg_pkg::slink_reg__in_t  ),
-    .hwif_out_t     ( slink_reg_pkg::slink_reg__out_t )
-  ) i_slink_serializer (
-    .clk_i                    ( clk_i                          ),
-    .rst_ni                   ( rst_ni                         ),
-    .clk_sl_i                 ( clk_sl_i                       ),
-    .rst_sl_ni                ( rst_sl_ni                      ),
-    .axi_in_req_i             ( axi_in_req_i                   ),
-    .axi_in_rsp_o             ( axi_in_rsp_o                   ),
-    .axi_out_req_o            ( axi_out_req_o                  ),
-    .axi_out_rsp_i            ( axi_out_rsp_i                  ),
-    .hwif_out_i               ( reg2hw                         ),
-    .hwif_in_o                ( hw2reg                         ),
-    .phy_data_out_o           ( serializer2phy_data_out         ),
-    .phy_data_out_valid_o     ( serializer2phy_data_out_valid   ),
-    .phy_data_out_ready_i     ( phy2serializer_data_out_ready   ),
-    .phy_data_in_i            ( phy2serializer_data_in          ),
-    .phy_data_in_valid_i      ( phy2serializer_data_in_valid    ),
-    .phy_data_in_ready_o      ( serializer2phy_data_in_ready    ),
-    .tx_phy_clk_div_o         ( tx_phy_clk_div                  ),
-    .tx_phy_clk_shift_start_o ( tx_phy_clk_shift_start          ),
-    .tx_phy_clk_shift_end_o   ( tx_phy_clk_shift_end            ),
-    .isolated_i               ( isolated_i                     ),
-    .isolate_o                ( isolate_o                      ),
-    .clk_ena_o                ( clk_ena_o                      ),
-    .reset_no                 ( reset_no                       )
+    .ar_chan_t      ( ar_chan_t     ),
+    .r_chan_t       ( r_chan_t      ),
+    .payload_t      ( payload_t     ),
+    .credit_t       ( credit_t      )
+  ) i_serial_link_protocol (
+    .clk_i          ( clk_sl_i        ),
+    .rst_ni         ( rst_sl_ni       ),
+    .axi_in_req_i   ( axi_in_req_i    ),
+    .axi_in_rsp_o   ( axi_in_rsp_o    ),
+    .axi_out_req_o  ( axi_out_req_o   ),
+    .axi_out_rsp_i  ( axi_out_rsp_i   ),
+    .axis_in_req_i  ( axis_in_req     ),
+    .axis_in_rsp_o  ( axis_in_rsp     ),
+    .axis_out_req_o ( axis_out_req    ),
+    .axis_out_rsp_i ( axis_out_rsp    )
   );
+
+  /////////////////////////
+  //   DATA LINK LAYER   //
+  /////////////////////////
+
+  logic cfg_flow_control_fifo_clear;
+  logic cfg_raw_mode_out_data_fifo_clear;
+  logic raw_mode_out_data_valid;
+  logic [NumChannels-1:0] raw_mode_in_data_valid;
+  logic [NumChannels-1:0] raw_mode_out_ch_mask;
+
+  assign cfg_flow_control_fifo_clear =
+      reg2hw.flow_control_fifo_clear.wr_data.flow_control_fifo_clear
+    & reg2hw.flow_control_fifo_clear.req
+    & reg2hw.flow_control_fifo_clear.req_is_wr
+    & reg2hw.flow_control_fifo_clear.wr_biten.flow_control_fifo_clear;
+  assign cfg_raw_mode_out_data_fifo_clear =
+      reg2hw.raw_mode_out_data_fifo_ctrl.wr_data.clear
+    & reg2hw.raw_mode_out_data_fifo_ctrl.req
+    & reg2hw.raw_mode_out_data_fifo_ctrl.req_is_wr
+    & reg2hw.raw_mode_out_data_fifo_ctrl.wr_biten.clear;
+  for (genvar i = 0; i < NumChannels; i++) begin : gen_raw_mode_in_data_valid
+    assign raw_mode_out_ch_mask[i] =
+      reg2hw.raw_mode_out_ch_mask[i].raw_mode_out_ch_mask.value;
+  end
+
+  phy_data_t raw_mode_in_data_out;
+  phy_data_t raw_mode_in_data_shadow_q;
+  logic raw_mode_in_data_rd_pending;
+  logic raw_mode_in_data_capture;
+  raw_mode_words_t raw_mode_in_data_read_words;
+  raw_mode_words_t raw_mode_out_data_words;
+  logic [cc_pkg::cnt_width(RawModeFifoDepth)-1:0] raw_mode_out_data_fill_state;
+  logic raw_mode_out_data_is_full;
+
+  slink_link_layer #(
+    .axis_req_t       ( axis_req_t        ),
+    .axis_rsp_t       ( axis_rsp_t        ),
+    .phy_data_t       ( phy_data_t        ),
+    .NumChannels      ( NumChannels       ),
+    .NumLanes         ( NumLanes          ),
+    .RecvFifoDepth    ( RecvFifoDepth     ),
+    .RawModeFifoDepth ( RawModeFifoDepth  ),
+    .PayloadSplits    ( PayloadSplits     ),
+    .EnDdr            ( EnDdr             )
+  ) i_serial_link_data_link (
+    .clk_i                                   ( clk_sl_i                                         ),
+    .rst_ni                                  ( rst_sl_ni                                        ),
+    .axis_in_req_i                           ( axis_out_req                                     ),
+    .axis_in_rsp_o                           ( axis_out_rsp                                     ),
+    .axis_out_req_o                          ( axis_in_req                                      ),
+    .axis_out_rsp_i                          ( axis_in_rsp                                      ),
+    .data_out_o                              ( data_link2alloc_data_out                         ),
+    .data_out_valid_o                        ( data_link2alloc_data_out_valid                   ),
+    .data_out_ready_i                        ( alloc2data_link_data_out_ready                   ),
+    .data_in_i                               ( alloc2data_link_data_in                          ),
+    .data_in_valid_i                         ( alloc2data_link_data_in_valid                    ),
+    .data_in_ready_o                         ( data_link2alloc_data_in_ready                    ),
+    .cfg_flow_control_fifo_clear_i           ( cfg_flow_control_fifo_clear                      ),
+    .cfg_raw_mode_en_i                       ( reg2hw.raw_mode_en.raw_mode_en.value ),
+    .cfg_raw_mode_in_ch_sel_i                (
+      reg2hw.raw_mode_in_ch_sel.raw_mode_in_ch_sel.value[cc_pkg::idx_width(NumChannels)-1:0] ),
+    .cfg_raw_mode_in_data_o                  ( raw_mode_in_data_out ),
+    .cfg_raw_mode_in_data_valid_o            ( raw_mode_in_data_valid                           ),
+    .cfg_raw_mode_in_data_ready_i            ( raw_mode_in_data_rd_pending                      ),
+    .cfg_raw_mode_out_ch_mask_i              ( raw_mode_out_ch_mask                             ),
+    .cfg_raw_mode_out_data_i                 ( phy_data_t'(raw_mode_out_data_words) ),
+    .cfg_raw_mode_out_data_valid_i           ( raw_mode_out_data_valid ),
+    .cfg_raw_mode_out_en_i                   (
+      reg2hw.raw_mode_out_en.raw_mode_out_en.value ),
+    .cfg_raw_mode_out_data_fifo_clear_i      ( cfg_raw_mode_out_data_fifo_clear                 ),
+    .cfg_raw_mode_out_data_fifo_fill_state_o ( raw_mode_out_data_fill_state ),
+    .cfg_raw_mode_out_data_fifo_is_full_o    ( raw_mode_out_data_is_full )
+  );
+
+  assign raw_mode_in_data_capture =
+      reg2hw.raw_mode_in_data[0].req & ~reg2hw.raw_mode_in_data[0].req_is_wr;
+  assign raw_mode_in_data_rd_pending = raw_mode_in_data_capture;
+
+  always_ff @(posedge clk_sl_i or negedge rst_sl_ni) begin
+    if (!rst_sl_ni) begin
+      raw_mode_in_data_shadow_q <= '0;
+    end else if (raw_mode_in_data_capture) begin
+      raw_mode_in_data_shadow_q <= raw_mode_in_data_out;
+    end
+  end
+
+  // Capture the raw-mode output data into a word array for easier access
+  always_comb begin
+    raw_mode_out_data_words = '0;
+    for (int i = 0; i < NumRawModeDataWords; i++) begin
+      raw_mode_out_data_words[i*32 +: 32] =
+          reg2hw.raw_mode_out_data_fifo[i].raw_mode_out_data_fifo.value;
+    end
+  end
+
+  always_comb begin
+    raw_mode_in_data_read_words = raw_mode_words_t'(raw_mode_in_data_shadow_q);
+    if (raw_mode_in_data_capture) begin
+      raw_mode_in_data_read_words = raw_mode_words_t'(raw_mode_in_data_out);
+    end
+
+    for (int i = 0; i < NumRawModeDataWords; i++) begin
+      hw2reg.raw_mode_in_data[i].rd_data = '0;
+      hw2reg.raw_mode_in_data[i].rd_data.raw_mode_in_data =
+          raw_mode_in_data_read_words[i*32 +: 32];
+      `SLINK_SET_RDL_RD_ACK(raw_mode_in_data[i])
+    end
+  end
+
+  always_comb begin
+    hw2reg.raw_mode_out_data_fifo_ctrl.rd_data = '0;
+    hw2reg.raw_mode_out_data_fifo_ctrl.rd_data.fill_state = raw_mode_out_data_fill_state;
+    hw2reg.raw_mode_out_data_fifo_ctrl.rd_data.is_full = raw_mode_out_data_is_full;
+    for (int i = 0; i < NumChannels; i++) begin
+      hw2reg.raw_mode_in_data_valid[i].rd_data = '0;
+      hw2reg.raw_mode_in_data_valid[i].rd_data.raw_mode_in_data_valid = raw_mode_in_data_valid[i];
+      `SLINK_SET_RDL_RD_ACK(raw_mode_in_data_valid[i])
+    end
+  end
+
+  `SLINK_ASSIGN_RDL_RD_ACK(raw_mode_out_data_fifo_ctrl)
+  `SLINK_ASSIGN_RDL_WR_ACK(raw_mode_out_data_fifo_ctrl)
+  `SLINK_ASSIGN_RDL_WR_ACK(flow_control_fifo_clear)
+
+  `FF(raw_mode_out_data_valid,
+      reg2hw.raw_mode_out_data_fifo[NumRawModeDataWords-1].raw_mode_out_data_fifo.swmod, '0)
+
+  ///////////////////////
+  // CHANNEL ALLOCATOR //
+  ///////////////////////
+
+  if (!EnChAlloc) begin : gen_no_channel_alloc
+    // Don't instantiate the channel allocator for the single channel serial
+    // link variant. We just feedthrough all the connections
+
+    assign alloc2phy_data_out = data_link2alloc_data_out;
+    assign alloc2phy_data_out_valid = data_link2alloc_data_out_valid;
+    assign alloc2data_link_data_out_ready = phy2alloc_data_out_ready;
+
+    assign alloc2data_link_data_in = phy2alloc_data_in;
+    assign alloc2data_link_data_in_valid = phy2alloc_data_in_valid;
+    assign alloc2phy_data_in_ready = data_link2alloc_data_in_ready;
+
+  end else begin : gen_channel_alloc
+
+    logic cfg_tx_clear, cfg_rx_clear;
+    logic cfg_tx_flush_trigger;
+    logic [NumChannels-1:0] cfg_tx_channel_en, cfg_rx_channel_en;
+
+    assign cfg_tx_clear = reg2hw.channel_alloc_tx_ctrl.wr_data.clear
+      & reg2hw.channel_alloc_tx_ctrl.req
+      & reg2hw.channel_alloc_tx_ctrl.req_is_wr
+      & reg2hw.channel_alloc_tx_ctrl.wr_biten.clear;
+    assign cfg_rx_clear = reg2hw.channel_alloc_rx_ctrl.wr_data.clear
+      & reg2hw.channel_alloc_rx_ctrl.req
+      & reg2hw.channel_alloc_rx_ctrl.req_is_wr
+      & reg2hw.channel_alloc_rx_ctrl.wr_biten.clear;
+    assign cfg_tx_flush_trigger = reg2hw.channel_alloc_tx_ctrl.wr_data.flush
+      & reg2hw.channel_alloc_tx_ctrl.req
+      & reg2hw.channel_alloc_tx_ctrl.req_is_wr
+      & reg2hw.channel_alloc_tx_ctrl.wr_biten.flush;
+    for (genvar i = 0; i < NumChannels; i++) begin : gen_channel_en
+      assign cfg_tx_channel_en[i] =
+        reg2hw.channel_alloc_tx_ch_en[i].channel_alloc_tx_ch_en.value;
+      assign cfg_rx_channel_en[i] =
+        reg2hw.channel_alloc_rx_ch_en[i].channel_alloc_rx_ch_en.value;
+    end
+
+    slink_ch_alloc #(
+      .phy_data_t  ( phy_data_t    ),
+      .NumChannels ( NumChannels   )
+    ) i_channel_allocator(
+      .clk_i                     ( clk_sl_i                                       ),
+      .rst_ni                    ( rst_sl_ni                                      ),
+      .cfg_tx_clear_i            ( cfg_tx_clear                                   ),
+      .cfg_tx_channel_en_i       ( cfg_tx_channel_en                              ),
+      .cfg_tx_bypass_en_i        ( reg2hw.channel_alloc_tx_cfg.bypass_en.value ),
+      .cfg_tx_auto_flush_en_i    ( reg2hw.channel_alloc_tx_cfg.auto_flush_en.value ),
+      .cfg_tx_auto_flush_count_i ( reg2hw.channel_alloc_tx_cfg.auto_flush_count.value ),
+      .cfg_tx_flush_trigger_i    ( cfg_tx_flush_trigger                           ),
+      .cfg_rx_clear_i            ( cfg_rx_clear                                   ),
+      .cfg_rx_bypass_en_i        ( reg2hw.channel_alloc_rx_cfg.bypass_en.value ),
+      .cfg_rx_channel_en_i       ( cfg_rx_channel_en                              ),
+      .cfg_rx_auto_flush_en_i    ( reg2hw.channel_alloc_rx_cfg.auto_flush_en.value ),
+      .cfg_rx_auto_flush_count_i ( reg2hw.channel_alloc_rx_cfg.auto_flush_count.value ),
+      .cfg_rx_sync_en_i          ( reg2hw.channel_alloc_rx_cfg.sync_en.value ),
+      // From Data Link Layer
+      .data_out_i                ( data_link2alloc_data_out                       ),
+      .data_out_valid_i          ( data_link2alloc_data_out_valid                 ),
+      .data_out_ready_o          ( alloc2data_link_data_out_ready                 ),
+      // To Phy
+      .data_out_o                ( alloc2phy_data_out                             ),
+      .data_out_valid_o          ( alloc2phy_data_out_valid                       ),
+      .data_out_ready_i          ( phy2alloc_data_out_ready                       ),
+      // From Phy
+      .data_in_i                 ( phy2alloc_data_in                              ),
+      .data_in_valid_i           ( phy2alloc_data_in_valid                        ),
+      .data_in_ready_o           ( alloc2phy_data_in_ready                        ),
+      // To Data Link Layer
+      .data_in_o                 ( alloc2data_link_data_in                        ),
+      .data_in_valid_o           ( alloc2data_link_data_in_valid                  ),
+      .data_in_ready_i           ( data_link2alloc_data_in_ready                  )
+    );
+  end
 
   ////////////////////////
   //   PHYSICAL LAYER   //
@@ -145,21 +394,21 @@ module slink
       .EnDdr            ( EnDdr             ),
       .phy_data_t       ( phy_data_t        )
     ) i_slink_phys_layer (
-      .clk_i             ( clk_sl_i                         ),
-      .rst_ni            ( rst_sl_ni                        ),
-      .clk_div_i         ( tx_phy_clk_div[i]                ),
-      .clk_shift_start_i ( tx_phy_clk_shift_start[i]         ),
-      .clk_shift_end_i   ( tx_phy_clk_shift_end[i]           ),
-      .ddr_rcv_clk_i     ( ddr_rcv_clk_i[i]                 ),
-      .ddr_rcv_clk_o     ( ddr_rcv_clk_o[i]                 ),
-      .data_out_i        ( serializer2phy_data_out[i]        ),
-      .data_out_valid_i  ( serializer2phy_data_out_valid[i]  ),
-      .data_out_ready_o  ( phy2serializer_data_out_ready[i]  ),
-      .data_in_o         ( phy2serializer_data_in[i]         ),
-      .data_in_valid_o   ( phy2serializer_data_in_valid[i]   ),
-      .data_in_ready_i   ( serializer2phy_data_in_ready[i]   ),
-      .ddr_i             ( ddr_i[i]                         ),
-      .ddr_o             ( ddr_o[i]                         )
+      .clk_i             ( clk_sl_i                                     ),
+      .rst_ni            ( rst_sl_ni                                    ),
+      .clk_div_i         ( reg2hw.tx_phy_clk_div[i].clk_divs.value       ),
+      .clk_shift_start_i ( reg2hw.tx_phy_clk_start[i].clk_divs.value     ),
+      .clk_shift_end_i   ( reg2hw.tx_phy_clk_end[i].clk_shift_end.value  ),
+      .ddr_rcv_clk_i     ( ddr_rcv_clk_i[i]             ),
+      .ddr_rcv_clk_o     ( ddr_rcv_clk_o[i]             ),
+      .data_out_i        ( alloc2phy_data_out[i]        ),
+      .data_out_valid_i  ( alloc2phy_data_out_valid[i]  ),
+      .data_out_ready_o  ( phy2alloc_data_out_ready[i]  ),
+      .data_in_o         ( phy2alloc_data_in[i]         ),
+      .data_in_valid_o   ( phy2alloc_data_in_valid[i]   ),
+      .data_in_ready_i   ( alloc2phy_data_in_ready[i]   ),
+      .ddr_i             ( ddr_i[i]                     ),
+      .ddr_o             ( ddr_o[i]                     )
     );
   end
 
@@ -209,5 +458,32 @@ module slink
     .hwif_in  (hw2reg),
     .hwif_out (reg2hw)
   );
+
+  assign clk_ena_o = reg2hw.ctrl.clk_ena.value;
+  assign reset_no = reg2hw.ctrl.reset_n.value;
+  assign isolate_o = {reg2hw.ctrl.axi_out_isolate.value,
+                      reg2hw.ctrl.axi_in_isolate.value};
+
+  always_comb begin
+    hw2reg.isolated.rd_data  = '0;
+    hw2reg.isolated.rd_data.axi_in = isolated_i[0];
+    hw2reg.isolated.rd_data.axi_out = isolated_i[1];
+  end
+
+  `SLINK_ASSIGN_RDL_RD_ACK(isolated)
+
+  if (EnChAlloc) begin : gen_channel_alloc_regs
+    `SLINK_ASSIGN_RDL_WR_ACK(channel_alloc_tx_ctrl)
+    `SLINK_ASSIGN_RDL_WR_ACK(channel_alloc_rx_ctrl)
+  end else begin : gen_no_channel_alloc_regs
+    assign hw2reg.channel_alloc_tx_ctrl = '{default: '0};
+    assign hw2reg.channel_alloc_rx_ctrl = '{default: '0};
+  end
+
+  ////////////////////
+  //   ASSERTIONS   //
+  ////////////////////
+
+  `ASSERT_INIT(RawModeFifoDim, RecvFifoDepth >= RawModeFifoDepth)
 
 endmodule : slink

--- a/src/slink.sv
+++ b/src/slink.sv
@@ -203,10 +203,8 @@ module slink
   end
 
   phy_data_t raw_mode_in_data_out;
-  phy_data_t raw_mode_in_data_shadow_q;
-  logic raw_mode_in_data_rd_pending;
-  logic raw_mode_in_data_capture;
-  raw_mode_words_t raw_mode_in_data_read_words;
+  logic raw_mode_pop_req, raw_mode_push_req;
+  raw_mode_words_t raw_mode_in_data_words;
   raw_mode_words_t raw_mode_out_data_words;
   logic [cc_pkg::cnt_width(RawModeFifoDepth)-1:0] raw_mode_out_data_fill_state;
   logic raw_mode_out_data_is_full;
@@ -240,7 +238,7 @@ module slink
       reg2hw.raw_mode_in_ch_sel.raw_mode_in_ch_sel.value[cc_pkg::idx_width(NumChannels)-1:0] ),
     .cfg_raw_mode_in_data_o                  ( raw_mode_in_data_out ),
     .cfg_raw_mode_in_data_valid_o            ( raw_mode_in_data_valid                           ),
-    .cfg_raw_mode_in_data_ready_i            ( raw_mode_in_data_rd_pending                      ),
+    .cfg_raw_mode_in_data_ready_i            ( raw_mode_pop_req                                 ),
     .cfg_raw_mode_out_ch_mask_i              ( raw_mode_out_ch_mask                             ),
     .cfg_raw_mode_out_data_i                 ( phy_data_t'(raw_mode_out_data_words) ),
     .cfg_raw_mode_out_data_valid_i           ( raw_mode_out_data_valid ),
@@ -251,19 +249,9 @@ module slink
     .cfg_raw_mode_out_data_fifo_is_full_o    ( raw_mode_out_data_is_full )
   );
 
-  assign raw_mode_in_data_capture =
-      reg2hw.raw_mode_in_data[0].req & ~reg2hw.raw_mode_in_data[0].req_is_wr;
-  assign raw_mode_in_data_rd_pending = raw_mode_in_data_capture;
+  assign raw_mode_pop_req  = reg2hw.raw_mode_pop.raw_mode_pop.value;
+  assign raw_mode_push_req = reg2hw.raw_mode_push.raw_mode_push.value;
 
-  always_ff @(posedge clk_sl_i or negedge rst_sl_ni) begin
-    if (!rst_sl_ni) begin
-      raw_mode_in_data_shadow_q <= '0;
-    end else if (raw_mode_in_data_capture) begin
-      raw_mode_in_data_shadow_q <= raw_mode_in_data_out;
-    end
-  end
-
-  // Capture the raw-mode output data into a word array for easier access
   always_comb begin
     raw_mode_out_data_words = '0;
     for (int i = 0; i < NumRawModeDataWords; i++) begin
@@ -273,15 +261,11 @@ module slink
   end
 
   always_comb begin
-    raw_mode_in_data_read_words = raw_mode_words_t'(raw_mode_in_data_shadow_q);
-    if (raw_mode_in_data_capture) begin
-      raw_mode_in_data_read_words = raw_mode_words_t'(raw_mode_in_data_out);
-    end
-
+    raw_mode_in_data_words = raw_mode_words_t'(raw_mode_in_data_out);
     for (int i = 0; i < NumRawModeDataWords; i++) begin
       hw2reg.raw_mode_in_data[i].rd_data = '0;
       hw2reg.raw_mode_in_data[i].rd_data.raw_mode_in_data =
-          raw_mode_in_data_read_words[i*32 +: 32];
+          raw_mode_in_data_words[i*32 +: 32];
       `SLINK_SET_RDL_RD_ACK(raw_mode_in_data[i])
     end
   end
@@ -301,8 +285,7 @@ module slink
   `SLINK_ASSIGN_RDL_WR_ACK(raw_mode_out_data_fifo_ctrl)
   `SLINK_ASSIGN_RDL_WR_ACK(flow_control_fifo_clear)
 
-  `FF(raw_mode_out_data_valid,
-      reg2hw.raw_mode_out_data_fifo[NumRawModeDataWords-1].raw_mode_out_data_fifo.swmod, '0)
+  assign raw_mode_out_data_valid = raw_mode_push_req;
 
   ///////////////////////
   // CHANNEL ALLOCATOR //

--- a/src/slink_link_layer.sv
+++ b/src/slink_link_layer.sv
@@ -42,6 +42,9 @@ module slink_link_layer #(
   input  logic [Log2NumChannels-1:0]      cfg_raw_mode_in_ch_sel_i,
   output phy_data_t                       cfg_raw_mode_in_data_o,
   output logic [NumChannels-1:0]          cfg_raw_mode_in_data_valid_o,
+  // Explicit, decoupled pop request (SW-driven, one cycle pulse): cfg_raw_mode_in_data_o always
+  // shows the selected channel's current head-of-FIFO entry (a non-destructive peek, safe to read
+  // repeatedly); this only advances the FIFO to the next entry, it does not gate visibility.
   input  logic                            cfg_raw_mode_in_data_ready_i,
   input  logic [NumChannels-1:0]          cfg_raw_mode_out_ch_mask_i,
   input  phy_data_t                       cfg_raw_mode_out_data_i,
@@ -126,16 +129,17 @@ module slink_link_layer #(
     if (cfg_raw_mode_en_i) begin
       // Raw mode
       cfg_raw_mode_in_data_valid_o = data_in_valid_i;
-      // Ready is asserted if there is a read access
+      // Continuously peek the selected channel's head-of-FIFO entry, independent of any pop
+      // request - repeated reads of the same entry are safe and return the same value.
+      if (data_in_valid_i[cfg_raw_mode_in_ch_sel_i]) begin
+        cfg_raw_mode_in_data_o = data_in_i[cfg_raw_mode_in_ch_sel_i];
+      end
+      // Only an explicit pop request actually advances the FIFO.
       if (cfg_raw_mode_in_data_ready_i) begin
-        // Select channel to read from and wait for valid data
         if (data_in_valid_i[cfg_raw_mode_in_ch_sel_i]) begin
-          // Pop item from CDC RX FIFO
           data_in_ready_o[cfg_raw_mode_in_ch_sel_i] = 1'b1;
-          // respond with data from selected channel
-          cfg_raw_mode_in_data_o = data_in_i[cfg_raw_mode_in_ch_sel_i];
         end else begin
-          // TODO: send out Error response
+          // TODO: send out Error response (pop requested with nothing to pop)
         end
       end
     end else begin

--- a/src/slink_serializer.sv
+++ b/src/slink_serializer.sv
@@ -196,7 +196,7 @@ module slink_serializer #(
   logic raw_mode_in_data_capture;
   raw_mode_words_t raw_mode_in_data_read_words;
   raw_mode_words_t raw_mode_out_data_words;
-  logic [$clog2(RawModeFifoDepth)-1:0] raw_mode_out_data_fill_state;
+  logic [cc_pkg::cnt_width(RawModeFifoDepth)-1:0] raw_mode_out_data_fill_state;
   logic raw_mode_out_data_is_full;
 
   slink_link_layer #(

--- a/src/slink_serializer.sv
+++ b/src/slink_serializer.sv
@@ -191,10 +191,8 @@ module slink_serializer #(
   end
 
   phy_data_t raw_mode_in_data_out;
-  phy_data_t raw_mode_in_data_shadow_q;
-  logic raw_mode_in_data_rd_pending;
-  logic raw_mode_in_data_capture;
-  raw_mode_words_t raw_mode_in_data_read_words;
+  raw_mode_words_t raw_mode_in_data_words;
+  logic raw_mode_pop_req, raw_mode_push_req;
   raw_mode_words_t raw_mode_out_data_words;
   logic [cc_pkg::cnt_width(RawModeFifoDepth)-1:0] raw_mode_out_data_fill_state;
   logic raw_mode_out_data_is_full;
@@ -228,7 +226,7 @@ module slink_serializer #(
       hwif_out_i.raw_mode_in_ch_sel.raw_mode_in_ch_sel.value[cc_pkg::idx_width(NumChannels)-1:0] ),
     .cfg_raw_mode_in_data_o                  ( raw_mode_in_data_out ),
     .cfg_raw_mode_in_data_valid_o            ( raw_mode_in_data_valid                           ),
-    .cfg_raw_mode_in_data_ready_i            ( raw_mode_in_data_rd_pending                      ),
+    .cfg_raw_mode_in_data_ready_i            ( raw_mode_pop_req                                 ),
     .cfg_raw_mode_out_ch_mask_i              ( raw_mode_out_ch_mask                             ),
     .cfg_raw_mode_out_data_i                 ( phy_data_t'(raw_mode_out_data_words) ),
     .cfg_raw_mode_out_data_valid_i           ( raw_mode_out_data_valid ),
@@ -239,19 +237,9 @@ module slink_serializer #(
     .cfg_raw_mode_out_data_fifo_is_full_o    ( raw_mode_out_data_is_full )
   );
 
-  assign raw_mode_in_data_capture =
-      hwif_out_i.raw_mode_in_data[0].req & ~hwif_out_i.raw_mode_in_data[0].req_is_wr;
-  assign raw_mode_in_data_rd_pending = raw_mode_in_data_capture;
+  assign raw_mode_pop_req  = hwif_out_i.raw_mode_pop.raw_mode_pop.value;
+  assign raw_mode_push_req = hwif_out_i.raw_mode_push.raw_mode_push.value;
 
-  always_ff @(posedge clk_sl_i or negedge rst_sl_ni) begin
-    if (!rst_sl_ni) begin
-      raw_mode_in_data_shadow_q <= '0;
-    end else if (raw_mode_in_data_capture) begin
-      raw_mode_in_data_shadow_q <= raw_mode_in_data_out;
-    end
-  end
-
-  // Capture the raw-mode output data into a word array for easier access
   always_comb begin
     raw_mode_out_data_words = '0;
     for (int i = 0; i < NumRawModeDataWords; i++) begin
@@ -261,15 +249,11 @@ module slink_serializer #(
   end
 
   always_comb begin
-    raw_mode_in_data_read_words = raw_mode_words_t'(raw_mode_in_data_shadow_q);
-    if (raw_mode_in_data_capture) begin
-      raw_mode_in_data_read_words = raw_mode_words_t'(raw_mode_in_data_out);
-    end
-
+    raw_mode_in_data_words = raw_mode_words_t'(raw_mode_in_data_out);
     for (int i = 0; i < NumRawModeDataWords; i++) begin
       hwif_in_o.raw_mode_in_data[i].rd_data = '0;
       hwif_in_o.raw_mode_in_data[i].rd_data.raw_mode_in_data =
-          raw_mode_in_data_read_words[i*32 +: 32];
+          raw_mode_in_data_words[i*32 +: 32];
       `SLINK_SET_RDL_RD_ACK(raw_mode_in_data[i], hwif_in_o, hwif_out_i)
     end
   end
@@ -290,8 +274,7 @@ module slink_serializer #(
   `SLINK_ASSIGN_RDL_WR_ACK(raw_mode_out_data_fifo_ctrl, hwif_in_o, hwif_out_i)
   `SLINK_ASSIGN_RDL_WR_ACK(flow_control_fifo_clear, hwif_in_o, hwif_out_i)
 
-  `FF(raw_mode_out_data_valid,
-      hwif_out_i.raw_mode_out_data_fifo[NumRawModeDataWords-1].raw_mode_out_data_fifo.swmod, '0)
+  assign raw_mode_out_data_valid = raw_mode_push_req;
 
   ///////////////////////
   // CHANNEL ALLOCATOR //

--- a/src/slink_serializer.sv
+++ b/src/slink_serializer.sv
@@ -14,13 +14,15 @@
 /// Protocol + Data Link + Channel Allocator + config-register front-end of the serial link.
 /// Converts AXI4 to a per-channel packet stream (`phy_data_t`) meant to be driven into any
 /// physical backend (e.g. `slink_phys_layer`, or a different transport such as UCIe RDI).
-module slink_serializer
-  import slink_reg_pkg::*;
-#(
+module slink_serializer #(
   // Number of credits for flow control
-  parameter int NumCredits        = 8,
-  // Whether to use a register CDC for the configuration registers
-  parameter bit NoRegCdc          = 1'b0,
+  parameter int NumCredits                     = 8,
+  parameter int unsigned NumChannels           = 1,
+  parameter int unsigned NumLanes              = 8,
+  parameter bit          EnDdr                 = 1'b1,
+  parameter int unsigned Log2MaxClkDiv         = 10,
+  parameter int unsigned Log2RawModeTXFifoDepth = 3,
+  parameter bit          EnChAlloc             = (NumChannels > 1),
   parameter type axi_req_t  = logic,
   parameter type axi_rsp_t  = logic,
   parameter type aw_chan_t  = logic,
@@ -28,35 +30,29 @@ module slink_serializer
   parameter type r_chan_t   = logic,
   parameter type w_chan_t   = logic,
   parameter type b_chan_t   = logic,
-  parameter type apb_req_t  = logic,
-  parameter type apb_rsp_t  = logic,
-  parameter type apb_addr_t = logic[31:0],
-  parameter type apb_data_t = logic[31:0],
-  parameter type apb_strb_t = logic[3:0],
+  parameter type hwif_in_t  = logic,
+  parameter type hwif_out_t = logic,
   // Local shorthand so port declarations below don't need to repeat the expression.
   // (`phy_data_t` itself is a typedef, not usable in the port list, so the raw-bit
   // port width is derived here and re-wrapped into `phy_data_t` inside the body.)
   localparam int unsigned NumBitsPerCycle = NumLanes * (1 + EnDdr),
   localparam int unsigned MaxClkDiv = 2**Log2MaxClkDiv
 ) (
-  // There are 3 different clock/resets:
-  // 1) clk_i & rst_ni: "always-on" clock & reset coming from the SoC domain. Only config registers are conected to this clock
+  // There are 2 different clock/resets relevant to this module:
+  // 1) clk_i & rst_ni: "always-on" clock & reset coming from the SoC domain.
   // 2) clk_sl_i & rst_sl_ni: Same as 1) but clock is gated and reset is SW synchronized. This is the clock that drives the serial link
   //    i.e. protocol, data-link and channel allocator all run on this clock and can be clock gated if needed. If no clock gating, reset synchronization
   //    is desired, you can tie clk_sl_i -> clk_i resp. rst_sl_ni -> rst_ni
-  // 3) clk_reg_i & rst_reg_ni: peripheral clock and reset. Only connected to RegBus CDC. If NoRegCdc is set, this clock must be the same as 1)
   input  logic                      clk_i,
   input  logic                      rst_ni,
   input  logic                      clk_sl_i,
   input  logic                      rst_sl_ni,
-  input  logic                      clk_reg_i,
-  input  logic                      rst_reg_ni,
   input  axi_req_t                  axi_in_req_i,
   output axi_rsp_t                  axi_in_rsp_o,
   output axi_req_t                  axi_out_req_o,
   input  axi_rsp_t                  axi_out_rsp_i,
-  input  apb_req_t                  apb_req_i,
-  output apb_rsp_t                  apb_rsp_o,
+  input  hwif_out_t                 hwif_out_i,  // was the internal reg2hw
+  output hwif_in_t                  hwif_in_o,   // was the internal hw2reg
   // Per-channel packet stream towards/from the physical backend (`phy_data_t` width)
   output logic [NumChannels-1:0][NumBitsPerCycle-1:0] phy_data_out_o,
   output logic [NumChannels-1:0]                      phy_data_out_valid_o,
@@ -123,14 +119,8 @@ module slink_serializer
   typedef logic tuser_t;
   `AXI_STREAM_TYPEDEF_ALL(axis, tdata_t, tstrb_t, tkeep_t, tid_t, tdest_t, tuser_t)
 
-  apb_req_t apb_req;
-  apb_rsp_t apb_rsp;
-
   axis_req_t  axis_out_req, axis_in_req;
   axis_rsp_t  axis_out_rsp, axis_in_rsp;
-
-  slink_reg__out_t reg2hw;
-  slink_reg__in_t hw2reg;
 
   phy_data_t [NumChannels-1:0]  data_link2alloc_data_out;
   logic [NumChannels-1:0]       data_link2alloc_data_out_valid;
@@ -182,18 +172,18 @@ module slink_serializer
   logic [NumChannels-1:0] raw_mode_out_ch_mask;
 
   assign cfg_flow_control_fifo_clear =
-      reg2hw.flow_control_fifo_clear.wr_data.flow_control_fifo_clear
-    & reg2hw.flow_control_fifo_clear.req
-    & reg2hw.flow_control_fifo_clear.req_is_wr
-    & reg2hw.flow_control_fifo_clear.wr_biten.flow_control_fifo_clear;
+      hwif_out_i.flow_control_fifo_clear.wr_data.flow_control_fifo_clear
+    & hwif_out_i.flow_control_fifo_clear.req
+    & hwif_out_i.flow_control_fifo_clear.req_is_wr
+    & hwif_out_i.flow_control_fifo_clear.wr_biten.flow_control_fifo_clear;
   assign cfg_raw_mode_out_data_fifo_clear =
-      reg2hw.raw_mode_out_data_fifo_ctrl.wr_data.clear
-    & reg2hw.raw_mode_out_data_fifo_ctrl.req
-    & reg2hw.raw_mode_out_data_fifo_ctrl.req_is_wr
-    & reg2hw.raw_mode_out_data_fifo_ctrl.wr_biten.clear;
+      hwif_out_i.raw_mode_out_data_fifo_ctrl.wr_data.clear
+    & hwif_out_i.raw_mode_out_data_fifo_ctrl.req
+    & hwif_out_i.raw_mode_out_data_fifo_ctrl.req_is_wr
+    & hwif_out_i.raw_mode_out_data_fifo_ctrl.wr_biten.clear;
   for (genvar i = 0; i < NumChannels; i++) begin : gen_raw_mode_in_data_valid
     assign raw_mode_out_ch_mask[i] =
-      reg2hw.raw_mode_out_ch_mask[i].raw_mode_out_ch_mask.value;
+      hwif_out_i.raw_mode_out_ch_mask[i].raw_mode_out_ch_mask.value;
   end
 
   phy_data_t raw_mode_in_data_out;
@@ -224,43 +214,44 @@ module slink_serializer
     .data_in_valid_i                         ( alloc2data_link_data_in_valid                    ),
     .data_in_ready_o                         ( data_link2alloc_data_in_ready                    ),
     .cfg_flow_control_fifo_clear_i           ( cfg_flow_control_fifo_clear                      ),
-    .cfg_raw_mode_en_i                       ( reg2hw.raw_mode_en.raw_mode_en.value ),
+    .cfg_raw_mode_en_i                       ( hwif_out_i.raw_mode_en.raw_mode_en.value ),
     .cfg_raw_mode_in_ch_sel_i                (
-      reg2hw.raw_mode_in_ch_sel.raw_mode_in_ch_sel.value[cc_pkg::idx_width(NumChannels)-1:0] ),
+      hwif_out_i.raw_mode_in_ch_sel.raw_mode_in_ch_sel.value[cc_pkg::idx_width(NumChannels)-1:0] ),
     .cfg_raw_mode_in_data_o                  ( raw_mode_in_data_out ),
     .cfg_raw_mode_in_data_valid_o            ( raw_mode_in_data_valid                           ),
     .cfg_raw_mode_in_data_ready_i            (
-      reg2hw.raw_mode_in_data.req & ~reg2hw.raw_mode_in_data.req_is_wr ),
+      hwif_out_i.raw_mode_in_data.req & ~hwif_out_i.raw_mode_in_data.req_is_wr ),
     .cfg_raw_mode_out_ch_mask_i              ( raw_mode_out_ch_mask                             ),
     .cfg_raw_mode_out_data_i                 (
-      phy_data_t'(reg2hw.raw_mode_out_data_fifo.raw_mode_out_data_fifo.value) ),
+      phy_data_t'(hwif_out_i.raw_mode_out_data_fifo.raw_mode_out_data_fifo.value) ),
     .cfg_raw_mode_out_data_valid_i           ( raw_mode_out_data_valid ),
     .cfg_raw_mode_out_en_i                   (
-      reg2hw.raw_mode_out_en.raw_mode_out_en.value ),
+      hwif_out_i.raw_mode_out_en.raw_mode_out_en.value ),
     .cfg_raw_mode_out_data_fifo_clear_i      ( cfg_raw_mode_out_data_fifo_clear                 ),
     .cfg_raw_mode_out_data_fifo_fill_state_o ( raw_mode_out_data_fill_state ),
     .cfg_raw_mode_out_data_fifo_is_full_o    ( raw_mode_out_data_is_full )
   );
 
   always_comb begin
-    hw2reg.raw_mode_in_data.rd_data = '0;
-    hw2reg.raw_mode_in_data.rd_data.raw_mode_in_data = raw_mode_in_data_out;
-    hw2reg.raw_mode_out_data_fifo_ctrl.rd_data = '0;
-    hw2reg.raw_mode_out_data_fifo_ctrl.rd_data.fill_state = raw_mode_out_data_fill_state;
-    hw2reg.raw_mode_out_data_fifo_ctrl.rd_data.is_full = raw_mode_out_data_is_full;
+    hwif_in_o.raw_mode_in_data.rd_data = '0;
+    hwif_in_o.raw_mode_in_data.rd_data.raw_mode_in_data = raw_mode_in_data_out;
+    hwif_in_o.raw_mode_out_data_fifo_ctrl.rd_data = '0;
+    hwif_in_o.raw_mode_out_data_fifo_ctrl.rd_data.fill_state = raw_mode_out_data_fill_state;
+    hwif_in_o.raw_mode_out_data_fifo_ctrl.rd_data.is_full = raw_mode_out_data_is_full;
     for (int i = 0; i < NumChannels; i++) begin
-      hw2reg.raw_mode_in_data_valid[i].rd_data = '0;
-      hw2reg.raw_mode_in_data_valid[i].rd_data.raw_mode_in_data_valid = raw_mode_in_data_valid[i];
-      `SLINK_SET_RDL_RD_ACK(raw_mode_in_data_valid[i])
+      hwif_in_o.raw_mode_in_data_valid[i].rd_data = '0;
+      hwif_in_o.raw_mode_in_data_valid[i].rd_data.raw_mode_in_data_valid =
+          raw_mode_in_data_valid[i];
+      `SLINK_SET_RDL_RD_ACK(raw_mode_in_data_valid[i], hwif_in_o, hwif_out_i)
     end
   end
 
-  `SLINK_ASSIGN_RDL_RD_ACK(raw_mode_in_data)
-  `SLINK_ASSIGN_RDL_RD_ACK(raw_mode_out_data_fifo_ctrl)
-  `SLINK_ASSIGN_RDL_WR_ACK(raw_mode_out_data_fifo_ctrl)
-  `SLINK_ASSIGN_RDL_WR_ACK(flow_control_fifo_clear)
+  `SLINK_ASSIGN_RDL_RD_ACK(raw_mode_in_data, hwif_in_o, hwif_out_i)
+  `SLINK_ASSIGN_RDL_RD_ACK(raw_mode_out_data_fifo_ctrl, hwif_in_o, hwif_out_i)
+  `SLINK_ASSIGN_RDL_WR_ACK(raw_mode_out_data_fifo_ctrl, hwif_in_o, hwif_out_i)
+  `SLINK_ASSIGN_RDL_WR_ACK(flow_control_fifo_clear, hwif_in_o, hwif_out_i)
 
-  `FF(raw_mode_out_data_valid, reg2hw.raw_mode_out_data_fifo.raw_mode_out_data_fifo.swmod, '0)
+  `FF(raw_mode_out_data_valid, hwif_out_i.raw_mode_out_data_fifo.raw_mode_out_data_fifo.swmod, '0)
 
   ///////////////////////
   // CHANNEL ALLOCATOR //
@@ -284,23 +275,23 @@ module slink_serializer
     logic cfg_tx_flush_trigger;
     logic [NumChannels-1:0] cfg_tx_channel_en, cfg_rx_channel_en;
 
-    assign cfg_tx_clear = reg2hw.channel_alloc_tx_ctrl.wr_data.clear
-      & reg2hw.channel_alloc_tx_ctrl.req
-      & reg2hw.channel_alloc_tx_ctrl.req_is_wr
-      & reg2hw.channel_alloc_tx_ctrl.wr_biten.clear;
-    assign cfg_rx_clear = reg2hw.channel_alloc_rx_ctrl.wr_data.clear
-      & reg2hw.channel_alloc_rx_ctrl.req
-      & reg2hw.channel_alloc_rx_ctrl.req_is_wr
-      & reg2hw.channel_alloc_rx_ctrl.wr_biten.clear;
-    assign cfg_tx_flush_trigger = reg2hw.channel_alloc_tx_ctrl.wr_data.flush
-      & reg2hw.channel_alloc_tx_ctrl.req
-      & reg2hw.channel_alloc_tx_ctrl.req_is_wr
-      & reg2hw.channel_alloc_tx_ctrl.wr_biten.flush;
+    assign cfg_tx_clear = hwif_out_i.channel_alloc_tx_ctrl.wr_data.clear
+      & hwif_out_i.channel_alloc_tx_ctrl.req
+      & hwif_out_i.channel_alloc_tx_ctrl.req_is_wr
+      & hwif_out_i.channel_alloc_tx_ctrl.wr_biten.clear;
+    assign cfg_rx_clear = hwif_out_i.channel_alloc_rx_ctrl.wr_data.clear
+      & hwif_out_i.channel_alloc_rx_ctrl.req
+      & hwif_out_i.channel_alloc_rx_ctrl.req_is_wr
+      & hwif_out_i.channel_alloc_rx_ctrl.wr_biten.clear;
+    assign cfg_tx_flush_trigger = hwif_out_i.channel_alloc_tx_ctrl.wr_data.flush
+      & hwif_out_i.channel_alloc_tx_ctrl.req
+      & hwif_out_i.channel_alloc_tx_ctrl.req_is_wr
+      & hwif_out_i.channel_alloc_tx_ctrl.wr_biten.flush;
     for (genvar i = 0; i < NumChannels; i++) begin : gen_channel_en
       assign cfg_tx_channel_en[i] =
-        reg2hw.channel_alloc_tx_ch_en[i].channel_alloc_tx_ch_en.value;
+        hwif_out_i.channel_alloc_tx_ch_en[i].channel_alloc_tx_ch_en.value;
       assign cfg_rx_channel_en[i] =
-        reg2hw.channel_alloc_rx_ch_en[i].channel_alloc_rx_ch_en.value;
+        hwif_out_i.channel_alloc_rx_ch_en[i].channel_alloc_rx_ch_en.value;
     end
 
     slink_ch_alloc #(
@@ -311,16 +302,16 @@ module slink_serializer
       .rst_ni                    ( rst_sl_ni                                      ),
       .cfg_tx_clear_i            ( cfg_tx_clear                                   ),
       .cfg_tx_channel_en_i       ( cfg_tx_channel_en                              ),
-      .cfg_tx_bypass_en_i        ( reg2hw.channel_alloc_tx_cfg.bypass_en.value ),
-      .cfg_tx_auto_flush_en_i    ( reg2hw.channel_alloc_tx_cfg.auto_flush_en.value ),
-      .cfg_tx_auto_flush_count_i ( reg2hw.channel_alloc_tx_cfg.auto_flush_count.value ),
+      .cfg_tx_bypass_en_i        ( hwif_out_i.channel_alloc_tx_cfg.bypass_en.value ),
+      .cfg_tx_auto_flush_en_i    ( hwif_out_i.channel_alloc_tx_cfg.auto_flush_en.value ),
+      .cfg_tx_auto_flush_count_i ( hwif_out_i.channel_alloc_tx_cfg.auto_flush_count.value ),
       .cfg_tx_flush_trigger_i    ( cfg_tx_flush_trigger                           ),
       .cfg_rx_clear_i            ( cfg_rx_clear                                   ),
-      .cfg_rx_bypass_en_i        ( reg2hw.channel_alloc_rx_cfg.bypass_en.value ),
+      .cfg_rx_bypass_en_i        ( hwif_out_i.channel_alloc_rx_cfg.bypass_en.value ),
       .cfg_rx_channel_en_i       ( cfg_rx_channel_en                              ),
-      .cfg_rx_auto_flush_en_i    ( reg2hw.channel_alloc_rx_cfg.auto_flush_en.value ),
-      .cfg_rx_auto_flush_count_i ( reg2hw.channel_alloc_rx_cfg.auto_flush_count.value ),
-      .cfg_rx_sync_en_i          ( reg2hw.channel_alloc_rx_cfg.sync_en.value ),
+      .cfg_rx_auto_flush_en_i    ( hwif_out_i.channel_alloc_rx_cfg.auto_flush_en.value ),
+      .cfg_rx_auto_flush_count_i ( hwif_out_i.channel_alloc_rx_cfg.auto_flush_count.value ),
+      .cfg_rx_sync_en_i          ( hwif_out_i.channel_alloc_rx_cfg.sync_en.value ),
       // From Data Link Layer
       .data_out_i                ( data_link2alloc_data_out                       ),
       .data_out_valid_i          ( data_link2alloc_data_out_valid                 ),
@@ -346,77 +337,30 @@ module slink_serializer
   ///////////////////////////////////////////
 
   for (genvar i = 0; i < NumChannels; i++) begin : gen_tx_phy_clk_cfg
-    assign tx_phy_clk_div_o[i]         = reg2hw.tx_phy_clk_div[i].clk_divs.value;
-    assign tx_phy_clk_shift_start_o[i] = reg2hw.tx_phy_clk_start[i].clk_divs.value;
-    assign tx_phy_clk_shift_end_o[i]   = reg2hw.tx_phy_clk_end[i].clk_shift_end.value;
+    assign tx_phy_clk_div_o[i]         = hwif_out_i.tx_phy_clk_div[i].clk_divs.value;
+    assign tx_phy_clk_shift_start_o[i] = hwif_out_i.tx_phy_clk_start[i].clk_divs.value;
+    assign tx_phy_clk_shift_end_o[i]   = hwif_out_i.tx_phy_clk_end[i].clk_shift_end.value;
   end
 
-  /////////////////////////////////
-  //   CONFIGURATION REGISTERS   //
-  /////////////////////////////////
-
-  if (!NoRegCdc) begin : gen_reg_cdc
-    apb_cdc #(
-      .LogDepth ( 1          ),
-      .req_t    ( apb_req_t  ),
-      .resp_t   ( apb_rsp_t  ),
-      .addr_t   ( apb_addr_t ),
-      .data_t   ( apb_data_t ),
-      .strb_t   ( apb_strb_t )
-    ) i_cdc_cfg (
-      .src_pclk_i    ( clk_reg_i   ),
-      .src_preset_ni ( rst_reg_ni  ),
-      .src_req_i     ( apb_req_i   ),
-      .src_resp_o    ( apb_rsp_o   ),
-
-      .dst_pclk_i    ( clk_i       ),
-      .dst_preset_ni ( rst_ni      ),
-      .dst_req_o     ( apb_req     ),
-      .dst_resp_i    ( apb_rsp     )
-    );
-  end else begin : gen_no_reg_cdc
-    assign apb_req = apb_req_i;
-    assign apb_rsp_o = apb_rsp;
-  end
-
-  slink_reg i_serial_link_reg (
-    .clk  (clk_i),
-    .arst_n (rst_ni),
-
-    .s_apb_psel    (apb_req.psel),
-    .s_apb_penable (apb_req.penable),
-    .s_apb_pwrite  (apb_req.pwrite),
-    .s_apb_pprot   (apb_req.pprot),
-    .s_apb_paddr   (apb_req.paddr[slink_reg_pkg::SLINK_REG_MIN_ADDR_WIDTH-1:0]),
-    .s_apb_pwdata  (apb_req.pwdata),
-    .s_apb_pstrb   (apb_req.pstrb),
-    .s_apb_pready  (apb_rsp.pready),
-    .s_apb_prdata  (apb_rsp.prdata),
-    .s_apb_pslverr (apb_rsp.pslverr),
-
-    .hwif_in  (hw2reg),
-    .hwif_out (reg2hw)
-  );
-
-  assign clk_ena_o = reg2hw.ctrl.clk_ena.value;
-  assign reset_no = reg2hw.ctrl.reset_n.value;
-  assign isolate_o = {reg2hw.ctrl.axi_out_isolate.value,
-                      reg2hw.ctrl.axi_in_isolate.value};
+  assign clk_ena_o = hwif_out_i.ctrl.clk_ena.value;
+  assign reset_no = hwif_out_i.ctrl.reset_n.value;
+  assign isolate_o = {hwif_out_i.ctrl.axi_out_isolate.value,
+                      hwif_out_i.ctrl.axi_in_isolate.value};
 
   always_comb begin
-    hw2reg.isolated.rd_data  = '0;
-    hw2reg.isolated.rd_data.axi_in = isolated_i[0];
-    hw2reg.isolated.rd_data.axi_out = isolated_i[1];
+    hwif_in_o.isolated.rd_data  = '0;
+    hwif_in_o.isolated.rd_data.axi_in = isolated_i[0];
+    hwif_in_o.isolated.rd_data.axi_out = isolated_i[1];
   end
 
-  `SLINK_ASSIGN_RDL_RD_ACK(isolated)
+  `SLINK_ASSIGN_RDL_RD_ACK(isolated, hwif_in_o, hwif_out_i)
 
   if (EnChAlloc) begin : gen_channel_alloc_regs
-    `SLINK_ASSIGN_RDL_WR_ACK(channel_alloc_tx_ctrl)
-    `SLINK_ASSIGN_RDL_WR_ACK(channel_alloc_rx_ctrl)
+    `SLINK_ASSIGN_RDL_WR_ACK(channel_alloc_tx_ctrl, hwif_in_o, hwif_out_i)
+    `SLINK_ASSIGN_RDL_WR_ACK(channel_alloc_rx_ctrl, hwif_in_o, hwif_out_i)
   end else begin : gen_no_channel_alloc_regs
-    assign hw2reg.channel_alloc_tx_ctrl = '{default: '0};
-    assign hw2reg.channel_alloc_rx_ctrl = '{default: '0};
+    assign hwif_in_o.channel_alloc_tx_ctrl = '{default: '0};
+    assign hwif_in_o.channel_alloc_rx_ctrl = '{default: '0};
   end
 
   ////////////////////

--- a/src/slink_serializer.sv
+++ b/src/slink_serializer.sv
@@ -1,0 +1,428 @@
+// Copyright 2022 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+// Authors:
+//  - Tim Fischer <fischeti@iis.ee.ethz.ch>
+//  - Manuel Eggimann <meggimann@iis.ee.ethz.ch>
+
+`include "common_cells/registers.svh"
+`include "common_cells/assertions.svh"
+`include "axi_stream/typedef.svh"
+`include "rdl_assign.svh"
+
+/// Protocol + Data Link + Channel Allocator + config-register front-end of the serial link.
+/// Converts AXI4 to a per-channel packet stream (`phy_data_t`) meant to be driven into any
+/// physical backend (e.g. `slink_phys_layer`, or a different transport such as UCIe RDI).
+module slink_serializer
+  import slink_reg_pkg::*;
+#(
+  // Number of credits for flow control
+  parameter int NumCredits        = 8,
+  // Whether to use a register CDC for the configuration registers
+  parameter bit NoRegCdc          = 1'b0,
+  parameter type axi_req_t  = logic,
+  parameter type axi_rsp_t  = logic,
+  parameter type aw_chan_t  = logic,
+  parameter type ar_chan_t  = logic,
+  parameter type r_chan_t   = logic,
+  parameter type w_chan_t   = logic,
+  parameter type b_chan_t   = logic,
+  parameter type apb_req_t  = logic,
+  parameter type apb_rsp_t  = logic,
+  parameter type apb_addr_t = logic[31:0],
+  parameter type apb_data_t = logic[31:0],
+  parameter type apb_strb_t = logic[3:0],
+  // Local shorthand so port declarations below don't need to repeat the expression.
+  // (`phy_data_t` itself is a typedef, not usable in the port list, so the raw-bit
+  // port width is derived here and re-wrapped into `phy_data_t` inside the body.)
+  localparam int unsigned NumBitsPerCycle = NumLanes * (1 + EnDdr),
+  localparam int unsigned MaxClkDiv = 2**Log2MaxClkDiv
+) (
+  // There are 3 different clock/resets:
+  // 1) clk_i & rst_ni: "always-on" clock & reset coming from the SoC domain. Only config registers are conected to this clock
+  // 2) clk_sl_i & rst_sl_ni: Same as 1) but clock is gated and reset is SW synchronized. This is the clock that drives the serial link
+  //    i.e. protocol, data-link and channel allocator all run on this clock and can be clock gated if needed. If no clock gating, reset synchronization
+  //    is desired, you can tie clk_sl_i -> clk_i resp. rst_sl_ni -> rst_ni
+  // 3) clk_reg_i & rst_reg_ni: peripheral clock and reset. Only connected to RegBus CDC. If NoRegCdc is set, this clock must be the same as 1)
+  input  logic                      clk_i,
+  input  logic                      rst_ni,
+  input  logic                      clk_sl_i,
+  input  logic                      rst_sl_ni,
+  input  logic                      clk_reg_i,
+  input  logic                      rst_reg_ni,
+  input  axi_req_t                  axi_in_req_i,
+  output axi_rsp_t                  axi_in_rsp_o,
+  output axi_req_t                  axi_out_req_o,
+  input  axi_rsp_t                  axi_out_rsp_i,
+  input  apb_req_t                  apb_req_i,
+  output apb_rsp_t                  apb_rsp_o,
+  // Per-channel packet stream towards/from the physical backend (`phy_data_t` width)
+  output logic [NumChannels-1:0][NumBitsPerCycle-1:0] phy_data_out_o,
+  output logic [NumChannels-1:0]                      phy_data_out_valid_o,
+  input  logic [NumChannels-1:0]                      phy_data_out_ready_i,
+  input  logic [NumChannels-1:0][NumBitsPerCycle-1:0] phy_data_in_i,
+  input  logic [NumChannels-1:0]                      phy_data_in_valid_i,
+  output logic [NumChannels-1:0]                      phy_data_in_ready_o,
+  // Per-channel TX clock-divider/phase-shift configuration for a DDR/SDR PHY backend.
+  // Unused (and safe to leave unconnected) for backends that don't forward a source-synchronous clock.
+  output logic [NumChannels-1:0][$clog2(MaxClkDiv):0] tx_phy_clk_div_o,
+  output logic [NumChannels-1:0][$clog2(MaxClkDiv):0] tx_phy_clk_shift_start_o,
+  output logic [NumChannels-1:0][$clog2(MaxClkDiv):0] tx_phy_clk_shift_end_o,
+  // AXI isolation signals (in/out), if not used tie to 0
+  input  logic [1:0]                isolated_i,
+  output logic [1:0]                isolate_o,
+  // Clock gate register
+  output logic                      clk_ena_o,
+  // synch-reset register
+  output logic                      reset_no
+);
+
+  localparam int unsigned RawModeFifoDepth = 2**Log2RawModeTXFifoDepth;
+
+  typedef logic [$clog2(NumCredits):0] credit_t;
+  typedef logic [NumBitsPerCycle-1:0] phy_data_t;
+
+  // Determine the largest sized AXI channel
+  localparam int AxiChannels[5] = {$bits(b_chan_t),
+                          $bits(aw_chan_t),
+                          $bits(w_chan_t),
+                          $bits(ar_chan_t),
+                          $bits(r_chan_t)};
+  localparam int MaxAxiChannelBits =
+  slink_pkg::find_max_channel(AxiChannels);
+
+
+  // The payload that is converted into an AXI stream consists of
+  // 1) AXI Beat
+  // 2) B Channel (which is always transmitted)
+  // 3) Header
+  // 4) Credit for flow control
+  typedef struct packed {
+    logic [MaxAxiChannelBits-1:0] axi_ch;
+    logic b_valid;
+    b_chan_t b;
+    slink_pkg::tag_e hdr;
+    credit_t credit;
+  } payload_t;
+
+  localparam int BandWidth = NumChannels * NumBitsPerCycle; // doubled BW if DDR enabled
+  localparam int PayloadSplits = ($bits(payload_t) + BandWidth - 1) / BandWidth;
+  localparam int RecvFifoDepth = NumCredits * PayloadSplits;
+
+  // Axi stream dimension must be a multiple of 8 bits
+  localparam int StreamDataBytes = ($bits(payload_t) + 7) / 8;
+
+  // Typdefs for Axi Stream interface
+  // All except tdata_t are unused at the moment
+  typedef logic [StreamDataBytes*8-1:0] tdata_t;
+  typedef logic [StreamDataBytes-1:0] tstrb_t;
+  typedef logic [StreamDataBytes-1:0] tkeep_t;
+  typedef logic tid_t;
+  typedef logic tdest_t;
+  typedef logic tuser_t;
+  `AXI_STREAM_TYPEDEF_ALL(axis, tdata_t, tstrb_t, tkeep_t, tid_t, tdest_t, tuser_t)
+
+  apb_req_t apb_req;
+  apb_rsp_t apb_rsp;
+
+  axis_req_t  axis_out_req, axis_in_req;
+  axis_rsp_t  axis_out_rsp, axis_in_rsp;
+
+  slink_reg__out_t reg2hw;
+  slink_reg__in_t hw2reg;
+
+  phy_data_t [NumChannels-1:0]  data_link2alloc_data_out;
+  logic [NumChannels-1:0]       data_link2alloc_data_out_valid;
+  logic                         alloc2data_link_data_out_ready;
+
+  phy_data_t [NumChannels-1:0]  alloc2data_link_data_in;
+  logic [NumChannels-1:0]       alloc2data_link_data_in_valid;
+  logic [NumChannels-1:0]       data_link2alloc_data_in_ready;
+
+
+  ////////////////////////
+  //   PROTOCOL LAYER   //
+  ////////////////////////
+
+  slink_prot_layer #(
+    .NumCredits     ( NumCredits    ),
+    .axi_req_t      ( axi_req_t     ),
+    .axi_rsp_t      ( axi_rsp_t     ),
+    .axis_req_t     ( axis_req_t    ),
+    .axis_rsp_t     ( axis_rsp_t    ),
+    .aw_chan_t      ( aw_chan_t     ),
+    .w_chan_t       ( w_chan_t      ),
+    .b_chan_t       ( b_chan_t      ),
+    .ar_chan_t      ( ar_chan_t     ),
+    .r_chan_t       ( r_chan_t      ),
+    .payload_t      ( payload_t     ),
+    .credit_t       ( credit_t      )
+  ) i_serial_link_protocol (
+    .clk_i          ( clk_sl_i        ),
+    .rst_ni         ( rst_sl_ni       ),
+    .axi_in_req_i   ( axi_in_req_i    ),
+    .axi_in_rsp_o   ( axi_in_rsp_o    ),
+    .axi_out_req_o  ( axi_out_req_o   ),
+    .axi_out_rsp_i  ( axi_out_rsp_i   ),
+    .axis_in_req_i  ( axis_in_req     ),
+    .axis_in_rsp_o  ( axis_in_rsp     ),
+    .axis_out_req_o ( axis_out_req    ),
+    .axis_out_rsp_i ( axis_out_rsp    )
+  );
+
+  /////////////////////////
+  //   DATA LINK LAYER   //
+  /////////////////////////
+
+  logic cfg_flow_control_fifo_clear;
+  logic cfg_raw_mode_out_data_fifo_clear;
+  logic raw_mode_out_data_valid;
+  logic [NumChannels-1:0] raw_mode_in_data_valid;
+  logic [NumChannels-1:0] raw_mode_out_ch_mask;
+
+  assign cfg_flow_control_fifo_clear =
+      reg2hw.flow_control_fifo_clear.wr_data.flow_control_fifo_clear
+    & reg2hw.flow_control_fifo_clear.req
+    & reg2hw.flow_control_fifo_clear.req_is_wr
+    & reg2hw.flow_control_fifo_clear.wr_biten.flow_control_fifo_clear;
+  assign cfg_raw_mode_out_data_fifo_clear =
+      reg2hw.raw_mode_out_data_fifo_ctrl.wr_data.clear
+    & reg2hw.raw_mode_out_data_fifo_ctrl.req
+    & reg2hw.raw_mode_out_data_fifo_ctrl.req_is_wr
+    & reg2hw.raw_mode_out_data_fifo_ctrl.wr_biten.clear;
+  for (genvar i = 0; i < NumChannels; i++) begin : gen_raw_mode_in_data_valid
+    assign raw_mode_out_ch_mask[i] =
+      reg2hw.raw_mode_out_ch_mask[i].raw_mode_out_ch_mask.value;
+  end
+
+  phy_data_t raw_mode_in_data_out;
+  logic [$clog2(RawModeFifoDepth)-1:0] raw_mode_out_data_fill_state;
+  logic raw_mode_out_data_is_full;
+
+  slink_link_layer #(
+    .axis_req_t       ( axis_req_t        ),
+    .axis_rsp_t       ( axis_rsp_t        ),
+    .phy_data_t       ( phy_data_t        ),
+    .NumChannels      ( NumChannels       ),
+    .NumLanes         ( NumLanes          ),
+    .RecvFifoDepth    ( RecvFifoDepth     ),
+    .RawModeFifoDepth ( RawModeFifoDepth  ),
+    .PayloadSplits    ( PayloadSplits     ),
+    .EnDdr            ( EnDdr             )
+  ) i_serial_link_data_link (
+    .clk_i                                   ( clk_sl_i                                         ),
+    .rst_ni                                  ( rst_sl_ni                                        ),
+    .axis_in_req_i                           ( axis_out_req                                     ),
+    .axis_in_rsp_o                           ( axis_out_rsp                                     ),
+    .axis_out_req_o                          ( axis_in_req                                      ),
+    .axis_out_rsp_i                          ( axis_in_rsp                                      ),
+    .data_out_o                              ( data_link2alloc_data_out                         ),
+    .data_out_valid_o                        ( data_link2alloc_data_out_valid                   ),
+    .data_out_ready_i                        ( alloc2data_link_data_out_ready                   ),
+    .data_in_i                               ( alloc2data_link_data_in                          ),
+    .data_in_valid_i                         ( alloc2data_link_data_in_valid                    ),
+    .data_in_ready_o                         ( data_link2alloc_data_in_ready                    ),
+    .cfg_flow_control_fifo_clear_i           ( cfg_flow_control_fifo_clear                      ),
+    .cfg_raw_mode_en_i                       ( reg2hw.raw_mode_en.raw_mode_en.value ),
+    .cfg_raw_mode_in_ch_sel_i                (
+      reg2hw.raw_mode_in_ch_sel.raw_mode_in_ch_sel.value[cc_pkg::idx_width(NumChannels)-1:0] ),
+    .cfg_raw_mode_in_data_o                  ( raw_mode_in_data_out ),
+    .cfg_raw_mode_in_data_valid_o            ( raw_mode_in_data_valid                           ),
+    .cfg_raw_mode_in_data_ready_i            (
+      reg2hw.raw_mode_in_data.req & ~reg2hw.raw_mode_in_data.req_is_wr ),
+    .cfg_raw_mode_out_ch_mask_i              ( raw_mode_out_ch_mask                             ),
+    .cfg_raw_mode_out_data_i                 (
+      phy_data_t'(reg2hw.raw_mode_out_data_fifo.raw_mode_out_data_fifo.value) ),
+    .cfg_raw_mode_out_data_valid_i           ( raw_mode_out_data_valid ),
+    .cfg_raw_mode_out_en_i                   (
+      reg2hw.raw_mode_out_en.raw_mode_out_en.value ),
+    .cfg_raw_mode_out_data_fifo_clear_i      ( cfg_raw_mode_out_data_fifo_clear                 ),
+    .cfg_raw_mode_out_data_fifo_fill_state_o ( raw_mode_out_data_fill_state ),
+    .cfg_raw_mode_out_data_fifo_is_full_o    ( raw_mode_out_data_is_full )
+  );
+
+  always_comb begin
+    hw2reg.raw_mode_in_data.rd_data = '0;
+    hw2reg.raw_mode_in_data.rd_data.raw_mode_in_data = raw_mode_in_data_out;
+    hw2reg.raw_mode_out_data_fifo_ctrl.rd_data = '0;
+    hw2reg.raw_mode_out_data_fifo_ctrl.rd_data.fill_state = raw_mode_out_data_fill_state;
+    hw2reg.raw_mode_out_data_fifo_ctrl.rd_data.is_full = raw_mode_out_data_is_full;
+    for (int i = 0; i < NumChannels; i++) begin
+      hw2reg.raw_mode_in_data_valid[i].rd_data = '0;
+      hw2reg.raw_mode_in_data_valid[i].rd_data.raw_mode_in_data_valid = raw_mode_in_data_valid[i];
+      `SLINK_SET_RDL_RD_ACK(raw_mode_in_data_valid[i])
+    end
+  end
+
+  `SLINK_ASSIGN_RDL_RD_ACK(raw_mode_in_data)
+  `SLINK_ASSIGN_RDL_RD_ACK(raw_mode_out_data_fifo_ctrl)
+  `SLINK_ASSIGN_RDL_WR_ACK(raw_mode_out_data_fifo_ctrl)
+  `SLINK_ASSIGN_RDL_WR_ACK(flow_control_fifo_clear)
+
+  `FF(raw_mode_out_data_valid, reg2hw.raw_mode_out_data_fifo.raw_mode_out_data_fifo.swmod, '0)
+
+  ///////////////////////
+  // CHANNEL ALLOCATOR //
+  ///////////////////////
+
+  if (!EnChAlloc) begin : gen_no_channel_alloc
+    // Don't instantiate the channel allocator for the single channel serial
+    // link variant. We just feedthrough all the connections
+
+    assign phy_data_out_o = data_link2alloc_data_out;
+    assign phy_data_out_valid_o = data_link2alloc_data_out_valid;
+    assign alloc2data_link_data_out_ready = phy_data_out_ready_i;
+
+    assign alloc2data_link_data_in = phy_data_in_i;
+    assign alloc2data_link_data_in_valid = phy_data_in_valid_i;
+    assign phy_data_in_ready_o = data_link2alloc_data_in_ready;
+
+  end else begin : gen_channel_alloc
+
+    logic cfg_tx_clear, cfg_rx_clear;
+    logic cfg_tx_flush_trigger;
+    logic [NumChannels-1:0] cfg_tx_channel_en, cfg_rx_channel_en;
+
+    assign cfg_tx_clear = reg2hw.channel_alloc_tx_ctrl.wr_data.clear
+      & reg2hw.channel_alloc_tx_ctrl.req
+      & reg2hw.channel_alloc_tx_ctrl.req_is_wr
+      & reg2hw.channel_alloc_tx_ctrl.wr_biten.clear;
+    assign cfg_rx_clear = reg2hw.channel_alloc_rx_ctrl.wr_data.clear
+      & reg2hw.channel_alloc_rx_ctrl.req
+      & reg2hw.channel_alloc_rx_ctrl.req_is_wr
+      & reg2hw.channel_alloc_rx_ctrl.wr_biten.clear;
+    assign cfg_tx_flush_trigger = reg2hw.channel_alloc_tx_ctrl.wr_data.flush
+      & reg2hw.channel_alloc_tx_ctrl.req
+      & reg2hw.channel_alloc_tx_ctrl.req_is_wr
+      & reg2hw.channel_alloc_tx_ctrl.wr_biten.flush;
+    for (genvar i = 0; i < NumChannels; i++) begin : gen_channel_en
+      assign cfg_tx_channel_en[i] =
+        reg2hw.channel_alloc_tx_ch_en[i].channel_alloc_tx_ch_en.value;
+      assign cfg_rx_channel_en[i] =
+        reg2hw.channel_alloc_rx_ch_en[i].channel_alloc_rx_ch_en.value;
+    end
+
+    slink_ch_alloc #(
+      .phy_data_t  ( phy_data_t    ),
+      .NumChannels ( NumChannels   )
+    ) i_channel_allocator(
+      .clk_i                     ( clk_sl_i                                       ),
+      .rst_ni                    ( rst_sl_ni                                      ),
+      .cfg_tx_clear_i            ( cfg_tx_clear                                   ),
+      .cfg_tx_channel_en_i       ( cfg_tx_channel_en                              ),
+      .cfg_tx_bypass_en_i        ( reg2hw.channel_alloc_tx_cfg.bypass_en.value ),
+      .cfg_tx_auto_flush_en_i    ( reg2hw.channel_alloc_tx_cfg.auto_flush_en.value ),
+      .cfg_tx_auto_flush_count_i ( reg2hw.channel_alloc_tx_cfg.auto_flush_count.value ),
+      .cfg_tx_flush_trigger_i    ( cfg_tx_flush_trigger                           ),
+      .cfg_rx_clear_i            ( cfg_rx_clear                                   ),
+      .cfg_rx_bypass_en_i        ( reg2hw.channel_alloc_rx_cfg.bypass_en.value ),
+      .cfg_rx_channel_en_i       ( cfg_rx_channel_en                              ),
+      .cfg_rx_auto_flush_en_i    ( reg2hw.channel_alloc_rx_cfg.auto_flush_en.value ),
+      .cfg_rx_auto_flush_count_i ( reg2hw.channel_alloc_rx_cfg.auto_flush_count.value ),
+      .cfg_rx_sync_en_i          ( reg2hw.channel_alloc_rx_cfg.sync_en.value ),
+      // From Data Link Layer
+      .data_out_i                ( data_link2alloc_data_out                       ),
+      .data_out_valid_i          ( data_link2alloc_data_out_valid                 ),
+      .data_out_ready_o          ( alloc2data_link_data_out_ready                 ),
+      // To Phy
+      .data_out_o                ( phy_data_out_o                                 ),
+      .data_out_valid_o          ( phy_data_out_valid_o                           ),
+      .data_out_ready_i          ( phy_data_out_ready_i                           ),
+      // From Phy
+      .data_in_i                 ( phy_data_in_i                                  ),
+      .data_in_valid_i           ( phy_data_in_valid_i                            ),
+      .data_in_ready_o           ( phy_data_in_ready_o                            ),
+      // To Data Link Layer
+      .data_in_o                 ( alloc2data_link_data_in                        ),
+      .data_in_valid_o           ( alloc2data_link_data_in_valid                  ),
+      .data_in_ready_i           ( data_link2alloc_data_in_ready                  )
+    );
+  end
+
+
+  ///////////////////////////////////////////
+  //   TX PHY CLOCK CONFIG (for PHY use)   //
+  ///////////////////////////////////////////
+
+  for (genvar i = 0; i < NumChannels; i++) begin : gen_tx_phy_clk_cfg
+    assign tx_phy_clk_div_o[i]         = reg2hw.tx_phy_clk_div[i].clk_divs.value;
+    assign tx_phy_clk_shift_start_o[i] = reg2hw.tx_phy_clk_start[i].clk_divs.value;
+    assign tx_phy_clk_shift_end_o[i]   = reg2hw.tx_phy_clk_end[i].clk_shift_end.value;
+  end
+
+  /////////////////////////////////
+  //   CONFIGURATION REGISTERS   //
+  /////////////////////////////////
+
+  if (!NoRegCdc) begin : gen_reg_cdc
+    apb_cdc #(
+      .LogDepth ( 1          ),
+      .req_t    ( apb_req_t  ),
+      .resp_t   ( apb_rsp_t  ),
+      .addr_t   ( apb_addr_t ),
+      .data_t   ( apb_data_t ),
+      .strb_t   ( apb_strb_t )
+    ) i_cdc_cfg (
+      .src_pclk_i    ( clk_reg_i   ),
+      .src_preset_ni ( rst_reg_ni  ),
+      .src_req_i     ( apb_req_i   ),
+      .src_resp_o    ( apb_rsp_o   ),
+
+      .dst_pclk_i    ( clk_i       ),
+      .dst_preset_ni ( rst_ni      ),
+      .dst_req_o     ( apb_req     ),
+      .dst_resp_i    ( apb_rsp     )
+    );
+  end else begin : gen_no_reg_cdc
+    assign apb_req = apb_req_i;
+    assign apb_rsp_o = apb_rsp;
+  end
+
+  slink_reg i_serial_link_reg (
+    .clk  (clk_i),
+    .arst_n (rst_ni),
+
+    .s_apb_psel    (apb_req.psel),
+    .s_apb_penable (apb_req.penable),
+    .s_apb_pwrite  (apb_req.pwrite),
+    .s_apb_pprot   (apb_req.pprot),
+    .s_apb_paddr   (apb_req.paddr[slink_reg_pkg::SLINK_REG_MIN_ADDR_WIDTH-1:0]),
+    .s_apb_pwdata  (apb_req.pwdata),
+    .s_apb_pstrb   (apb_req.pstrb),
+    .s_apb_pready  (apb_rsp.pready),
+    .s_apb_prdata  (apb_rsp.prdata),
+    .s_apb_pslverr (apb_rsp.pslverr),
+
+    .hwif_in  (hw2reg),
+    .hwif_out (reg2hw)
+  );
+
+  assign clk_ena_o = reg2hw.ctrl.clk_ena.value;
+  assign reset_no = reg2hw.ctrl.reset_n.value;
+  assign isolate_o = {reg2hw.ctrl.axi_out_isolate.value,
+                      reg2hw.ctrl.axi_in_isolate.value};
+
+  always_comb begin
+    hw2reg.isolated.rd_data  = '0;
+    hw2reg.isolated.rd_data.axi_in = isolated_i[0];
+    hw2reg.isolated.rd_data.axi_out = isolated_i[1];
+  end
+
+  `SLINK_ASSIGN_RDL_RD_ACK(isolated)
+
+  if (EnChAlloc) begin : gen_channel_alloc_regs
+    `SLINK_ASSIGN_RDL_WR_ACK(channel_alloc_tx_ctrl)
+    `SLINK_ASSIGN_RDL_WR_ACK(channel_alloc_rx_ctrl)
+  end else begin : gen_no_channel_alloc_regs
+    assign hw2reg.channel_alloc_tx_ctrl = '{default: '0};
+    assign hw2reg.channel_alloc_rx_ctrl = '{default: '0};
+  end
+
+  ////////////////////
+  //   ASSERTIONS   //
+  ////////////////////
+
+  `ASSERT_INIT(RawModeFifoDim, RecvFifoDepth >= RawModeFifoDepth)
+
+endmodule : slink_serializer

--- a/src/slink_serializer.sv
+++ b/src/slink_serializer.sv
@@ -75,9 +75,13 @@ module slink_serializer #(
 );
 
   localparam int unsigned RawModeFifoDepth = 2**Log2RawModeTXFifoDepth;
+  localparam int unsigned NumRawModeDataWords =
+      (NumBitsPerCycle > 32) ? ((NumBitsPerCycle + 31) / 32) : 1;
+  localparam int unsigned RawModeDataBits = NumRawModeDataWords * 32;
 
   typedef logic [$clog2(NumCredits):0] credit_t;
   typedef logic [NumBitsPerCycle-1:0] phy_data_t;
+  typedef logic [RawModeDataBits-1:0] raw_mode_words_t;
 
   // Determine the largest sized AXI channel
   localparam int AxiChannels[5] = {$bits(b_chan_t),
@@ -187,6 +191,11 @@ module slink_serializer #(
   end
 
   phy_data_t raw_mode_in_data_out;
+  phy_data_t raw_mode_in_data_shadow_q;
+  logic raw_mode_in_data_rd_pending;
+  logic raw_mode_in_data_capture;
+  raw_mode_words_t raw_mode_in_data_read_words;
+  raw_mode_words_t raw_mode_out_data_words;
   logic [$clog2(RawModeFifoDepth)-1:0] raw_mode_out_data_fill_state;
   logic raw_mode_out_data_is_full;
 
@@ -219,11 +228,9 @@ module slink_serializer #(
       hwif_out_i.raw_mode_in_ch_sel.raw_mode_in_ch_sel.value[cc_pkg::idx_width(NumChannels)-1:0] ),
     .cfg_raw_mode_in_data_o                  ( raw_mode_in_data_out ),
     .cfg_raw_mode_in_data_valid_o            ( raw_mode_in_data_valid                           ),
-    .cfg_raw_mode_in_data_ready_i            (
-      hwif_out_i.raw_mode_in_data.req & ~hwif_out_i.raw_mode_in_data.req_is_wr ),
+    .cfg_raw_mode_in_data_ready_i            ( raw_mode_in_data_rd_pending                      ),
     .cfg_raw_mode_out_ch_mask_i              ( raw_mode_out_ch_mask                             ),
-    .cfg_raw_mode_out_data_i                 (
-      phy_data_t'(hwif_out_i.raw_mode_out_data_fifo.raw_mode_out_data_fifo.value) ),
+    .cfg_raw_mode_out_data_i                 ( phy_data_t'(raw_mode_out_data_words) ),
     .cfg_raw_mode_out_data_valid_i           ( raw_mode_out_data_valid ),
     .cfg_raw_mode_out_en_i                   (
       hwif_out_i.raw_mode_out_en.raw_mode_out_en.value ),
@@ -232,9 +239,42 @@ module slink_serializer #(
     .cfg_raw_mode_out_data_fifo_is_full_o    ( raw_mode_out_data_is_full )
   );
 
+  assign raw_mode_in_data_capture =
+      hwif_out_i.raw_mode_in_data[0].req & ~hwif_out_i.raw_mode_in_data[0].req_is_wr;
+  assign raw_mode_in_data_rd_pending = raw_mode_in_data_capture;
+
+  always_ff @(posedge clk_sl_i or negedge rst_sl_ni) begin
+    if (!rst_sl_ni) begin
+      raw_mode_in_data_shadow_q <= '0;
+    end else if (raw_mode_in_data_capture) begin
+      raw_mode_in_data_shadow_q <= raw_mode_in_data_out;
+    end
+  end
+
+  // Capture the raw-mode output data into a word array for easier access
   always_comb begin
-    hwif_in_o.raw_mode_in_data.rd_data = '0;
-    hwif_in_o.raw_mode_in_data.rd_data.raw_mode_in_data = raw_mode_in_data_out;
+    raw_mode_out_data_words = '0;
+    for (int i = 0; i < NumRawModeDataWords; i++) begin
+      raw_mode_out_data_words[i*32 +: 32] =
+          hwif_out_i.raw_mode_out_data_fifo[i].raw_mode_out_data_fifo.value;
+    end
+  end
+
+  always_comb begin
+    raw_mode_in_data_read_words = raw_mode_words_t'(raw_mode_in_data_shadow_q);
+    if (raw_mode_in_data_capture) begin
+      raw_mode_in_data_read_words = raw_mode_words_t'(raw_mode_in_data_out);
+    end
+
+    for (int i = 0; i < NumRawModeDataWords; i++) begin
+      hwif_in_o.raw_mode_in_data[i].rd_data = '0;
+      hwif_in_o.raw_mode_in_data[i].rd_data.raw_mode_in_data =
+          raw_mode_in_data_read_words[i*32 +: 32];
+      `SLINK_SET_RDL_RD_ACK(raw_mode_in_data[i], hwif_in_o, hwif_out_i)
+    end
+  end
+
+  always_comb begin
     hwif_in_o.raw_mode_out_data_fifo_ctrl.rd_data = '0;
     hwif_in_o.raw_mode_out_data_fifo_ctrl.rd_data.fill_state = raw_mode_out_data_fill_state;
     hwif_in_o.raw_mode_out_data_fifo_ctrl.rd_data.is_full = raw_mode_out_data_is_full;
@@ -246,12 +286,12 @@ module slink_serializer #(
     end
   end
 
-  `SLINK_ASSIGN_RDL_RD_ACK(raw_mode_in_data, hwif_in_o, hwif_out_i)
   `SLINK_ASSIGN_RDL_RD_ACK(raw_mode_out_data_fifo_ctrl, hwif_in_o, hwif_out_i)
   `SLINK_ASSIGN_RDL_WR_ACK(raw_mode_out_data_fifo_ctrl, hwif_in_o, hwif_out_i)
   `SLINK_ASSIGN_RDL_WR_ACK(flow_control_fifo_clear, hwif_in_o, hwif_out_i)
 
-  `FF(raw_mode_out_data_valid, hwif_out_i.raw_mode_out_data_fifo.raw_mode_out_data_fifo.swmod, '0)
+  `FF(raw_mode_out_data_valid,
+      hwif_out_i.raw_mode_out_data_fifo[NumRawModeDataWords-1].raw_mode_out_data_fifo.swmod, '0)
 
   ///////////////////////
   // CHANNEL ALLOCATOR //

--- a/src/slink_serializer.sv
+++ b/src/slink_serializer.sv
@@ -192,7 +192,6 @@ module slink_serializer #(
 
   phy_data_t raw_mode_in_data_out;
   raw_mode_words_t raw_mode_in_data_words;
-  logic raw_mode_pop_req, raw_mode_push_req;
   raw_mode_words_t raw_mode_out_data_words;
   logic [cc_pkg::cnt_width(RawModeFifoDepth)-1:0] raw_mode_out_data_fill_state;
   logic raw_mode_out_data_is_full;
@@ -226,7 +225,7 @@ module slink_serializer #(
       hwif_out_i.raw_mode_in_ch_sel.raw_mode_in_ch_sel.value[cc_pkg::idx_width(NumChannels)-1:0] ),
     .cfg_raw_mode_in_data_o                  ( raw_mode_in_data_out ),
     .cfg_raw_mode_in_data_valid_o            ( raw_mode_in_data_valid                           ),
-    .cfg_raw_mode_in_data_ready_i            ( raw_mode_pop_req                                 ),
+    .cfg_raw_mode_in_data_ready_i            ( hwif_out_i.raw_mode_pop.raw_mode_pop.value       ),
     .cfg_raw_mode_out_ch_mask_i              ( raw_mode_out_ch_mask                             ),
     .cfg_raw_mode_out_data_i                 ( phy_data_t'(raw_mode_out_data_words) ),
     .cfg_raw_mode_out_data_valid_i           ( raw_mode_out_data_valid ),
@@ -236,9 +235,6 @@ module slink_serializer #(
     .cfg_raw_mode_out_data_fifo_fill_state_o ( raw_mode_out_data_fill_state ),
     .cfg_raw_mode_out_data_fifo_is_full_o    ( raw_mode_out_data_is_full )
   );
-
-  assign raw_mode_pop_req  = hwif_out_i.raw_mode_pop.raw_mode_pop.value;
-  assign raw_mode_push_req = hwif_out_i.raw_mode_push.raw_mode_push.value;
 
   always_comb begin
     raw_mode_out_data_words = '0;
@@ -274,7 +270,7 @@ module slink_serializer #(
   `SLINK_ASSIGN_RDL_WR_ACK(raw_mode_out_data_fifo_ctrl, hwif_in_o, hwif_out_i)
   `SLINK_ASSIGN_RDL_WR_ACK(flow_control_fifo_clear, hwif_in_o, hwif_out_i)
 
-  assign raw_mode_out_data_valid = raw_mode_push_req;
+  assign raw_mode_out_data_valid = hwif_out_i.raw_mode_push.raw_mode_push.value;
 
   ///////////////////////
   // CHANNEL ALLOCATOR //

--- a/test/tb_ch_calib_slink.sv
+++ b/test/tb_ch_calib_slink.sv
@@ -42,6 +42,8 @@ module tb_ch_calib_slink;
   localparam int unsigned RegStrbWidth    = RegDataWidth / 8;
 
   localparam int unsigned ChMaskBitsPerCycle = `MIN(`MIN(NumBits, NumChannels), RegDataWidth);
+  localparam int unsigned RawModeNumWords = (NumBits + RegDataWidth - 1) / RegDataWidth;
+  localparam int unsigned RawModeDataBits = RawModeNumWords * RegDataWidth;
 
   // ==============
   //    DDR Link
@@ -64,6 +66,7 @@ module tb_ch_calib_slink;
   `APB_TYPEDEF_ALL(apb, cfg_addr_t, cfg_data_t, cfg_strb_t)
 
   typedef logic [NumBits-1:0]  phy_data_t;
+  typedef logic [RawModeDataBits-1:0] raw_mode_data_t;
 
   // Model signals
   axi_req_t   axi_out_req_1, axi_out_req_2;
@@ -450,6 +453,25 @@ module tb_ch_calib_slink;
     assert (!resp) else $error("Not able to write cfg reg");
   endtask
 
+  task automatic raw_mode_write(apb_master_t drv, phy_data_t data);
+    automatic raw_mode_data_t words = raw_mode_data_t'(data);
+    for (int i = 0; i < RawModeNumWords; i++) begin
+      cfg_write(drv, `SLINK_REG_RAW_MODE_OUT_DATA_FIFO_BASE_ADDR(i),
+          words[i*RegDataWidth+:RegDataWidth]);
+    end
+  endtask
+
+  task automatic raw_mode_read(apb_master_t drv, output phy_data_t data);
+    automatic cfg_data_t word;
+    automatic raw_mode_data_t words;
+    words = '0;
+    for (int i = 0; i < RawModeNumWords; i++) begin
+      cfg_read(drv, `SLINK_REG_RAW_MODE_IN_DATA_BASE_ADDR(i), word);
+      words[i*RegDataWidth+:RegDataWidth] = word;
+    end
+    data = phy_data_t'(words);
+  endtask
+
   task automatic bringup_link(apb_master_t drv, int id);
     $info("[DDR%0d]: Enabling clock and deassert link reset.", id);
     // Reset and clock gate sequence, AXI isolation remains enabled
@@ -517,7 +539,7 @@ module tb_ch_calib_slink;
     for (int i = 0; i < 8; i++) begin
       pattern = 16'haaaa << i;
       pattern_q.push_back(pattern);
-      cfg_write(drv, `SLINK_REG_RAW_MODE_OUT_DATA_FIFO_BASE_ADDR, pattern);
+      raw_mode_write(drv, pattern);
     end
     // Send out pattern
     cfg_write(drv, `SLINK_REG_RAW_MODE_OUT_EN_BASE_ADDR, 1);
@@ -542,12 +564,15 @@ module tb_ch_calib_slink;
           break;
         end
         // Read out first pattern
-        cfg_read(drv, `SLINK_REG_RAW_MODE_IN_DATA_BASE_ADDR, data);
-        if (pattern_q[i] != data) begin
-          $error("[DDR%0d][CH%0d] Pattern missmatch actual %h data expected %h",
-            id, c, data, pattern_q[i]);
-          working_rx_channels[c] = 1'b0;
-          break;
+        begin
+          automatic phy_data_t raw_mode_data;
+          raw_mode_read(drv, raw_mode_data);
+          if (pattern_q[i] != raw_mode_data) begin
+            $error("[DDR%0d][CH%0d] Pattern missmatch actual %h data expected %h",
+              id, c, raw_mode_data, pattern_q[i]);
+            working_rx_channels[c] = 1'b0;
+            break;
+          end
         end
       end
       if (working_rx_channels[c]) begin
@@ -576,7 +601,7 @@ module tb_ch_calib_slink;
     $info("[DDR%0d] Sending out RX channel mask.", id);
     for (int i = 0; i < (NumChannels + ChMaskBitsPerCycle - 1)/ChMaskBitsPerCycle; i++) begin
       // Write the channel mask into the TX FIFO
-      cfg_write(drv, `SLINK_REG_RAW_MODE_OUT_DATA_FIFO_BASE_ADDR, {'0, working_rx_channels[ChMaskBitsPerCycle*i+:ChMaskBitsPerCycle]});
+      raw_mode_write(drv, phy_data_t'(working_rx_channels[ChMaskBitsPerCycle*i+:ChMaskBitsPerCycle]));
     end
     // Wait until the channel mask from the other side has arrived
     do begin
@@ -592,7 +617,12 @@ module tb_ch_calib_slink;
         cfg_write(drv, `SLINK_REG_RAW_MODE_IN_CH_SEL_BASE_ADDR, c);
         // Read the mask
         for (int i = 0; i < (NumChannels + ChMaskBitsPerCycle - 1)/ChMaskBitsPerCycle; i++) begin
-          cfg_read(drv, `SLINK_REG_RAW_MODE_IN_DATA_BASE_ADDR, working_tx_channels[ChMaskBitsPerCycle*i+:ChMaskBitsPerCycle]);
+          begin
+            automatic phy_data_t raw_mode_data;
+            raw_mode_read(drv, raw_mode_data);
+            working_tx_channels[ChMaskBitsPerCycle*i+:ChMaskBitsPerCycle] =
+                raw_mode_data[ChMaskBitsPerCycle-1:0];
+          end
         end
       end
     end

--- a/test/tb_ch_calib_slink.sv
+++ b/test/tb_ch_calib_slink.sv
@@ -459,6 +459,7 @@ module tb_ch_calib_slink;
       cfg_write(drv, `SLINK_REG_RAW_MODE_OUT_DATA_FIFO_BASE_ADDR(i),
           words[i*RegDataWidth+:RegDataWidth]);
     end
+    cfg_write(drv, `SLINK_REG_RAW_MODE_PUSH_BASE_ADDR, 1);
   endtask
 
   task automatic raw_mode_read(apb_master_t drv, output phy_data_t data);
@@ -470,6 +471,7 @@ module tb_ch_calib_slink;
       words[i*RegDataWidth+:RegDataWidth] = word;
     end
     data = phy_data_t'(words);
+    cfg_write(drv, `SLINK_REG_RAW_MODE_POP_BASE_ADDR, 1);
   endtask
 
   task automatic bringup_link(apb_master_t drv, int id);
@@ -494,6 +496,12 @@ module tb_ch_calib_slink;
     // Don't do calibration for single channels
     if (NumChannels == 1) begin
       $warning("[DDR%0d]: Single channel configurations are not calibrated", id);
+      $info("[DDR%0d] Enabling AXI ports...",id);
+      cfg_write(drv, `SLINK_REG_CTRL_BASE_ADDR, 32'h03);
+      do begin
+        cfg_read(drv, `SLINK_REG_ISOLATED_BASE_ADDR, data);
+      end while(data != 0);
+      $info("[DDR%0d] Link is ready", id);
       return;
     end
     $info("[DDR%0d]: Starting link calibration.", id);


### PR DESCRIPTION
# Split serializer from PHY

This PR introduces an intermediate module, `slink_serializer`, which handles converting the AXI protocol into AXI-Stream and splitting the payload into packets.

This refactor enables the following:
- The protocol/control-flow logic can be reused with different PHY implementations (e.g., UCIe).
- Moving `slink_reg` out of the serializer allows multiple serializers (and eventually serial links) to be instantiated in the same design, each with its own parametrization. This isn't currently possible: once a downstream project depends on the serial link, IP parameters such as `NumChannels`, `NumLanes`, and `EnDdr` are inherited directly from the generated RDL, tying every instance to the same configuration.
